### PR TITLE
Gracefully stop docker container when it receives SIGTERM

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -22,4 +22,4 @@ if [ "$LD_DISABLE_BACKGROUND_TASKS" != "True" ]; then
 fi
 
 # Start uwsgi server
-uwsgi --http :$LD_SERVER_PORT uwsgi.ini
+exec uwsgi --http :$LD_SERVER_PORT uwsgi.ini

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -11,6 +11,7 @@ stats = 127.0.0.1:9191
 uid = www-data
 gid = www-data
 buffer-size = 8192
+die-on-term = true
 
 if-env = LD_CONTEXT_PATH
 static-map = /%(_)static=static


### PR DESCRIPTION
Fix for #284. Useful for when running in docker or kubernetes. 

Two things it fixes:
* Signals were not making their way to the `uwsig` process as it was invoked from the `bootstrap.sh` entrypoint script. By `exec`ing that command, it will receive signals. 
* However, in `uwsig` versions before 2.10, it treats `SIGTERM` a bit oddly. [See here](https://uwsgi-docs.readthedocs.io/en/latest/ThingsToKnow.html):
> Till uWSGI 2.1, by default, sending the SIGTERM signal to uWSGI means “brutally reload the stack” while the convention is to shut an application down on SIGTERM. To shutdown uWSGI use SIGINT or SIGQUIT instead. If you absolutely can not live with uWSGI being so disrespectful towards SIGTERM, by all means enable the die-on-term option. Fortunately, this bad choice has been fixed in uWSGI 2.1

By setting `die-on-term` in the .ini we can avoid this behavior. 

## Testing
Without changes (using latest linkding image):
```
➜  ~/temp/linkding docker-compose up -d
[+] Running 2/2
 ⠿ Network linkding_default  Created                                                 0.0s
 ⠿ Container linkding        Started                                                 0.3s
➜  ~/temp/linkding  docker-compose down
[+] Running 2/2
 ⠿ Container linkding        Removed                                                 0.2s
 ⠿ Network linkding_default  Removed                                                 0.1s
```

With changes:
```
➜  ~/temp/linkding docker-compose up -d
[+] Running 2/2
 ⠿ Network linkding_default  Created                                                  0.0s
 ⠿ Container linkding        Started                                                  0.3s
➜  ~/temp/linkding docker-compose down
[+] Running 2/2
 ⠿ Container linkding        Removed                                                  1.1s
 ⠿ Network linkding_default  Removed                                                  0.0s
```

Fixes #284