### PR TITLE
Add Linkding version endpoint

### DIFF
--- a/bookmarks/api/routes.py
+++ b/bookmarks/api/routes.py
@@ -9,6 +9,7 @@ from bookmarks.api.serializers import BookmarkSerializer, TagSerializer
 from bookmarks.models import Bookmark, Tag
 from bookmarks.services.bookmarks import archive_bookmark, unarchive_bookmark
 from bookmarks.services.website_loader import load_website_metadata
+from bookmarks.views.settings import app_version
 
 
 class BookmarkViewSet(viewsets.GenericViewSet,
@@ -88,6 +89,16 @@ class TagViewSet(viewsets.GenericViewSet,
         return {'user': self.request.user}
 
 
+class VersionViewSet(viewsets.ViewSet,
+                     mixins.ListModelMixin):
+
+    def list(self, request):
+        return Response({
+            'version': app_version
+        }, status=status.HTTP_200_OK)
+
+
 router = DefaultRouter()
 router.register(r'bookmarks', BookmarkViewSet, basename='bookmark')
 router.register(r'tags', TagViewSet, basename='tag')
+router.register(r'version', VersionViewSet, basename='version')

--- a/bookmarks/tests/test_bookmarks_api.py
+++ b/bookmarks/tests/test_bookmarks_api.py
@@ -7,6 +7,7 @@ from rest_framework.authtoken.models import Token
 
 from bookmarks.models import Bookmark
 from bookmarks.tests.helpers import LinkdingApiTestCase, BookmarkFactoryMixin
+from bookmarks.views.settings import app_version
 
 
 class BookmarksApiTestCase(LinkdingApiTestCase, BookmarkFactoryMixin):
@@ -225,3 +226,7 @@ class BookmarksApiTestCase(LinkdingApiTestCase, BookmarkFactoryMixin):
 
         url = reverse('bookmarks:bookmark-unarchive', args=[inaccessible_bookmark.id])
         self.post(url, expected_status_code=status.HTTP_404_NOT_FOUND)
+
+    def test_get_version_from_api(self):
+        response = self.get(reverse('bookmarks:version-list'), expected_status_code=status.HTTP_200_OK)
+        self.assertEqual(response.data['version'], app_version)

--- a/docs/API.md
+++ b/docs/API.md
@@ -203,3 +203,11 @@ Example payload:
   "name": "example"
 }
 ```
+
+#### Version
+
+Retrieve Linkding version.
+
+```
+GET /api/version/
+```


### PR DESCRIPTION
Closes #272. Retrieves the current Linkding version at `/api/version` endpoint. 

I hope this doesn't get mistaken for the API's version.