### PR TITLE
Make health check in Dockerfile honor context path setting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,6 @@ RUN ["chmod", "g+w", "."]
 RUN ["chmod", "+x", "./bootstrap.sh"]
 
 HEALTHCHECK --interval=30s --retries=3 --timeout=1s \
-CMD curl -f http://localhost:${LD_SERVER_PORT:-9090}/health || exit 1
+CMD curl -f http://localhost:${LD_SERVER_PORT:-9090}/${LD_CONTEXT_PATH}health || exit 1
 
 CMD ["./bootstrap.sh"]


### PR DESCRIPTION
When using the context path setting the health check defined in Dockerfile fails, reporting the container state as unhealthy. That's because the path to the health endpoint is hardcoded to `/health` in Dockerfile, while the actual endpoint is provided under `${LD_CONTEXT_PATH}/health`.

This patch changes the path in Dockerfile to honor the value of LD_CONTEXT_PATH.