### PR TITLE
Docker compose support

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,3 @@
 LD_CONTAINER_NAME=linkding
 LD_HOST_PORT=9090
-LD_HOST_DATA_DIR=./linkding_data
+LD_HOST_DATA_DIR=./data

--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,3 @@
+LD_CONTAINER_NAME=linkding
+LD_HOST_PORT=9090
+LD_HOST_DATA_DIR=./linkding_data

--- a/README.md
+++ b/README.md
@@ -48,6 +48,22 @@ docker exec -it linkding python manage.py createsuperuser --username=joe --email
 ```
 The command will prompt you for a secure password. After the command has completed you can start using the application by logging into the UI with your credentials.
 
+###  Docker-compose setup
+
+To install linkding using docker-compose you can use the `docker-compose.yml` file. Rename the `.env.sample` file to `.env` and set you parameters, the run:
+```shell
+docker-compose up -d
+```
+
+### Docker-compose user setup
+
+Finally you need to create a user so that you can access the frontend. Replace the credentials in the following command and run it:
+```shell
+docker-compose exec linkding python manage.py createsuperuser --username=joe --email=joe@example.com
+```
+The command will prompt you for a secure password. After the command has completed you can start using the application by logging into the UI with your credentials.
+
+
 ### Manual setup
 
 If you can not or don't want to use Docker you can install the application manually on your server. To do so you can basically follow the steps from the *Development* section below while cross-referencing the `Dockerfile` and `bootstrap.sh` on how to make the application production-ready.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+
+services:
+  linkding:
+    container_name: "${LD_CONTAINER_NAME:-linkding}"
+    image: sissbruecker/linkding:latest
+    ports:
+      - "${LD_HOST_PORT:-9090}:9090"
+    volumes:
+      - "${LD_HOST_DATA_DIR:-./linkding_data}:/etc/linkding/data"
+    restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,5 +7,5 @@ services:
     ports:
       - "${LD_HOST_PORT:-9090}:9090"
     volumes:
-      - "${LD_HOST_DATA_DIR:-./linkding_data}:/etc/linkding/data"
+      - "${LD_HOST_DATA_DIR:-./data}:/etc/linkding/data"
     restart: unless-stopped


### PR DESCRIPTION
Added the docker-compose.yml file and some instructions. I wasn't sure about how much text needed to be repeated.

`docker-compose exec linkding python manage.py createsuperuser --username=joe --email=joe@example.com` allows people to run this command even if they changed the container name since `docker-compose exec` checks for the service name in `docker-compose.yml` and not the container name.

Tested with and without the `.env`  file