### PR TITLE
Prefill form if URL is already bookmarked

### DIFF
--- a/bookmarks/api/routes.py
+++ b/bookmarks/api/routes.py
@@ -1,4 +1,3 @@
-from django.urls import reverse
 from rest_framework import viewsets, mixins, status
 from rest_framework.decorators import action
 from rest_framework.response import Response

--- a/bookmarks/templates/bookmarks/form.html
+++ b/bookmarks/templates/bookmarks/form.html
@@ -15,8 +15,8 @@
       </div>
     {% endif %}
     <div class="form-input-hint bookmark-exists">
-      This URL is already bookmarked. You can <a href="#">edit</a> it or you can overwrite the existing bookmark
-      by saving this form.
+      This URL is already bookmarked.
+      The form has been pre-filled with the existing bookmark, and saving the form will update the existing bookmark.
     </div>
   </div>
   <div class="form-group">
@@ -128,6 +128,9 @@
       const urlInput = document.getElementById('{{ form.url.id_for_label }}');
       const titleInput = document.getElementById('{{ form.title.id_for_label }}');
       const descriptionInput = document.getElementById('{{ form.description.id_for_label }}');
+      const tagsInput = document.getElementById('{{ form.tag_string.id_for_label }}');
+      const unreadCheckbox = document.getElementById('{{ form.unread.id_for_label }}');
+      const sharedCheckbox = document.getElementById('{{ form.shared.id_for_label }}');
       const websiteTitleInput = document.getElementById('{{ form.website_title.id_for_label }}');
       const websiteDescriptionInput = document.getElementById('{{ form.website_description.id_for_label }}');
       const editedBookmarkId = {{ bookmark_id }};
@@ -143,6 +146,14 @@
         } else {
           input.removeAttribute('placeholder');
         }
+      }
+
+      function updateInput(input, value) {
+          input.value = value;
+      }
+
+      function updateCheckbox(input, value) {
+          input.checked = value;
       }
 
       function checkUrl() {
@@ -162,13 +173,17 @@
             toggleLoadingIcon(titleInput, false);
             toggleLoadingIcon(descriptionInput, false);
 
-            // Display hint if URL is already bookmarked
+            // Prefill form and display hint if URL is already bookmarked
+            const existingBookmark = data.bookmark;
             const bookmarkExistsHint = document.querySelector('.form-input-hint.bookmark-exists');
-            const editExistingBookmarkLink = bookmarkExistsHint.querySelector('a');
 
-            if (data.bookmark && data.bookmark.id !== editedBookmarkId) {
+            if (existingBookmark && !editedBookmarkId) {
               bookmarkExistsHint.style['display'] = 'block';
-              editExistingBookmarkLink.href = data.bookmark.edit_url;
+              updateInput(titleInput, existingBookmark.title);
+              updateInput(descriptionInput, existingBookmark.description);
+              updateInput(tagsInput, existingBookmark.tag_names.join(" "));
+              updateCheckbox(unreadCheckbox, existingBookmark.unread);
+              updateCheckbox(sharedCheckbox, existingBookmark.shared);
             } else {
               bookmarkExistsHint.style['display'] = 'none';
             }


### PR DESCRIPTION
When adding a new bookmark, and if the URL entered into the bookmark form is already bookmarked, prefill the form with the data from the existing bookmark. Saving the bookmark will update the existing bookmark, which works the same as before.