### PR TITLE
Update search to include tags even if not explicitly searching for tags

### DIFF
--- a/bookmarks/queries.py
+++ b/bookmarks/queries.py
@@ -41,6 +41,7 @@ def _base_bookmarks_query(user: Optional[User], query_string: str) -> QuerySet:
             | Q(website_title__icontains=term)
             | Q(website_description__icontains=term)
             | Q(url__icontains=term)
+            | Q(tags__name__icontains=term)
         )
 
     for tag_name in query['tag_names']:


### PR DESCRIPTION
Updates search to follow the behavior proposed in #409:
- Searching for a term returns results which contains the term in any field, including tags.
- Searching for a tag with `#` only returns those which are tagged with the tag. 

@sissbruecker let me know what you think about leaving this as the default or hiding it behind a setting