### PR TITLE
Fix favicon being cleared by web archive snapshot task

### DIFF
--- a/bookmarks/services/tasks.py
+++ b/bookmarks/services/tasks.py
@@ -10,8 +10,8 @@ from waybackpy.exceptions import WaybackError, TooManyRequestsError, NoCDXRecord
 
 import bookmarks.services.wayback
 from bookmarks.models import Bookmark, UserProfile
-from bookmarks.services.website_loader import DEFAULT_USER_AGENT
 from bookmarks.services import favicon_loader
+from bookmarks.services.website_loader import DEFAULT_USER_AGENT
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +37,7 @@ def _load_newest_snapshot(bookmark: Bookmark):
 
         if existing_snapshot:
             bookmark.web_archive_snapshot_url = existing_snapshot.archive_url
-            bookmark.save()
+            bookmark.save(update_fields=['web_archive_snapshot_url'])
             logger.info(f'Using newest snapshot. url={bookmark.url} from={existing_snapshot.datetime_timestamp}')
 
     except NoCDXRecordFound:
@@ -51,7 +51,7 @@ def _create_snapshot(bookmark: Bookmark):
     archive = waybackpy.WaybackMachineSaveAPI(bookmark.url, DEFAULT_USER_AGENT, max_tries=1)
     archive.save()
     bookmark.web_archive_snapshot_url = archive.archive_url
-    bookmark.save()
+    bookmark.save(update_fields=['web_archive_snapshot_url'])
     logger.info(f'Successfully created new snapshot for bookmark:. url={bookmark.url}')
 
 
@@ -134,7 +134,7 @@ def _load_favicon_task(bookmark_id: int):
 
     if new_favicon != bookmark.favicon_file:
         bookmark.favicon_file = new_favicon
-        bookmark.save()
+        bookmark.save(update_fields=['favicon_file'])
         logger.info(f'Successfully updated favicon for bookmark. url={bookmark.url} icon={new_favicon}')
 
 


### PR DESCRIPTION
With the introduction of the favicon background task, adding a bookmark can result in running both, the web archive snapshot task, and the favicon task in parallel. Both load the bookmark at the start of the task, then do their own processing, and then save the bookmark at the end. This could result in one task overriding the updated data of the other task, as the bookmark instance was not refreshed at the end of the task, before saving it. From testing this usually results in the favicon being cleared by the snapshot task, as the snapshot task takes longer.

Refreshing the bookmark would ideally wrap refreshing and saving the bookmark in a transaction, however that sporadically results in database locked errors with Sqlite. Instead this fix involves only updating the field that is relevant to each task.