### PR TITLE
Have the 'new' form load existing URL

### DIFF
--- a/bookmarks/templates/bookmarks/new.html
+++ b/bookmarks/templates/bookmarks/new.html
@@ -5,10 +5,18 @@
     <div class="columns">
         <section class="content-area column col-12">
             <div class="content-area-header">
+                {% if 0 == bookmark_id %}
                 <h2>New bookmark</h2>
+                {% else %}
+                <h2>Edit bookmark</h2>
+                {% endif %}
             </div>
+            {% if 0 == bookmark_id %}
             <form action="{% url 'bookmarks:new' %}" method="post" class="col-6 col-md-12" novalidate>
-                {% bookmark_form form return_url auto_close=auto_close %}
+            {% else %}
+            <form action="{% url 'bookmarks:edit' bookmark_id %}" method="post" class="col-6 col-md-12" novalidate>
+            {% endif %}
+                {% bookmark_form form return_url bookmark_id auto_close=auto_close %}
             </form>
         </section>
     </div>

--- a/bookmarks/views/bookmarks.py
+++ b/bookmarks/views/bookmarks.py
@@ -82,14 +82,25 @@ def new(request):
             else:
                 return HttpResponseRedirect(reverse('bookmarks:index'))
     else:
-        form = BookmarkForm()
-        if initial_url:
-            form.initial['url'] = initial_url
+        try:
+            bookmark = Bookmark.objects.get(url=initial_url)
+            print(bookmark.id)
+            bookmark_id = bookmark.id
+            form = BookmarkForm(instance=bookmark)
+            form.initial['tag_string'] = build_tag_string(bookmark.tag_names, ' ')
+        except Bookmark.DoesNotExist:
+            bookmark_id = 0
+            form = BookmarkForm()
+            if initial_url:
+                form.initial['url'] = initial_url
+        # AFAIK Shouldn't be possible, but if there are duplicate URLs there is an
+        # uncaught Bookmark.MultipleObjectsReturned that will happen here
         if initial_auto_close:
             form.initial['auto_close'] = 'true'
 
     context = {
         'form': form,
+        'bookmark_id': bookmark_id,
         'auto_close': initial_auto_close,
         'return_url': reverse('bookmarks:index')
     }


### PR DESCRIPTION
The current behavior of the 'add' form simply overwriting existing bookmarks is pretty annoying. This is particularly true when trying to use using the bookmarklet.

In my opinion it would be ideal to completely merge the new+edit forms. If the 'new' form gets passed an existing URL load all the current details, instead of just allowing a blind overwrite with a warning.

This PR is my attempt at some of the changes you might need to do that.
