### PR TITLE
Add opensearch to allow add search in webrowser

### DIFF
--- a/bookmarks/templates/bookmarks/layout.html
+++ b/bookmarks/templates/bookmarks/layout.html
@@ -1,5 +1,6 @@
 {% load static %}
 {% load sass_tags %}
+{% load opensearch_tags %}
 
 <!DOCTYPE html>
 {# Use data attributes as storage for access in static scripts #}
@@ -26,6 +27,7 @@
     <link href="{% sass_src 'theme-light.scss' %}" rel="stylesheet" type="text/css"
           media="(prefers-color-scheme: light)"/>
   {% endif %}
+  {% opensearch_meta %}
 </head>
 <body>
 <header>

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,4 @@ sqlparse==0.4.2
 typing-extensions==3.10.0.0
 urllib3==1.26.11
 waybackpy==3.0.6
+opensearch-py>=2.0.1

--- a/siteroot/settings/base.py
+++ b/siteroot/settings/base.py
@@ -43,6 +43,7 @@ INSTALLED_APPS = [
     'rest_framework',
     'rest_framework.authtoken',
     'background_task',
+    'opensearch',
 ]
 
 MIDDLEWARE = [
@@ -193,6 +194,23 @@ if LD_ENABLE_AUTH_PROXY:
 trusted_origins = os.getenv('LD_CSRF_TRUSTED_ORIGINS', '')
 if trusted_origins:
     CSRF_TRUSTED_ORIGINS = trusted_origins.split(',')
+
+### Opensearch
+
+#Contains a brief human-readable title that identifies this search engine. Force to "Linkding"
+OPENSEARCH_SHORT_NAME = 'Linkding'
+#Contains a human-readable text description of the search engine. Force to "Self-hosted bookmark service"
+OPENSEARCH_DESCRIPTION = 'Self-hosted bookmark service'
+#Contains width of an image that can be used in association with this search content.  Force to 256.
+OPENSEARCH_FAVICON_WIDTH = 256
+#Contains height of an image that can be used in association with this search content. Force to 256.
+OPENSEARCH_FAVICON_HEIGHT = 256
+#Contains mimetype of an image that can be used in association with this search content. Force to "image/png"
+OPENSEARCH_FAVICON_TYPE = 'image/png'
+#Contains a URL that identifies the location of an image that can be used in association with this search content. Force to "static/favicon.png"
+OPENSEARCH_FAVICON_FILE = '/static/favicon.png'
+#Contains a Django URL name to search content. Force to "bookmarks"
+OPENSEARCH_SEARCH_URL = '/bookmarks'
 
 # Database
 # https://docs.djangoproject.com/en/2.2/ref/settings/#databases

--- a/siteroot/urls.py
+++ b/siteroot/urls.py
@@ -15,7 +15,7 @@ Including another URLconf
 """
 from django.conf import settings
 from django.contrib.auth import views as auth_views
-from django.urls import path, include
+from django.urls import path, include, re_path
 
 from bookmarks.admin import linkding_admin_site
 from .settings import ALLOW_REGISTRATION, DEBUG
@@ -29,6 +29,7 @@ urlpatterns = [
     path('change-password/', auth_views.PasswordChangeView.as_view(), name='change_password'),
     path('password-change-done/', auth_views.PasswordChangeDoneView.as_view(), name='password_change_done'),
     path('', include('bookmarks.urls')),
+    re_path(r"^opensearch/", include("opensearch.urls")),
 ]
 
 if settings.LD_CONTEXT_PATH:


### PR DESCRIPTION
Sorry i have check lot of time to understand namespace issue but i need help

error is bellow 
![image](https://user-images.githubusercontent.com/6951820/212534620-edd94e2b-661c-4778-8212-e4df9c91534b.png)
but if i replace opensearch by  bookmarks:opensearch in django-opensearch template, it's work