### PR TITLE
Dark Theme

### DIFF
--- a/bookmarks/styles/base.scss
+++ b/bookmarks/styles/base.scss
@@ -65,14 +65,11 @@ h2 {
     background: $dt-body-bg;
     color: $dt-body-font-color;
   }
-  h2 {
-    color: $dt-gray-color-light;
-  }
   .tab-block {
     border-bottom: solid 1px $dt-border-color;
   }
   .empty {
     background: $dt-bg-color;
-    color: $dt-gray-color-light;
+    color: $gray-color-light;
   }
 }

--- a/bookmarks/styles/base.scss
+++ b/bookmarks/styles/base.scss
@@ -58,3 +58,21 @@ h2 {
 .tab-block {
   border-bottom: solid 1px $border-color;
 }
+
+// Dark Theme
+@media (prefers-color-scheme: dark) {
+  body {
+    background: $dt-body-bg;
+    color: $dt-body-font-color;
+  }
+  h2 {
+    color: $dt-gray-color-light;
+  }
+  .tab-block {
+    border-bottom: solid 1px $dt-border-color;
+  }
+  .empty {
+    background: $dt-bg-color;
+    color: $dt-gray-color-light;
+  }
+}

--- a/bookmarks/styles/bookmarks.scss
+++ b/bookmarks/styles/bookmarks.scss
@@ -140,18 +140,25 @@ ul.bookmark-list {
   .menu {
     background: $dt-bg-color;
   }
-  //New bookmark tags input-form menu
-  .menu-item.selected.svelte-nfqi2o>a.svelte-nfqi2o {
-    background: $dt-bg-color !important;
+  .menu .menu-item > a {
+    color: $dt-primary-color-light !important;
   }
-  .menu-item.selected.svelte-nfqi2o>a.svelte-nfqi2o:hover {
-    background: $dt-highlight-color !important;
+  //New bookmark tags input-form menu
+  li.menu-item.selected.svelte-nfqi2o>a.svelte-nfqi2o {
+    background: $dt-bg-color;
+  }
+  li.menu-item.selected.svelte-nfqi2o>a.svelte-nfqi2o:hover {
+    background: $dt-highlight-color;
     color: $dt-light-color;
+  }
+  //Border to improve contrast on menu
+  ul.menu.open.svelte-nfqi2o.svelte-nfqi2o, ul.menu.open.svelte-zmrtk1{
+    border: 1px solid $primary-color;
+    border-top: hidden;
   }
   //Search bar on main page
   .menu .menu-item > a:focus, .menu .menu-item > a:hover {
     background: $dt-highlight-color;
-    color: $dt-light-color;
+    color: $dt-light-color !important;
   }
 }
-

--- a/bookmarks/styles/bookmarks.scss
+++ b/bookmarks/styles/bookmarks.scss
@@ -103,3 +103,55 @@ ul.bookmark-list {
     }
   }
 }
+
+// Dark Theme
+@media (prefers-color-scheme: dark) {
+  ul.bookmark-list {
+    .description {
+      color: $dt-gray-color-dark;
+      a {
+        color: $dt-alternative-color;
+      }
+    }
+    .actions .btn-link {
+      color: $dt-gray-color;
+      &:focus, &:hover, &:active, &.active {
+        color: lighten($dt-gray-color, 10%);
+      }
+    }
+  }
+
+  .tag-cloud {
+    a {
+      color: $dt-alternative-color;
+    }
+    .highlight-char {
+      color: $dt-alternative-color-dark;
+    }
+  }
+
+  .btn {
+    background: $dt-bg-color;
+  }
+  .btn:focus, .btn:hover {
+    background: $dt-highlight-color;
+  }
+
+  .menu {
+    background: $dt-bg-color;
+  }
+  //New bookmark tags input-form menu
+  .menu-item.selected.svelte-nfqi2o>a.svelte-nfqi2o {
+    background: $dt-bg-color !important;
+  }
+  .menu-item.selected.svelte-nfqi2o>a.svelte-nfqi2o:hover {
+    background: $dt-highlight-color !important;
+    color: $dt-light-color;
+  }
+  //Search bar on main page
+  .menu .menu-item > a:focus, .menu .menu-item > a:hover {
+    background: $dt-highlight-color;
+    color: $dt-light-color;
+  }
+}
+

--- a/bookmarks/styles/bookmarks.scss
+++ b/bookmarks/styles/bookmarks.scss
@@ -106,30 +106,6 @@ ul.bookmark-list {
 
 // Dark Theme
 @media (prefers-color-scheme: dark) {
-  ul.bookmark-list {
-    .description {
-      color: $dt-gray-color-dark;
-      a {
-        color: $dt-alternative-color;
-      }
-    }
-    .actions .btn-link {
-      color: $dt-gray-color;
-      &:focus, &:hover, &:active, &.active {
-        color: lighten($dt-gray-color, 10%);
-      }
-    }
-  }
-
-  .tag-cloud {
-    a {
-      color: $dt-alternative-color;
-    }
-    .highlight-char {
-      color: $dt-alternative-color-dark;
-    }
-  }
-
   .btn {
     background: $dt-bg-color;
   }

--- a/bookmarks/styles/dark.scss
+++ b/bookmarks/styles/dark.scss
@@ -1,0 +1,41 @@
+// Copy of colors from spectre _variables
+
+// Core colors
+//$dt-primary-color: #5755d9 !default;
+//$dt-primary-color-dark: darken($primary-color, 3%) !default;
+//$dt-primary-color-light: lighten($primary-color, 3%) !default;
+//$dt-secondary-color: lighten($primary-color, 37.5%) !default;
+//$dt-secondary-color-dark: darken($secondary-color, 3%) !default;
+//$dt-secondary-color-light: lighten($secondary-color, 3%) !default;
+
+// Gray colors
+$dt-dark-color: #303742 !default;
+$dt-light-color: #ddd !default;
+$dt-gray-color: lighten($dt-dark-color, 55%) !default;
+$dt-gray-color-dark: darken($dt-gray-color, 30%) !default;
+$dt-gray-color-light: lighten($dt-gray-color, 20%) !default;
+
+$dt-border-color: #30363d !default;
+$dt-border-color-dark: darken($dt-border-color, 10%) !default;
+$dt-border-color-light: lighten($dt-border-color, 8%) !default;
+$dt-bg-color: #161b22 !default;
+$dt-bg-color-dark: #0d1117 !default;
+$dt-bg-color-light: $dt-light-color !default;
+
+// Control colors
+//$dt-success-color: #32b643 !default;
+//$dt-warning-color: #ffb700 !default;
+//$dt-error-color: #e85600 !default;
+
+// Other colors
+//$dt-code-color: #d73e48 !default;
+$dt-highlight-color: #388bfd !default; //#388bfd
+$dt-body-bg: $dt-bg-color-dark !default;
+$dt-body-font-color: #8b949e !default;
+//$dt-link-color: $dt-primary-color !default;
+//$dt-link-color-dark: darken($dt-link-color, 10%) !default;
+//$dt-link-color-light: lighten($dt-link-color, 10%) !default;
+
+// Custom colors
+$dt-alternative-color: #05a6a3;
+$dt-alternative-color-dark: darken($alternative-color, 5%);

--- a/bookmarks/styles/dark.scss
+++ b/bookmarks/styles/dark.scss
@@ -4,11 +4,7 @@
 $dt-primary-color-light: lighten($primary-color, 15%) !default;
 
 // Gray colors
-$dt-dark-color: #303742 !default;
 $dt-light-color: #ddd !default;
-$dt-gray-color: lighten($dt-dark-color, 55%) !default;
-$dt-gray-color-dark: darken($dt-gray-color, 30%) !default;
-$dt-gray-color-light: lighten($dt-gray-color, 20%) !default;
 
 // Border Bg colors
 $dt-border-color: #30363d !default;
@@ -22,5 +18,3 @@ $dt-body-bg: $dt-bg-color-dark !default;
 // Other colors
 $dt-highlight-color: #388bfd !default;
 $dt-body-font-color: #8b949e !default;
-$dt-alternative-color: #05a6a3;
-$dt-alternative-color-dark: darken($alternative-color, 5%);

--- a/bookmarks/styles/dark.scss
+++ b/bookmarks/styles/dark.scss
@@ -1,12 +1,7 @@
 // Copy of colors from spectre _variables
 
 // Core colors
-//$dt-primary-color: #5755d9 !default;
-//$dt-primary-color-dark: darken($primary-color, 3%) !default;
-//$dt-primary-color-light: lighten($primary-color, 3%) !default;
-//$dt-secondary-color: lighten($primary-color, 37.5%) !default;
-//$dt-secondary-color-dark: darken($secondary-color, 3%) !default;
-//$dt-secondary-color-light: lighten($secondary-color, 3%) !default;
+$dt-primary-color-light: lighten($primary-color, 15%) !default;
 
 // Gray colors
 $dt-dark-color: #303742 !default;
@@ -15,27 +10,17 @@ $dt-gray-color: lighten($dt-dark-color, 55%) !default;
 $dt-gray-color-dark: darken($dt-gray-color, 30%) !default;
 $dt-gray-color-light: lighten($dt-gray-color, 20%) !default;
 
+// Border Bg colors
 $dt-border-color: #30363d !default;
 $dt-border-color-dark: darken($dt-border-color, 10%) !default;
 $dt-border-color-light: lighten($dt-border-color, 8%) !default;
 $dt-bg-color: #161b22 !default;
 $dt-bg-color-dark: #0d1117 !default;
 $dt-bg-color-light: $dt-light-color !default;
-
-// Control colors
-//$dt-success-color: #32b643 !default;
-//$dt-warning-color: #ffb700 !default;
-//$dt-error-color: #e85600 !default;
+$dt-body-bg: $dt-bg-color-dark !default;
 
 // Other colors
-//$dt-code-color: #d73e48 !default;
-$dt-highlight-color: #388bfd !default; //#388bfd
-$dt-body-bg: $dt-bg-color-dark !default;
+$dt-highlight-color: #388bfd !default;
 $dt-body-font-color: #8b949e !default;
-//$dt-link-color: $dt-primary-color !default;
-//$dt-link-color-dark: darken($dt-link-color, 10%) !default;
-//$dt-link-color-light: lighten($dt-link-color, 10%) !default;
-
-// Custom colors
 $dt-alternative-color: #05a6a3;
 $dt-alternative-color-dark: darken($alternative-color, 5%);

--- a/bookmarks/styles/index.scss
+++ b/bookmarks/styles/index.scss
@@ -1,12 +1,6 @@
 // Font sizes
 $html-font-size: 18px !default;
 
-@media (prefers-color-scheme: dark) {
-}
-
-html[data-theme='dark'] {
-}
-
 //$alternative-color: #c84e00;
 //$alternative-color: #FF84E8;
 //$alternative-color: #98C1D9;
@@ -25,7 +19,7 @@ $alternative-color-dark: darken($alternative-color, 5%);
 
 
 // Import style modules
-@import "dark"; //import first to override changes in files below
+@import "dark";
 @import "base";
 @import "util";
 @import "shared";

--- a/bookmarks/styles/index.scss
+++ b/bookmarks/styles/index.scss
@@ -1,6 +1,12 @@
 // Font sizes
 $html-font-size: 18px !default;
 
+@media (prefers-color-scheme: dark) {
+}
+
+html[data-theme='dark'] {
+}
+
 //$alternative-color: #c84e00;
 //$alternative-color: #FF84E8;
 //$alternative-color: #98C1D9;
@@ -19,6 +25,7 @@ $alternative-color-dark: darken($alternative-color, 5%);
 
 
 // Import style modules
+@import "dark"; //import first to override changes in files below
 @import "base";
 @import "util";
 @import "shared";

--- a/bookmarks/styles/settings.scss
+++ b/bookmarks/styles/settings.scss
@@ -12,3 +12,10 @@
     height: auto;
   }
 }
+
+// Dark Theme
+@media (prefers-color-scheme: dark) {
+  .form-input:disabled {
+    background: $dt-bg-color;
+  }
+}

--- a/bookmarks/styles/shared.scss
+++ b/bookmarks/styles/shared.scss
@@ -11,3 +11,20 @@ section.content-area {
     }
   }
 }
