### PR TITLE
Support running on OpenShift as an arbitrary user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ EXPOSE 9090
 # Activate virtual env
 ENV VIRTUAL_ENV /opt/venv
 ENV PATH /opt/venv/bin:$PATH
-# Support running container images as an an arbitrary user (e.g., OpenShift)
+# Allow running containers as an an arbitrary user in the root group, to support deployment scenarios like OpenShift, Podman
 RUN ["chmod", "g+w", "."]
 # Run bootstrap logic
 RUN ["chmod", "+x", "./bootstrap.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,8 @@ EXPOSE 9090
 # Activate virtual env
 ENV VIRTUAL_ENV /opt/venv
 ENV PATH /opt/venv/bin:$PATH
+# Support running container images as an an arbitrary user (e.g., OpenShift)
+RUN ["chmod", "g+w", "."]
 # Run bootstrap logic
 RUN ["chmod", "+x", "./bootstrap.sh"]
 CMD ["./bootstrap.sh"]


### PR DESCRIPTION
I recently deployed linkding to an OpenShift environment which required updating the permisisons of the `/etc/linkding` folder to make them group-writable. As per the OpenShift documentation (https://docs.openshift.com/container-platform/4.8/openshift_images/create-images.html), containers on OpenShift do not run as root but as an arbitrary user which is a member of the `root` group:

```
For an image to support running as an arbitrary user, directories and files that are written to by
processes in the image must be owned by the root group and be read/writable by that group.
Files to be executed must also have group execute permissions.
```

Thank you for considering this pull request. 