### PR TITLE
docs(readme): add community helm chart reference to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,5 +168,6 @@ The frontend is now available under http://localhost:8000
 
 ## Community
 
+- [Helm Chart](https://charts.pascaliske.dev/charts/linkding/) Helm Chart for deploying linkding inside a Kubernetes cluster. By [pascaliske](https://github.com/pascaliske)
 - [linkding-extension](https://github.com/jeroenpardon/linkding-extension) Chromium compatible extension that wraps the linkding bookmarklet. Tested with Chrome, Edge, Brave. By [jeroenpardon](https://github.com/jeroenpardon)
 - [linkding-injector](https://github.com/Fivefold/linkding-injector) Injects search results from linkding into the sidebar of search pages like google and duckduckgo. Tested with Firefox and Chrome. By [Fivefold](https://github.com/Fivefold)


### PR DESCRIPTION
Hi @sissbruecker,

Thank you for building and maintaining this awesome tool! 🚀 

I don't know if you find this useful but I built a [helm chart](https://charts.pascaliske.dev/charts/linkding/) for this container for anyone who wants to install it inside an Kubernetes cluster. It would be an honor for me to be mentioned on your project!

Feel free to close this PR if you don't want to mention it! 🙂 