### PR TITLE
Added link to community extension linkding-injector to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,3 +169,4 @@ The frontend is now available under http://localhost:8000
 ## Community
 
 - [linkding-extension](https://github.com/jeroenpardon/linkding-extension) Chromium compatible extension that wraps the linkding bookmarklet. Tested with Chrome, Edge, Brave. By [jeroenpardon](https://github.com/jeroenpardon)
+- [linkding-injector](https://github.com/Fivefold/linkding-injector) Injects search results from linkding into the sidebar of search pages like google and duckduckgo. Tested with Firefox and Chrome. By [Fivefold](https://github.com/Fivefold)


### PR DESCRIPTION
The search results injection extension from sissbruecker/linkding-extension#11 is ready. See https://github.com/Fivefold/linkding-injector

This PR adds a link to the README in the Community section.