### PR TITLE
Add POST archived API endpoint

### DIFF
--- a/bookmarks/api/routes.py
+++ b/bookmarks/api/routes.py
@@ -32,15 +32,24 @@ class BookmarkViewSet(viewsets.GenericViewSet,
     def get_serializer_context(self):
         return {'user': self.request.user}
 
-    @action(methods=['get'], detail=False)
+    @action(methods=['get', 'post'], detail=False)
     def archived(self, request):
-        user = request.user
-        query_string = request.GET.get('q')
-        query_set = queries.query_archived_bookmarks(user, query_string)
-        page = self.paginate_queryset(query_set)
-        serializer = self.get_serializer_class()
-        data = serializer(page, many=True).data
-        return self.get_paginated_response(data)
+        if request.method == 'GET':
+            user = request.user
+            query_string = request.GET.get('q')
+            query_set = queries.query_archived_bookmarks(user, query_string)
+            page = self.paginate_queryset(query_set)
+            serializer = self.get_serializer_class()
+            data = serializer(page, many=True).data
+            return self.get_paginated_response(data)
+
+        if request.method == 'POST':
+            serializer = self.get_serializer(data=request.data)
+            if serializer.is_valid():
+                self.perform_create(serializer)
+                archive_bookmark(serializer.save())
+                return Response(status=status.HTTP_201_CREATED)
+            return Response(status=status.HTTP_400_BAD_REQUEST)
 
     @action(methods=['post'], detail=True)
     def archive(self, request, pk):

--- a/bookmarks/api/routes.py
+++ b/bookmarks/api/routes.py
@@ -32,24 +32,15 @@ class BookmarkViewSet(viewsets.GenericViewSet,
     def get_serializer_context(self):
         return {'user': self.request.user}
 
-    @action(methods=['get', 'post'], detail=False)
+    @action(methods=['get'], detail=False)
     def archived(self, request):
-        if request.method == 'GET':
-            user = request.user
-            query_string = request.GET.get('q')
-            query_set = queries.query_archived_bookmarks(user, query_string)
-            page = self.paginate_queryset(query_set)
-            serializer = self.get_serializer_class()
-            data = serializer(page, many=True).data
-            return self.get_paginated_response(data)
-
-        if request.method == 'POST':
-            serializer = self.get_serializer(data=request.data)
-            if serializer.is_valid():
-                self.perform_create(serializer)
-                archive_bookmark(serializer.save())
-                return Response(status=status.HTTP_201_CREATED)
-            return Response(status=status.HTTP_400_BAD_REQUEST)
+        user = request.user
+        query_string = request.GET.get('q')
+        query_set = queries.query_archived_bookmarks(user, query_string)
+        page = self.paginate_queryset(query_set)
+        serializer = self.get_serializer_class()
+        data = serializer(page, many=True).data
+        return self.get_paginated_response(data)
 
     @action(methods=['post'], detail=True)
     def archive(self, request, pk):

--- a/bookmarks/api/serializers.py
+++ b/bookmarks/api/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 
 from bookmarks.models import Bookmark, Tag, build_tag_string
-from bookmarks.services.bookmarks import create_bookmark, update_bookmark, archive_bookmark
+from bookmarks.services.bookmarks import create_bookmark, update_bookmark
 from bookmarks.services.tags import get_or_create_tag
 
 
@@ -43,12 +43,9 @@ class BookmarkSerializer(serializers.ModelSerializer):
         bookmark.url = validated_data['url']
         bookmark.title = validated_data['title']
         bookmark.description = validated_data['description']
+        bookmark.is_archived = validated_data['is_archived']
         tag_string = build_tag_string(validated_data['tag_names'])
-        bookmark = create_bookmark(bookmark, tag_string, self.context['user'])
-
-        if validated_data['is_archived']:
-            bookmark = archive_bookmark(bookmark)
-        return bookmark
+        return create_bookmark(bookmark, tag_string, self.context['user'])
 
     def update(self, instance: Bookmark, validated_data):
         instance.url = validated_data['url']

--- a/bookmarks/tests/test_bookmarks_api.py
+++ b/bookmarks/tests/test_bookmarks_api.py
@@ -113,6 +113,12 @@ class BookmarksApiTestCase(LinkdingApiTestCase, BookmarkFactoryMixin):
         self.assertEqual(bookmark.tags.filter(name=data['tag_names'][0]).count(), 1)
         self.assertEqual(bookmark.tags.filter(name=data['tag_names'][1]).count(), 1)
 
+    def test_create_bookmark_minimal_payload_does_not_archive(self):
+        data = {'url': 'https://example.com/'}
+        self.post(reverse('bookmarks:bookmark-list'), data, status.HTTP_201_CREATED)
+        bookmark = Bookmark.objects.get(url=data['url'])
+        self.assertFalse(bookmark.is_archived)
+
     def test_get_bookmark(self):
         url = reverse('bookmarks:bookmark-detail', args=[self.bookmark1.id])
         response = self.get(url, expected_status_code=status.HTTP_200_OK)

--- a/bookmarks/tests/test_bookmarks_api.py
+++ b/bookmarks/tests/test_bookmarks_api.py
@@ -47,8 +47,8 @@ class BookmarksApiTestCase(LinkdingApiTestCase, BookmarkFactoryMixin):
     def test_create_bookmark(self):
         data = {
             'url': 'https://example.com/',
-            'title': 'Test title',
-            'description': 'Test description',
+            'title': 'test title',
+            'description': 'test description',
             'tag_names': ['tag1', 'tag2']
         }
         self.post(reverse('bookmarks:bookmark-list'), data, status.HTTP_201_CREATED)
@@ -91,6 +91,15 @@ class BookmarksApiTestCase(LinkdingApiTestCase, BookmarkFactoryMixin):
     def test_list_archived_bookmarks_should_filter_by_query(self):
         response = self.get(reverse('bookmarks:bookmark-archived') + '?q=#' + self.tag1.name, expected_status_code=status.HTTP_200_OK)
         self.assertBookmarkListEqual(response.data['results'], [self.archived_bookmark1])
+
+    def test_create_archived_bookmark(self):
+        data = {
+            'url': 'https://example.com/',
+            'title': 'test Title',
+            'description': 'test Description',
+            'tag_names': ['tag1', 'tag2']
+        }
+        self.post(reverse('bookmarks:bookmark-archived'), data, status.HTTP_201_CREATED)
 
     def test_get_bookmark(self):
         url = reverse('bookmarks:bookmark-detail', args=[self.bookmark1.id])

--- a/docs/API.md
+++ b/docs/API.md
@@ -84,7 +84,7 @@ POST /api/bookmarks/
 ```
 
 Creates a new bookmark. Tags are simply assigned using their names. Including
-`is_archived: True` creates a new archived bookmark.
+`is_archived: true` saves a bookmark directly to the archive.
 
 Example payload:
 
@@ -93,7 +93,7 @@ Example payload:
   "url": "https://example.com",
   "title": "Example title",
   "description": "Example description",
-  "is_archived": False,
+  "is_archived": false,
   "tag_names": [
     "tag1",
     "tag2"

--- a/docs/API.md
+++ b/docs/API.md
@@ -83,7 +83,8 @@ Retrieves a single bookmark by ID.
 POST /api/bookmarks/
 ```
 
-Creates a new bookmark. Tags are simply assigned using their names.
+Creates a new bookmark. Tags are simply assigned using their names. Including
+`is_archived: True` creates a new archived bookmark.
 
 Example payload:
 
@@ -92,28 +93,7 @@ Example payload:
   "url": "https://example.com",
   "title": "Example title",
   "description": "Example description",
-  "tag_names": [
-    "tag1",
-    "tag2"
-  ]
-}
-```
-
-**Create Archived**
-
-```
-POST /api/bookmarks/archived/
-```
-
-Creates a new archived bookmark. Tags are simply assigned using their names.
-
-Example payload:
-
-```json
-{
-  "url": "https://example.com",
-  "title": "Example title",
-  "description": "Example description",
+  "is_archived": False,
   "tag_names": [
     "tag1",
     "tag2"

--- a/docs/API.md
+++ b/docs/API.md
@@ -24,7 +24,7 @@ The following resources are available:
 GET /api/bookmarks/
 ```
 
-List bookmarks. 
+List bookmarks.
 
 Parameters:
 
@@ -65,7 +65,7 @@ Example response:
 GET /api/bookmarks/archived/
 ```
 
-List archived bookmarks. 
+List archived bookmarks.
 
 Parameters and response are the same as for the regular list endpoint.
 
@@ -84,6 +84,28 @@ POST /api/bookmarks/
 ```
 
 Creates a new bookmark. Tags are simply assigned using their names.
+
+Example payload:
+
+```json
+{
+  "url": "https://example.com",
+  "title": "Example title",
+  "description": "Example description",
+  "tag_names": [
+    "tag1",
+    "tag2"
+  ]
+}
+```
+
+**Create Archived**
+
+```
+POST /api/bookmarks/archived/
+```
+
+Creates a new archived bookmark. Tags are simply assigned using their names.
 
 Example payload:
 
@@ -201,4 +223,3 @@ Example payload:
   "name": "example"
 }
 ```
-


### PR DESCRIPTION
This PR implements a POST method for the `/api/bookmarks/archived` endpoint that creates an archived bookmark directly.

It would be helpful for #243.