### PR TITLE
Allow specifying port through LINKDING_PORT environment variable

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Bootstrap script that gets executed in new Docker containers
 
+LINKDING_PORT="${LINKDING_PORT:-9090}"
+
 # Create data folder if it does not exist
 mkdir -p data
 
@@ -13,4 +15,4 @@ python manage.py generate_secret_key
 chown -R www-data: /etc/linkding/data
 
 # Start uwsgi server
-uwsgi uwsgi.ini
+uwsgi --http :$LINKDING_PORT uwsgi.ini

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Bootstrap script that gets executed in new Docker containers
 
-LINKDING_PORT="${LINKDING_PORT:-9090}"
+LD_SERVER_PORT="${LD_SERVER_PORT:-9090}"
 
 # Create data folder if it does not exist
 mkdir -p data
@@ -15,4 +15,4 @@ python manage.py generate_secret_key
 chown -R www-data: /etc/linkding/data
 
 # Start uwsgi server
-uwsgi --http :$LINKDING_PORT uwsgi.ini
+uwsgi --http :$LD_SERVER_PORT uwsgi.ini

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -36,3 +36,9 @@ Completely disables URL validation for bookmarks. This can be useful if you inte
 Values: `Integer` as seconds | Default = `60`
 
 Configures the request timeout in the uwsgi application server. This can be useful if you want to import a bookmark file with a high number of bookmarks and run into request timeouts.
+
+### `LD_SERVER_PORT`
+
+Values: Valid port number | Default = `9090`
+
+Allows to set a custom port for the UWSGI server running in the container. While Docker containers have their own IP address namespace and port collisions are impossible to achieve, there are other container solutions that share one. Podman, for example, runs all containers in a pod under one namespace, which results in every port only being allowed to be assigned once. This option allows to set a custom port in order to avoid collisions with other containers.

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -1,5 +1,4 @@
 [uwsgi]
-http = :9090
 chdir = /etc/linkding
 module = siteroot.wsgi:application
 env = DJANGO_SETTINGS_MODULE=siteroot.settings.prod


### PR DESCRIPTION
While Docker containers have their own IP address namespace and port collisions are impossible to achieve, other container solutions share one.
Podman, for example, runs all containers in a pod under one namespace, which results in every port only being allowed to be assigned once. Having a default port in the image that cannot be changed can cause collisions and incompabilities.

This change allows setting a custom port for UWSGI through the environment while keeping the default port as fallback to keep backwards compatibility. 