### PR TITLE
Increase buffer size

### DIFF
--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -11,6 +11,7 @@ vacuum=True
 stats = 127.0.0.1:9191
 uid = www-data
 gid = www-data
+buffer-size = 8192
 
 if-env = LD_REQUEST_TIMEOUT
 http-timeout = %(_)


### PR DESCRIPTION
Handles requests with a larger block size than the default 4096

Fixes: #28 