### PR TITLE
Allow to log real client ip in logs when using a reverse proxy

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -109,6 +109,12 @@ Multiple origins can be specified by separating them with a comma (`,`).
 
 This setting is adopted from the Django framework used by linkding, more information on the setting is available in the [Django documentation](https://docs.djangoproject.com/en/4.0/ref/settings/#std-setting-CSRF_TRUSTED_ORIGINS).
 
+### `LD_LOG_X_FORWARDED_FOR`
+
+Values: `true` or `false` | Default =  `false`
+
+Set uWSGI [log-x-forwarded-for](https://uwsgi-docs.readthedocs.io/en/latest/Options.html?#log-x-forwarded-for) parameter allowing to keep the real IP of clients in logs when using a reverse proxy.
+
 ### `LD_DB_ENGINE`
 
 Values: `postgres` or `sqlite` | Default = `sqlite`
@@ -149,9 +155,3 @@ Values: `Integer` | Default =  None
 
 The port of the database server.
 Should use the default port if left empty, for example `5432` for PostgresSQL.
-
-### `LD_LOG_X_FORWARDED_FOR`
-
-Values: `true` or `false` | Default =  `false`
-
-Set uWSGI [log-x-forwarded-for](https://uwsgi-docs.readthedocs.io/en/latest/Options.html?#log-x-forwarded-for) parameter allowing to keep the real IP of clients in logs when using a reverse proxy.

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -149,3 +149,9 @@ Values: `Integer` | Default =  None
 
 The port of the database server.
 Should use the default port if left empty, for example `5432` for PostgresSQL.
+
+### `LD_LOG_X_FORWARDED_FOR`
+
+Values: `true` or `false` | Default =  `false`
+
+Set uWSGI [log-x-forwarded-for](https://uwsgi-docs.readthedocs.io/en/latest/Options.html?#log-x-forwarded-for) parameter allowing to keep the real IP of clients in logs when using a reverse proxy.

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -22,3 +22,7 @@ http-timeout = %(_)
 socket-timeout = %(_)
 harakiri = %(_)
 endif =
+
+if-env = LD_LOG_X_FORWARDED_FOR
+log-x-forwarded-for = %(_)
+endif =


### PR DESCRIPTION
Add a new *LD_LOG_X_FORWARDED_FOR* environment variable allowing to manage 
uWSGI [log-x-forwarded-for](https://uwsgi-docs.readthedocs.io/en/latest/Options.html?#log-x-forwarded-for) parameter. It allows to use the ip from *X-Forwarded-For* header instead of *REMOTE_ADDR* in logs and thus to keep real client IP when using a reverse proxy.