### PR TITLE
Cache website metadata to avoid duplicate scraping

### DIFF
--- a/bookmarks/services/website_loader.py
+++ b/bookmarks/services/website_loader.py
@@ -1,5 +1,6 @@
 import logging
 from dataclasses import dataclass
+from functools import lru_cache
 
 import requests
 from bs4 import BeautifulSoup
@@ -23,6 +24,9 @@ class WebsiteMetadata:
         }
 
 
+# Caching metadata avoids scraping again when saving bookmarks, in case the
+# metadata was already scraped to show preview values in the bookmark form
+@lru_cache(maxsize=10)
 def load_website_metadata(url: str):
     title = None
     description = None

--- a/bookmarks/tests/test_website_loader.py
+++ b/bookmarks/tests/test_website_loader.py
@@ -25,6 +25,10 @@ class MockStreamingResponse:
 
 
 class WebsiteLoaderTestCase(TestCase):
+    def setUp(self):
+        # clear cached metadata before test run
+        website_loader.load_website_metadata.cache_clear()
+
     def render_html_document(self, title, description):
         return f'''
         <!DOCTYPE html>


### PR DESCRIPTION
Caches results from scraping websites, which allows to skip scraping when saving a bookmark if the URL has already been scraped when opening the bookmark form. This should speed up saving bookmarks a bit.