### PR TITLE
Add docker-compose support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+
+services:
+  linkding:
+    container_name: linkding
+    image: sissbruecker/linkding:latest
+    ports:
+      - "9090:9090"
+    volumes:
+      - <your backup data folder>:/etc/linkding/data
+    restart: unless-stopped


### PR DESCRIPTION
Start your LinkDing instance with `docker-compose up -d`
It still needs the `docker exec -it linkding python manage.py createsuperuser --username=joe --email=joe@example.com` command, it would be nice to automate it [using a .env file](https://docs.docker.com/compose/environment-variables/)

It probably should be mentioned in the README, too.