### PR TITLE
Fix for Bookmarks Importer

### DIFF
--- a/bookmarks/services/importer.py
+++ b/bookmarks/services/importer.py
@@ -28,7 +28,8 @@ def _import_bookmark_tag(bookmark_tag: bs4.Tag, user: User):
     bookmark = _get_or_create_bookmark(url, user)
 
     bookmark.url = url
-    bookmark.date_added = datetime.utcfromtimestamp(int(link_tag['add_date']))
+    add_date = link_tag.get('add_date', datetime.now().timestamp())
+    bookmark.date_added = datetime.utcfromtimestamp(int(add_date)).astimezone()
     bookmark.date_modified = bookmark.date_added
     bookmark.unread = link_tag.get('toread', '0') == '1'
     bookmark.title = link_tag.string

--- a/bookmarks/services/importer.py
+++ b/bookmarks/services/importer.py
@@ -30,14 +30,14 @@ def _import_bookmark_tag(bookmark_tag: bs4.Tag, user: User):
     bookmark.url = url
     bookmark.date_added = datetime.utcfromtimestamp(int(link_tag['add_date']))
     bookmark.date_modified = bookmark.date_added
-    bookmark.unread = link_tag['toread'] == '1'
+    bookmark.unread = link_tag.get('toread', '0') == '1'
     bookmark.title = link_tag.string
     bookmark.owner = user
 
     bookmark.save()
 
     # Set tags
-    tag_string = link_tag['tags']
+    tag_string = link_tag.get('tags', '')
     tag_names = parse_tag_string(tag_string)
     tags = get_or_create_tags(tag_names, user)
 


### PR DESCRIPTION
Fixes for #18 
- Use a default value if attribute missing from tag
    - Added default '0' for 'toread': This means `bookmark.unread` will default to false
    - Added default '' for 'tags': No tags will be added by default 
    - Added default 'current time(`datetime.now().timestamp()`)' for `date_added`
- Use system's timezone for the parsed timestamp: Earlier the parsed timestamp was not made timezone aware whereas the model's field was timezone aware. This caused a warning while inserting the bookmark into the database. Not sure if this actually caused any problems, I added it because I was able to find it :slightly_smiling_face: 