### PR TITLE
Fix bookmark website metadata not being updated when URL changes

### DIFF
--- a/bookmarks/services/bookmarks.py
+++ b/bookmarks/services/bookmarks.py
@@ -48,6 +48,7 @@ def update_bookmark(bookmark: Bookmark, tag_string, current_user: User):
         tasks.create_web_archive_snapshot(current_user, bookmark, True)
         # Only update website metadata if URL changed
         _update_website_metadata(bookmark)
+        bookmark.save()
 
     return bookmark
 


### PR DESCRIPTION
Ensure website metadata is updated when changing the URL of an existing bookmark.