### PR TITLE
Add support for micro-, nanosecond timestamps in importer

### DIFF
--- a/bookmarks/services/importer.py
+++ b/bookmarks/services/importer.py
@@ -1,6 +1,5 @@
 import logging
 from dataclasses import dataclass
-from datetime import datetime
 
 from django.contrib.auth.models import User
 from django.utils import timezone
@@ -8,6 +7,7 @@ from django.utils import timezone
 from bookmarks.models import Bookmark, parse_tag_string
 from bookmarks.services.parser import parse, NetscapeBookmark
 from bookmarks.services.tags import get_or_create_tags
+from bookmarks.utils import parse_timestamp
 
 logger = logging.getLogger(__name__)
 
@@ -47,7 +47,7 @@ def _import_bookmark_tag(netscape_bookmark: NetscapeBookmark, user: User):
 
     bookmark.url = netscape_bookmark.href
     if netscape_bookmark.date_added:
-        bookmark.date_added = datetime.utcfromtimestamp(int(netscape_bookmark.date_added)).astimezone()
+        bookmark.date_added = parse_timestamp(netscape_bookmark.date_added)
     else:
         bookmark.date_added = timezone.now()
     bookmark.date_modified = bookmark.date_added

--- a/bookmarks/tests/resources/simple_valid_import_file.html
+++ b/bookmarks/tests/resources/simple_valid_import_file.html
@@ -11,10 +11,10 @@
     <DT><A HREF="https://example.com/1" ADD_DATE="1616337559" PRIVATE="0" TOREAD="0" TAGS="tag1">test title 1</A>
     <DD>test description 1
 
-    <DT><A HREF="https://example.com/2" ADD_DATE="1616337559" PRIVATE="0" TOREAD="0" TAGS="tag2">test title 2</A>
+    <DT><A HREF="https://example.com/2" ADD_DATE="1616337559000" PRIVATE="0" TOREAD="0" TAGS="tag2">test title 2</A>
     <DD>test description 2
 
-    <DT><A HREF="https://example.com/3" ADD_DATE="1616337559" PRIVATE="0" TOREAD="0" TAGS="tag3">test title 3</A>
+    <DT><A HREF="https://example.com/3" ADD_DATE="1616337559000000" PRIVATE="0" TOREAD="0" TAGS="tag3">test title 3</A>
     <DD>test description 3
 
 </DL><p>

--- a/bookmarks/utils.py
+++ b/bookmarks/utils.py
@@ -58,3 +58,40 @@ def humanize_relative_date(value: datetime, now: Optional[datetime] = None):
             return 'Yesterday'
         else:
             return weekday_names[value.isoweekday()]
+
+
+def parse_timestamp(value: str):
+    """
+    Parses a string timestamp into a datetime value
+    First tries to parse the timestamp as milliseconds.
+    If that fails with an error indicating that the timestamp exceeds the maximum,
+    it tries to parse the timestamp as microseconds, and then as nanoseconds
+    :param value:
+    :return:
+    """
+    try:
+        timestamp = int(value)
+    except ValueError:
+        raise ValueError(f'{value} is not a valid timestamp')
+
+    try:
+        return datetime.utcfromtimestamp(timestamp).astimezone()
+    except (OverflowError, ValueError, OSError):
+        pass
+
+    # Value exceeds the max. allowed timestamp
+    # Try parsing as microseconds
+    try:
+        return datetime.utcfromtimestamp(timestamp / 1000).astimezone()
+    except (OverflowError, ValueError, OSError):
+        pass
+
+    # Value exceeds the max. allowed timestamp
+    # Try parsing as nanoseconds
+    try:
+        return datetime.utcfromtimestamp(timestamp / 1000000).astimezone()
+    except (OverflowError, ValueError, OSError):
+        pass
+
+    # Timestamp is out of range
+    raise ValueError(f'{value} exceeds maximum value for a timestamp')


### PR DESCRIPTION
Changes the importer to support timestamps in micro- and nanosecond resolution

Fixes #146 

Idea for handling the fallbacks for different resolutions based on the solution in #147 by @ulixxe 