### PR TITLE
Prevent zoom-in after focusing an input on small viewports on iOS devices

### DIFF
--- a/bookmarks/styles/base.scss
+++ b/bookmarks/styles/base.scss
@@ -102,3 +102,12 @@ a:visited:hover {
     font-weight: bold;
   }
 }
+
+// Increase input font size on small viewports to prevent zooming on focus the input
+// on mobile devices. 430px relates to the "normalized" iPhone 14 Pro Max
+// viewport size
+@media screen and (max-width: 430px) {
+  .form-input {
+    font-size: 1rem;
+  }
+}

--- a/bookmarks/styles/base.scss
+++ b/bookmarks/styles/base.scss
@@ -108,6 +108,6 @@ a:visited:hover {
 // viewport size
 @media screen and (max-width: 430px) {
   .form-input {
-    font-size: 1rem;
+    font-size: 16px;
   }
 }


### PR DESCRIPTION
This PR adds a media query which sets the font-size for `.form-input` elements to `1rem` on viewports which are `430px` wide or smaller. This aims to prevent the automatic zoom-in on small viewports on iOS devices which slightly zoom-in a website after focusing an input element if the font-size of that element is smaller than 16px.

I am not sure if `base.scss` is the correct place for that change, but since it affects `.form-input` elements on mulitple views (e.g. the login inputs and the search input) that file felt fitting.