### PR TITLE
Drop privileges instead of running as root

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,10 +3,14 @@
 
 # Create data folder if it does not exist
 mkdir -p data
+
 # Run database migration
 python manage.py migrate
 # Generate secret key file if it does not exist
 python manage.py generate_secret_key
+
+# Ensure the DB folder is owned by the right user
+chown -R www-data: /etc/linkding/data
 
 # Start uwsgi server
 uwsgi uwsgi.ini

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -9,3 +9,5 @@ threads = 2
 pidfile = /tmp/linkding.pid
 vacuum=True
 stats = 127.0.0.1:9191
+uid = www-data
+gid = www-data


### PR DESCRIPTION
Hi,
in the current docker container UWSGI runs as root, while there is no need for that.
Instead of dropping privileges and running as user www-data from within docker (which would be preferred IMHO) I run chown on the db file, so that users can transparently upgrade existing setups.