### PR TITLE
Add community reference to aiolinkding

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ This section lists community projects around using linkding, in alphabetical ord
 - [Helm Chart](https://charts.pascaliske.dev/charts/linkding/) Helm Chart for deploying linkding inside a Kubernetes cluster. By [pascaliske](https://github.com/pascaliske)
 - [linkding-extension](https://github.com/jeroenpardon/linkding-extension) Chromium compatible extension that wraps the linkding bookmarklet. Tested with Chrome, Edge, Brave. By [jeroenpardon](https://github.com/jeroenpardon)
 - [linkding-injector](https://github.com/Fivefold/linkding-injector) Injects search results from linkding into the sidebar of search pages like google and duckduckgo. Tested with Firefox and Chrome. By [Fivefold](https://github.com/Fivefold)
+- [aiolinkding](https://github.com/bachya/aiolinkding) A Python3, async library to interact with the linkding REST API. By [bachya](https://github.com/bachya)
 
 ## Development
 


### PR DESCRIPTION
I started building a linkding workflow for Alfred and realized that instead of burying the linkding API logic in the workflow, it would be helpful (for both that project and others) to create a Python3, async wrapper library. Thus, this PR adds [`aiolinkding`](https://github.com/bachya/aiolinkding) to the community section of the docs.