### PR TITLE
feat: add refresh description button to scrape the bookmark descriptions

### DIFF
--- a/bookmarks/services/website_loader.py
+++ b/bookmarks/services/website_loader.py
@@ -41,6 +41,8 @@ def load_website_metadata(url: str):
 
         title = soup.title.string.strip() if soup.title is not None else None
         description_tag = soup.find('meta', attrs={'name': 'description'})
+        if not description_tag:
+            description_tag = soup.find('meta', attrs={'property': 'og:description'})
         description = description = description_tag['content'].strip() if description_tag and description_tag[
             'content'] else None
         end = timezone.now()

--- a/bookmarks/templates/settings/general.html
+++ b/bookmarks/templates/settings/general.html
@@ -61,6 +61,20 @@
           {% endif %}
         </div>
         <div class="form-group">
+          <label for="{{ form.refresh_descriptions.id_for_label }}" class="form-label">Refresh Descriptions</label>
+          <div class="form-input-hint">
+            Automatically loads descriptions for bookmarked websites and displays them next to each bookmark.
+          </div>
+          <button class="btn mt-2" name="refresh_descriptions">Refresh Descriptions</button>
+          {% if refresh_descriptions_success_message %}
+            <div class="has-success">
+              <p class="form-input-hint">
+                {{ refresh_descriptions_success_message }}
+              </p>
+            </div>
+          {% endif %}
+        </div>
+        <div class="form-group">
           <label for="{{ form.web_archive_integration.id_for_label }}" class="form-label">Internet Archive
             integration</label>
           {{ form.web_archive_integration|add_class:"form-select col-2 col-sm-12" }}

--- a/bookmarks/tests/test_settings_general_view.py
+++ b/bookmarks/tests/test_settings_general_view.py
@@ -177,6 +177,21 @@ class SettingsGeneralViewTestCase(TestCase, BookmarkFactoryMixin):
             <button class="btn mt-2" name="refresh_favicons">Refresh Favicons</button>
         ''', html, count=0)
 
+    def test_refresh_description(self):
+        with patch.object(task, 'schedule_refresh_descriptions') as mock_schedule_refresh_description:
+            form_data = {
+              'refresh_descriptions': '',
+            }
+            response = self.client.post(reverse('bookmarks:settings.general'), form_data)
+            html = response.content.decode()
+
+            mock_schedule_refresh_favicons.assert_called_once()
+            self.assertInHTML('''
+                <p class="form-input-hint">
+                    Scheduled descriptions update. This may take a while...
+                </p>
+            ''', html)
+
     def test_about_shows_version_info(self):
         response = self.client.get(reverse('bookmarks:settings.general'))
         html = response.content.decode()

--- a/bookmarks/views/settings.py
+++ b/bookmarks/views/settings.py
@@ -33,6 +33,7 @@ def general(request):
     enable_refresh_favicons = django_settings.LD_ENABLE_REFRESH_FAVICONS
     update_profile_success_message = None
     refresh_favicons_success_message = None
+    refresh_descriptions_success_message = None
     import_success_message = _find_message_with_tag(messages.get_messages(request), 'bookmark_import_success')
     import_errors_message = _find_message_with_tag(messages.get_messages(request), 'bookmark_import_errors')
     version_info = get_version_info(get_ttl_hash())
@@ -44,6 +45,9 @@ def general(request):
         if 'refresh_favicons' in request.POST:
             tasks.schedule_refresh_favicons(request.user)
             refresh_favicons_success_message = 'Scheduled favicon update. This may take a while...'
+        if 'refresh_descriptions' in request.POST:
+            tasks.schedule_refresh_descriptions(request.user)
+            refresh_descriptions_success_message = 'Scheduled descriptions update. This may take a while...'
 
     if not profile_form:
         profile_form = UserProfileForm(instance=request.user.profile)
@@ -53,6 +57,7 @@ def general(request):
         'enable_refresh_favicons': enable_refresh_favicons,
         'update_profile_success_message': update_profile_success_message,
         'refresh_favicons_success_message': refresh_favicons_success_message,
+        'refresh_descriptions_success_message': refresh_descriptions_success_message,
         'import_success_message': import_success_message,
         'import_errors_message': import_errors_message,
         'version_info': version_info,


### PR DESCRIPTION
Problem: after import. I didn't have any description. I would like the application to be able to do auto scrape of the description.

<img width="664" alt="image" src="https://user-images.githubusercontent.com/10431491/215366735-ea61f478-185d-459a-b72b-273836c6bda0.png">

<img width="930" alt="Screenshot 2023-01-29 at 9 27 38 PM" src="https://user-images.githubusercontent.com/10431491/215374830-d22c58aa-21f9-4481-b130-35c8bd4bf6bc.png">

<img width="750" alt="Screenshot 2023-01-29 at 9 27 44 PM" src="https://user-images.githubusercontent.com/10431491/215374836-ea21bd66-2af7-4fba-9335-c13bd4830e58.png">
