### PR TITLE
Disable autocapitalization for tag input form

### DIFF
--- a/bookmarks/components/TagAutocomplete.svelte
+++ b/bookmarks/components/TagAutocomplete.svelte
@@ -119,7 +119,7 @@
     <div class="form-autocomplete-input form-input" class:is-focused={isFocus}>
         <!-- autocomplete real input box -->
         <input id="{id}" name="{name}" value="{value ||''}" placeholder="&nbsp;"
-               class="form-input" type="text" autocomplete="off"
+               class="form-input" type="text" autocomplete="off" autocapitalize="off"
                on:input={handleInput} on:keydown={handleKeyDown}
                on:focus={handleFocus} on:blur={handleBlur}>
     </div>

--- a/bookmarks/templates/bookmarks/form.html
+++ b/bookmarks/templates/bookmarks/form.html
@@ -21,7 +21,7 @@
   </div>
   <div class="form-group">
     <label for="{{ form.tag_string.id_for_label }}" class="form-label">Tags</label>
-    {{ form.tag_string|add_class:"form-input"|attr:"autocomplete:off" }}
+    {{ form.tag_string|add_class:"form-input"|attr:"autocomplete:off"|attr:"autocapitalize:off" }}
     <div class="form-input-hint">
       Enter any number of tags separated by space and <strong>without</strong> the hash (#). If a tag does not
       exist it will be

--- a/bookmarks/tests/test_bookmark_edit_view.py
+++ b/bookmarks/tests/test_bookmark_edit_view.py
@@ -87,7 +87,7 @@ class BookmarkEditViewTestCase(TestCase, BookmarkFactoryMixin):
         tag_string = build_tag_string(bookmark.tag_names, ' ')
         self.assertInHTML(f'''
             <input type="text" name="tag_string" value="{tag_string}" 
-                    autocomplete="off" class="form-input" id="id_tag_string">
+                    autocomplete="off" autocapitalize="off" class="form-input" id="id_tag_string">
         ''', html)
 
         self.assertInHTML(f'''


### PR DESCRIPTION
I use lowercase names for all of my tags, so I find it annoying that the first tag I enter defaults to being capitalized (at least on mobile on iOS), and figured I'd open this PR to address it.

This change may be controversial [if others actually prefer this behavior](https://xkcd.com/1172/), but I feel that the current behavior of autocapitalizing only the first tag entered (as if inputting a sentence) is confusing at best.