### PR TITLE
Add simple docs of the new `shared` API parameter

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -49,6 +49,7 @@ Example response:
       "website_description": "Website description",
       "is_archived": false,
       "unread": false,
+      "shared": false,
       "tag_names": [
         "tag1",
         "tag2"
@@ -97,6 +98,7 @@ Example payload:
   "description": "Example description",
   "is_archived": false,
   "unread": false,
+  "shared": false,
   "tag_names": [
     "tag1",
     "tag2"


### PR DESCRIPTION
This PR adds small API doc updates to highlight [the new shared bookmark feature](https://github.com/sissbruecker/linkding/pull/311).