### PR TITLE
Multistage Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,7 +11,7 @@
 /build-*.sh
 /Dockerfile
 /*.iml
-/package*.json
+/package-*.json
 
 # Remove development settings
 /siteroot/settings/dev.py

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,13 +5,22 @@
 /node_modules
 /tmp
 /docs
+/static
+/build
 
 /.dockerignore
 /.gitignore
-/build-*.sh
 /Dockerfile
+/docker-compose.yml
+/*.sh
 /*.iml
-/package-*.json
+/*.patch
+/*.md
+/*.js
+
+# Whitelist files needed in build or prod image
+!/rollup.config.js
+!/bootstrap.sh
 
 # Remove development settings
 /siteroot/settings/dev.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,45 @@
-FROM python:3.7-slim-stretch
+FROM node:current-alpine AS NODEBUILD
+# copy directory to /opt and work inside it
+WORKDIR /opt
+COPY . /opt
+# run the npm portion of build-static script
+RUN rm -rf static && mkdir -p static/
+RUN npm install -g npm && \
+    npm install && \
+    npm run build
 
-# Install packages required for uswgi
-RUN apt-get update
-RUN apt-get -y install build-essential
-RUN apt-get -y install mime-support
 
-# Install requirements and uwsgi server for running python web apps
+FROM python:3.9-slim AS PYTHONBUILD
+# install missing system deps
+RUN apt-get update && apt-get -y install build-essential mime-support libpcre3-dev libsass-dev mime-support
+# set working dir
 WORKDIR /etc/linkding
 COPY requirements.prod.txt ./requirements.txt
-RUN pip install -U pip
-RUN pip install -Ur requirements.txt
+# make a virtualenv, upgrade pip & wheel, install prod requirements
+RUN mkdir /venv && \
+    python -m venv --upgrade-deps --copies /venv && \
+    /venv/bin/pip install --upgrade pip wheel && \
+    /venv/bin/pip install -Ur requirements.txt
+# run the python half of build-static script
+COPY --from=NODEBUILD /opt/ .
+RUN /venv/bin/python manage.py compilescss && \
+    /venv/bin/python manage.py collectstatic --ignore=*.scss && \
+    /venv/bin/python manage.py compilescss --delete-files
 
-# Copy application
-COPY . .
 
-# Expose uwsgi server at port 9090
+FROM python:3.9-slim as FINAL
+WORKDIR /etc/linkding
+# copy application code from PYTHONBUILD stage
+COPY --from=PYTHONBUILD /etc/linkding  /etc/linkding
+# copy virtualenv from PYTHONBUILD stage
+COPY --from=PYTHONBUILD /venv /venv
+# copy mime.types from PYTHONBUILD stage
+COPY --from=PYTHONBUILD /etc/mime.types /etc/mime.types
+# run bootstrap.sh
+RUN mkdir -p data && \
+    /venv/bin/python manage.py migrate && \
+    /venv/bin/python manage.py generate_secret_key && \
+    chown -R www-data: /etc/linkding/data
+# expose port and run uwsgi server
 EXPOSE 9090
-
-# Run bootstrap logic
-RUN ["chmod", "+x", "./bootstrap.sh"]
-CMD ["./bootstrap.sh"]
+CMD ["/venv/bin/uwsgi","/etc/linkding/uwsgi.ini"]

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -1,9 +1,8 @@
 beautifulsoup4==4.7.1
 certifi==2019.6.16
 chardet==3.0.4
+confusable-homoglyphs==3.2.0
 Django==2.2.13
-django-appconf==1.0.3
-django-compressor==2.3
 django-generate-secret-key==1.0.2
 django-picklefield==2.0
 django-registration==3.0.1
@@ -13,12 +12,8 @@ djangorestframework==3.11.1
 idna==2.8
 pyparsing==2.4.7
 pytz==2019.1
-rcssmin==1.0.6
 requests==2.22.0
-rjsmin==1.1.0
-six==1.12.0
 soupsieve==1.9.2
 sqlparse==0.3.0
 urllib3==1.25.3
 uWSGI==2.0.18
-libsass

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -21,3 +21,4 @@ soupsieve==1.9.2
 sqlparse==0.3.0
 urllib3==1.25.3
 uWSGI==2.0.18
+libsass


### PR DESCRIPTION
Hey, I really liked the design of the bookmark manager, so I tried to check it out locally. 

I tried to deploy it and it seemed like a lot of intermediate steps going between python and node tooling. I stopped and then tried docker and saw that Docker was also like that. Instead of opening an issue and hoping it'd get tidied up at some point, I instead went ahead and streamlined the build process by modifying the Dockerfile!

Now it'll go through the intermediate steps to build the static files all while building the docker image. So deployment is just:

```bash
docker run -ti --restart always -p 9090:9090 -v $PWD/uwsgi.ini:/etc/linkding/uwsgi.ini --name linkding sissbruecker/linkding
```

As for the changes themselves, the Dockerfile now utilizes mutlistage builds. This both reduces final image size (by 100 MB!) and eats the itermediate build steps that were present before.
*  The first stage `NODEBUILD` grabs package.json, and (eventually) runs `npm run build`.
*  The second stage `PYTHONBUILD` copies the output from `NODEBUILD` and does the python side of things. Additionally for space savings, it utilizes a virtualenv to install all the python dependencies and allow them to be copied out while leaving the build time dependencies (such as libsass-dev, libpcre3-dev,  and mime-support) out of the final image.
*  Finally, the last stage `FINAL` copies the final files from `PYTHONBUILD` along with the `mime.types` required, then runs the bootstrap script. 

When the image runs, it calls uwsgi from the virtualenv and everything is located correctly. Creating an adminuser is still another subsequient `docker exec -ti linkding /venv/bin/python manage.py createsuperuser --username=$USER --email=$EMAIL`  command, but that's not too bad overall.

Hope this helps!