### PR TITLE
feat: Archived Bookmarks RSS Feed

### DIFF
--- a/bookmarks/feeds.py
+++ b/bookmarks/feeds.py
@@ -18,7 +18,7 @@ class BaseBookmarksFeed(Feed):
     def get_object(self, request, feed_key: str):
         feed_token = FeedToken.objects.get(key__exact=feed_key)
         query_string = request.GET.get('q')
-        query_set = queries.query_bookmarks(feed_token.user, query_string)
+        query_set = queries._base_bookmarks_query(feed_token.user, query_string)
         return FeedContext(feed_token, query_set)
 
     def item_title(self, item: Bookmark):
@@ -42,7 +42,7 @@ class AllBookmarksFeed(BaseBookmarksFeed):
         return reverse('bookmarks:feeds.all', args=[context.feed_token.key])
 
     def items(self, context: FeedContext):
-        return context.query_set
+        return context.query_set.filter(is_archived=False)
 
 
 class UnreadBookmarksFeed(BaseBookmarksFeed):
@@ -53,4 +53,14 @@ class UnreadBookmarksFeed(BaseBookmarksFeed):
         return reverse('bookmarks:feeds.unread', args=[context.feed_token.key])
 
     def items(self, context: FeedContext):
-        return context.query_set.filter(unread=True)
+        return context.query_set.filter(is_archived=False, unread=True)
+
+class ArchivedBookmarksFeed(BaseBookmarksFeed):
+    title = 'Archived bookmarks'
+    description = 'All archived bookmarks'
+
+    def link(self, context: FeedContext):
+        return reverse('bookmarks:feeds.archived', args=[context.feed_token.key])
+
+    def items(self, context: FeedContext):
+        return context.query_set.filter(is_archived=True)

--- a/bookmarks/templates/settings/integrations.html
+++ b/bookmarks/templates/settings/integrations.html
@@ -52,6 +52,7 @@
             <ul>
               <li><a href="{{ all_feed_url }}">All bookmarks</a></li>
               <li><a href="{{ unread_feed_url }}">Unread bookmarks</a></li>
+              <li><a href="{{ archived_feed_url }}">Archived bookmarks</a></li>
             </ul>
             <p>
               All URLs support appending a <code>q</code> URL parameter for specifying a search query.

--- a/bookmarks/tests/test_feeds.py
+++ b/bookmarks/tests/test_feeds.py
@@ -62,6 +62,28 @@ class FeedsTestCase(TestCase, BookmarkFactoryMixin):
                             '</item>'
             self.assertContains(response, expected_item, count=1)
 
+    def test_all_archived_bookmarks(self):
+        bookmarks = [
+            self.setup_bookmark(is_archived=True, description='test description'),
+            self.setup_bookmark(is_archived=True, website_description='test website description'),
+            self.setup_bookmark(is_archived=True, description='test description'),
+        ]
+
+        response = self.client.get(reverse('bookmarks:feeds.archived', args=[self.token.key]))
+        self.assertEqual(response.status_code, 200)
+
+        self.assertContains(response, '<item>', count=len(bookmarks))
+
+        for bookmark in bookmarks:
+            expected_item = '<item>' \
+                            f'<title>{bookmark.resolved_title}</title>' \
+                            f'<link>{bookmark.url}</link>' \
+                            f'<description>{bookmark.resolved_description}</description>' \
+                            f'<pubDate>{rfc2822_date(bookmark.date_added)}</pubDate>' \
+                            f'<guid>{bookmark.url}</guid>' \
+                            '</item>'
+            self.assertContains(response, expected_item, count=1)
+
     def test_all_with_query(self):
         tag1 = self.setup_tag()
         bookmark1 = self.setup_bookmark()

--- a/bookmarks/tests/test_settings_integrations_view.py
+++ b/bookmarks/tests/test_settings_integrations_view.py
@@ -64,3 +64,4 @@ class SettingsIntegrationsViewTestCase(TestCase, BookmarkFactoryMixin):
         token = FeedToken.objects.first()
         self.assertInHTML(f'<a href="http://testserver/feeds/{token.key}/all">All bookmarks</a>', html)
         self.assertInHTML(f'<a href="http://testserver/feeds/{token.key}/unread">Unread bookmarks</a>', html)
+        self.assertInHTML(f'<a href="http://testserver/feeds/{token.key}/archived">Archived bookmarks</a>', html)

--- a/bookmarks/urls.py
+++ b/bookmarks/urls.py
@@ -4,7 +4,7 @@ from django.views.generic import RedirectView
 
 from bookmarks.api.routes import router
 from bookmarks import views
-from bookmarks.feeds import AllBookmarksFeed, UnreadBookmarksFeed
+from bookmarks.feeds import AllBookmarksFeed, ArchivedBookmarksFeed, UnreadBookmarksFeed
 
 app_name = 'bookmarks'
 urlpatterns = [
@@ -31,6 +31,7 @@ urlpatterns = [
     # Feeds
     path('feeds/<str:feed_key>/all', AllBookmarksFeed(), name='feeds.all'),
     path('feeds/<str:feed_key>/unread', UnreadBookmarksFeed(), name='feeds.unread'),
+    path('feeds/<str:feed_key>/archived', ArchivedBookmarksFeed(), name='feeds.archived'),
     # Health check
     path('health', views.health, name='health')
 ]

--- a/bookmarks/views/settings.py
+++ b/bookmarks/views/settings.py
@@ -105,11 +105,13 @@ def integrations(request):
     feed_token = FeedToken.objects.get_or_create(user=request.user)[0]
     all_feed_url = request.build_absolute_uri(reverse('bookmarks:feeds.all', args=[feed_token.key]))
     unread_feed_url = request.build_absolute_uri(reverse('bookmarks:feeds.unread', args=[feed_token.key]))
+    archived_feed_url = request.build_absolute_uri(reverse('bookmarks:feeds.archived', args=[feed_token.key]))
     return render(request, 'settings/integrations.html', {
         'application_url': application_url,
         'api_token': api_token.key,
         'all_feed_url': all_feed_url,
         'unread_feed_url': unread_feed_url,
+        'archived_feed_url': archived_feed_url,
     })
 
 


### PR DESCRIPTION
Hi!

First off, this is an awesome project. The codebase is super clean and simple. I love it! ❤️ 

I was originally looking for a way to archive to Archivebox and came across this issue https://github.com/sissbruecker/linkding/issues/380. I took a slightly different approach to the suggested to achieve part of this feature request.
 
Since Archivebox has support for parsing RSS, I've instead just exposed the archived bookmarks through that. All that is required to close the loop is schedule ArchiveBox to read the feed at the user's specified rate. For example, I have mine set to every 10 minutes. This also removes the need for the scheduling workload to be handled by linkding.

Granted, while the `Archive` link takes you to `archive.org` for now, as suggested in the issue above that can be exposed and updated in the settings/API. I'd be happy to work on this feature in the near future. For now with just the RSS feed it's sufficient to add the bookmarks URL to the Archivebox URL to get the actual snapshot.