+
+//  Dark Theme
+@media (prefers-color-scheme: dark) {
+  section.content-area {
+    .content-area-header {
+      border-bottom: solid 1px $dt-border-color;
+    }
+  }
+  .form-input {
+    background: $dt-bg-color;
+    border-color: $dt-border-color;
+    color: $dt-light-color;
+  }
+  .form-input:not(:placeholder-shown):invalid:focus {
+    background: $dt-bg-color;
+  }
+}


### PR DESCRIPTION
This is my proposal for a dark theme such as requested in #49 

I took a very simple approach using the media query [prefers-color-scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme) to toggle between light and dark. When dark mode is detected, which is determined by the users system settings, the css rules override some of the colors. Browser compatibility is fairly good for any versions from the last 2-3 years. OS compatibility is good as well, Ive tested on Android, Windows, Manjaro, and Fedora with Chrome and Firefox. I havent tested Mac or IOS but I understand they should be on par.
The benefit of using the media query is there's no js changes needed, which made it much easier to do. However if you prefer to have a dedicated switch in the settings then it would be possible to use the same styling as a starting point.

Did not change any of the defaults so the light theme should remain the same.

Color-wise I just used colors off of Github's dark theme and tweaked it until I think it looks reasonable. The colors used are all defined in dark.scss
![linkding_dark_1](https://user-images.githubusercontent.com/22862817/111103090-df73af80-850a-11eb-9baa-00c8b9484b0c.PNG)
![linkding_dark_2](https://user-images.githubusercontent.com/22862817/111103091-e00c4600-850a-11eb-933a-a2d0b6a8dcdb.PNG)
![linkding_dark_3](https://user-images.githubusercontent.com/22862817/111103092-e00c4600-850a-11eb-906e-d3a89c27dcb7.PNG)


