### PR TITLE
Correct LD_ENABLE_AUTH_PROXY documentation

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -83,7 +83,7 @@ Enables support for authentication proxies such as Authelia.
 This effectively disables credentials-based authentication and instead authenticates users if a specific request header contains a known username.
 You must make sure that your proxy (nginx, Traefik, Caddy, ...) forwards this header from your auth proxy to linkding. Check the documentation of your auth proxy and your reverse proxy on how to correctly set this up.
 
-Note that this does not automatically create new users, you still need to create users as described in the README, and users need to have the same username as in the auth proxy.
+Note that this automatically creates new users in the database if they do not already exist.
 
 Enabling this setting also requires configuring the following options:
 - `LD_AUTH_PROXY_USERNAME_HEADER` - The name of the request header that the auth proxy passes to the proxied application (linkding in this case), so that the application can identify the user.


### PR DESCRIPTION
Corrects documentation regarding handling of remote users when enabling the `LD_ENABLE_AUTH_PROXY` option.

Closes #372