### PR TITLE
Trim website metadata title and description

### DIFF
--- a/bookmarks/services/website_loader.py
+++ b/bookmarks/services/website_loader.py
@@ -29,9 +29,9 @@ def load_website_metadata(url: str):
         page_text = load_page(url)
         soup = BeautifulSoup(page_text, 'html.parser')
 
-        title = soup.title.string if soup.title is not None else None
+        title = soup.title.string.strip() if soup.title is not None else None
         description_tag = soup.find('meta', attrs={'name': 'description'})
-        description = description_tag['content'] if description_tag is not None else None
+        description = description_tag['content'].strip() if description_tag is not None else None
     finally:
         return WebsiteMetadata(url=url, title=title, description=description)
 

--- a/bookmarks/services/website_loader.py
+++ b/bookmarks/services/website_loader.py
@@ -31,7 +31,7 @@ def load_website_metadata(url: str):
 
         title = soup.title.string.strip() if soup.title is not None else None
         description_tag = soup.find('meta', attrs={'name': 'description'})
-        description = description_tag['content'].strip() if description_tag is not None else None
+        description = description = description_tag['content'].strip() if description_tag and description_tag['content'] else None
     finally:
         return WebsiteMetadata(url=url, title=title, description=description)
 

--- a/bookmarks/templates/bookmarks/form.html
+++ b/bookmarks/templates/bookmarks/form.html
@@ -139,7 +139,7 @@
 
       function updatePlaceholder(input, value) {
         if (value) {
-          input.setAttribute('placeholder', value);
+          input.setAttribute('placeholder', value.trim());
         } else {
           input.removeAttribute('placeholder');
         }

--- a/bookmarks/templates/bookmarks/form.html
+++ b/bookmarks/templates/bookmarks/form.html
@@ -139,7 +139,7 @@
 
       function updatePlaceholder(input, value) {
         if (value) {
-          input.setAttribute('placeholder', value.trim());
+          input.setAttribute('placeholder', value);
         } else {
           input.removeAttribute('placeholder');
         }


### PR DESCRIPTION
Some sites seem to return metadata titles / descriptions with trailing or leading whitespaces, which should be unwanted in most if not all cases. This PR adds a [`.trim`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/Trim) method call to the fetched values, which will remove these whitespaces.

The whitespaces are not shown in the bookmark list after it is saved, but they are being stored, so they are also still there when editing the bookmark.

One example would be [Humble Bundle](https://www.humblebundle.com/) pages, e.g. this one: https://www.humblebundle.com/software/unreal-engine-ultimate-game-dev-assets-software

![image](https://user-images.githubusercontent.com/33791936/209484617-15235c8b-67e4-45d4-8051-4c03f7473b85.png)
