### PR TITLE
Order tags in test_should_create_new_bookmark

### DIFF
--- a/bookmarks/tests/test_bookmark_edit_view.py
+++ b/bookmarks/tests/test_bookmark_edit_view.py
@@ -38,8 +38,9 @@ class BookmarkEditViewTestCase(TestCase, BookmarkFactoryMixin):
         self.assertEqual(bookmark.description, form_data['description'])
         self.assertEqual(bookmark.unread, form_data['unread'])
         self.assertEqual(bookmark.tags.count(), 2)
-        self.assertEqual(bookmark.tags.all()[0].name, 'editedtag1')
-        self.assertEqual(bookmark.tags.all()[1].name, 'editedtag2')
+        tags = bookmark.tags.order_by('name').all()
+        self.assertEqual(tags[0].name, 'editedtag1')
+        self.assertEqual(tags[1].name, 'editedtag2')
 
     def test_should_mark_bookmark_as_unread(self):
         bookmark = self.setup_bookmark()

--- a/bookmarks/tests/test_bookmark_new_view.py
+++ b/bookmarks/tests/test_bookmark_new_view.py
@@ -38,8 +38,9 @@ class BookmarkNewViewTestCase(TestCase, BookmarkFactoryMixin):
         self.assertEqual(bookmark.description, form_data['description'])
         self.assertEqual(bookmark.unread, form_data['unread'])
         self.assertEqual(bookmark.tags.count(), 2)
-        self.assertEqual(bookmark.tags.all()[0].name, 'tag1')
-        self.assertEqual(bookmark.tags.all()[1].name, 'tag2')
+        tags = bookmark.tags.order_by('name').all()
+        self.assertEqual(tags[0].name, 'tag1')
+        self.assertEqual(tags[1].name, 'tag2')
 
     def test_should_create_new_unread_bookmark(self):
         form_data = self.create_form_data({'unread': True})


### PR DESCRIPTION
This test seems to rely on the tags being queried in a specific order from the database, which is incidentally the case for SQLite.

This came up when I was merging my postgres fork with the latest release [here](https://github.com/sissbruecker/linkding/commit/99582f3d45d0c2d54df66113c019c95c75841c1d#diff-fa1abe4b8e2fd558c4c4450b3bd9b5bf0a255cfc516b8d125fcbf7534d7d1efdR41-R43)