### PR TITLE
Add community reference to linkding-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ This section lists community projects around using linkding, in alphabetical ord
 - [linkding-extension](https://github.com/jeroenpardon/linkding-extension) Chromium compatible extension that wraps the linkding bookmarklet. Tested with Chrome, Edge, Brave. By [jeroenpardon](https://github.com/jeroenpardon)
 - [linkding-injector](https://github.com/Fivefold/linkding-injector) Injects search results from linkding into the sidebar of search pages like google and duckduckgo. Tested with Firefox and Chrome. By [Fivefold](https://github.com/Fivefold)
 - [aiolinkding](https://github.com/bachya/aiolinkding) A Python3, async library to interact with the linkding REST API. By [bachya](https://github.com/bachya)
+- [linkding-cli](https://github.com/bachya/linkding-cli) A command-line interface (CLI) to interact with the linkding REST API. Powered by [aiolinkding](https://github.com/bachya/aiolinkding). By [bachya](https://github.com/bachya)
 
 ## Development
 


### PR DESCRIPTION
Following up on https://github.com/sissbruecker/linkding/pull/259, this PR adds a community reference to the first project powered by [aiolinkding](https://github.com/bachya/aiolinkding): [linkding-cli](https://github.com/bachya/linkding-cli)