### PR TITLE
archived bookmarks import/export

### DIFF
--- a/bookmarks/services/importer.py
+++ b/bookmarks/services/importer.py
@@ -5,7 +5,7 @@ from django.contrib.auth.models import User
 from django.utils import timezone
 
 from bookmarks.models import Bookmark, parse_tag_string
-from bookmarks.services.parser import parse, NetscapeBookmark
+from bookmarks.services.parser import parse, NetscapeBookmark, NetscapeBookmarkFileData
 from bookmarks.services.tags import get_or_create_tags
 from bookmarks.utils import parse_timestamp
 
@@ -23,15 +23,29 @@ def import_netscape_html(html: str, user: User):
     result = ImportResult()
 
     try:
-        netscape_bookmarks = parse(html)
+        netscape_data = parse(html)
     except:
         logging.exception('Could not read bookmarks file.')
         raise
 
+    archive_data = [sub_folder for sub_folder in netscape_data.sub_folders if sub_folder.folder == "archive"]
+    if archive_data:
+        archive_bookmarks = collect_bookmarks(archive_data[0])
+        result = _import_netscape(archive_bookmarks, result, user, True)
+
+    notarchive_sub_folders = [sub_folder for sub_folder in netscape_data.sub_folders if sub_folder.folder != "archive"]
+    netscape_data.sub_folders = notarchive_sub_folders
+    netscape_bookmarks = collect_bookmarks(netscape_data)
+    result = _import_netscape(netscape_bookmarks, result, user, False)
+
+    return result
+
+
+def _import_netscape(netscape_bookmarks: NetscapeBookmark, result: ImportResult, user: User, is_archived: bool):
     for netscape_bookmark in netscape_bookmarks:
         result.total = result.total + 1
         try:
-            _import_bookmark_tag(netscape_bookmark, user)
+            _import_bookmark_tag(netscape_bookmark, user, is_archived)
             result.success = result.success + 1
         except:
             shortened_bookmark_tag_str = str(netscape_bookmark)[:100] + '...'
@@ -41,7 +55,15 @@ def import_netscape_html(html: str, user: User):
     return result
 
 
-def _import_bookmark_tag(netscape_bookmark: NetscapeBookmark, user: User):
+def collect_bookmarks(bookmarks_data: NetscapeBookmarkFileData):
+    bookmarks_list = bookmarks_data.bookmarks
+    for sub_folder in bookmarks_data.sub_folders:
+        bookmarks_list = bookmarks_list + collect_bookmarks(sub_folder)
+
+    return bookmarks_list
+
+
+def _import_bookmark_tag(netscape_bookmark: NetscapeBookmark, user: User, is_archived: bool):
     # Either modify existing bookmark for the URL or create new one
     bookmark = _get_or_create_bookmark(netscape_bookmark.href, user)
 
@@ -56,6 +78,7 @@ def _import_bookmark_tag(netscape_bookmark: NetscapeBookmark, user: User):
     if netscape_bookmark.description:
         bookmark.description = netscape_bookmark.description
     bookmark.owner = user
+    bookmark.is_archived = is_archived
 
     bookmark.full_clean()
     bookmark.save()

--- a/bookmarks/views/settings.py
+++ b/bookmarks/views/settings.py
@@ -8,7 +8,8 @@ from django.urls import reverse
 from rest_framework.authtoken.models import Token
 
 from bookmarks.models import UserProfileForm
-from bookmarks.queries import query_bookmarks
+from bookmarks.queries import query_bookmarks, query_archived_bookmarks
+from bookmarks.services.parser import NetscapeBookmarkFileData
 from bookmarks.services import exporter
 from bookmarks.services import importer
 
@@ -84,8 +85,15 @@ def bookmark_import(request):
 def bookmark_export(request):
     # noinspection PyBroadException
     try:
-        bookmarks = query_bookmarks(request.user, '')
-        file_content = exporter.export_netscape_html(bookmarks)
+        archive_data = NetscapeBookmarkFileData(folder='archive',
+                                                 bookmarks=query_archived_bookmarks(request.user, ''),
+                                                 sub_folders=[],
+                                                 )
+        netscape_data = NetscapeBookmarkFileData(folder='',
+                                                 bookmarks=query_bookmarks(request.user, ''),
+                                                 sub_folders=[archive_data],
+                                                 )
+        file_content = exporter.export_netscape_html(netscape_data)
 
         response = HttpResponse(content_type='text/plain; charset=UTF-8')
         response['Content-Disposition'] = 'attachment; filename="bookmarks.html"'


### PR DESCRIPTION
This PR aims to export/import archived bookmarks together with all the others.
To distinguish archived bookmarks from not archived ones, I propose to use Netscape-bookmark-file-1 folders, and in particular, a folder named "archive" at the top level folder tree.
To do this, I extended Netscape-bookmark-file-1 parser to manage nested folders too. I defined a new dataclass "NetscapeBookmarkFileData" that stores nested folders and bookmarks. This dataclass is used in importer.py/exporter.py to import/export all bookmarks.
