### PR TITLE
Allow searching for untagged bookmarks

### DIFF
--- a/bookmarks/queries.py
+++ b/bookmarks/queries.py
@@ -55,6 +55,12 @@ def _base_bookmarks_query(user: User, query_string: str) -> QuerySet:
             tags__name__iexact=tag_name
         )
 
+    # Untagged bookmarks
+    if query['untagged']:
+        query_set = query_set.filter(
+            tags=None
+        )
+
     # Sort by date added
     query_set = query_set.order_by('-date_added')
 
@@ -90,11 +96,15 @@ def _parse_query_string(query_string):
     keywords = query_string.strip().split(' ')
     keywords = [word for word in keywords if word]
 
-    search_terms = [word for word in keywords if word[0] != '#']
+    search_terms = [word for word in keywords if word[0] != '#' and word[0] != '!']
     tag_names = [word[1:] for word in keywords if word[0] == '#']
     tag_names = unique(tag_names, str.lower)
+
+    # Special search commands
+    untagged = '!untagged' in keywords
 
     return {
         'search_terms': search_terms,
         'tag_names': tag_names,
+        'untagged': untagged,
     }

--- a/bookmarks/styles/util.scss
+++ b/bookmarks/styles/util.scss
@@ -15,3 +15,7 @@
 .text-gray-dark {
   color: $gray-color-dark;
 }
+
+.align-baseline {
+  align-items: baseline;
+}

--- a/bookmarks/templates/bookmarks/archive.html
+++ b/bookmarks/templates/bookmarks/archive.html
@@ -33,8 +33,10 @@
 
         {# Tag list #}
         <section class="content-area column col-4 hide-md">
-            <div class="content-area-header">
+            <div class="content-area-header align-baseline">
                 <h2>Tags</h2>
+                <div class="spacer"></div>
+                <a href="?q=!untagged" class="text-gray text-sm">Show Untagged</a>
             </div>
             {% tag_cloud tags %}
         </section>

--- a/bookmarks/templates/bookmarks/index.html
+++ b/bookmarks/templates/bookmarks/index.html
@@ -33,8 +33,10 @@
 
         {# Tag list #}
         <section class="content-area column col-4 hide-md">
-            <div class="content-area-header">
+            <div class="content-area-header align-baseline">
                 <h2>Tags</h2>
+                <div class="spacer"></div>
+                <a href="?q=!untagged" class="text-gray text-sm">Show Untagged</a>
             </div>
             {% tag_cloud tags %}
         </section>

--- a/bookmarks/tests/test_bookmark_index_view.py
+++ b/bookmarks/tests/test_bookmark_index_view.py
@@ -156,3 +156,8 @@ class BookmarkIndexViewTestCase(TestCase, BookmarkFactoryMixin):
         response = self.client.get(reverse('bookmarks:index'))
 
         self.assertVisibleBookmarks(response, visible_bookmarks, '_self')
+
+    def test_should_show_link_for_untagged_bookmarks(self):
+        response = self.client.get(reverse('bookmarks:index'))
+
+        self.assertContains(response, '<a href="?q=!untagged" class="text-gray text-sm">Show Untagged</a>')


### PR DESCRIPTION
Closes #192 

Created a Docker image for testing: [`sissbruecker/linkding:search-untagged-bookmarks`](https://hub.docker.com/layers/199660767/sissbruecker/linkding/search-untagged-bookmarks/images/sha256-af91d70e3bfca182812b74c61b0fa8fc6e2b5dbd218dd9a4995ff2fc4f881e93?context=repo)