### PR TITLE
feat: add query date parameters

### DIFF
--- a/bookmarks/api/routes.py
+++ b/bookmarks/api/routes.py
@@ -23,7 +23,11 @@ class BookmarkViewSet(viewsets.GenericViewSet,
         # For list action, use query set that applies search and tag projections
         if self.action == 'list':
             query_string = self.request.GET.get('q')
-            return queries.query_bookmarks(user, query_string)
+            query_date_keys = ['since_added', 'until_added', 'since_modified', 'until_modified']
+            query_dates = {
+                key: value for key, value in self.request.GET.items() if key in query_date_keys and value is not None
+            }
+            return queries.query_bookmarks(user, query_string, query_dates)
 
         # For single entity actions use default query set without projections
         return Bookmark.objects.all().filter(owner=user)

--- a/bookmarks/models.py
+++ b/bookmarks/models.py
@@ -123,6 +123,11 @@ class BookmarkFilters:
         self.query = request.GET.get('q') or ''
         self.user = request.GET.get('user') or ''
 
+        query_date_keys = ['since_added', 'until_added', 'since_modified', 'until_modified']
+        self.query_dates = {
+            key: value for key, value in request.GET.items() if key in query_date_keys and value is not None
+        }
+
 
 class UserProfile(models.Model):
     THEME_AUTO = 'auto'

--- a/docs/API.md
+++ b/docs/API.md
@@ -31,6 +31,10 @@ Parameters:
 - `q` - Filters results using a search phrase using the same logic as through the UI
 - `limit` - Limits the max. number of results. Default is `100`.
 - `offset` - Index from which to start returning results
+- `since_added` - Filter results that were added on or after the specified timestamp.  Accepted values include `YYYY-MM-dd`, `YYYY-MM-ddTHH:mm`, and `YYYY-MM-ddTHH:mm:ss`.
+- `until_added` - Filter results that were added on or before the specified timestamp.  Accepted values match `since_added`.
+- `since_modified` - Filter results that were modified on or after the specified timestamp.  Accepted values match `since_added`.
+- `until_modified` - Filter results that were modified on or before the specified timestamp.  Accepted values match `since_added`.
 
 Example response:
 
@@ -70,7 +74,7 @@ GET /api/bookmarks/archived/
 
 List archived bookmarks.
 
-Parameters and response are the same as for the regular list endpoint.
+Parameters and response are the same as for the regular list endpoint, excluding timestamp parameters (`since_added`, `until_added`, `since_modified`, and `until_modified`).
 
 **Retrieve**
 


### PR DESCRIPTION
The purpose of this PR is to implement the functionality requested in #382 , specifically being able to query for only newly added or modified bookmarks (versus a full list every time).  This PR enables this through the use of additional URL parameters:

- `since_added`
- `until_added`
- `since_modified`
- `until_modified`

Note only the basic list bookmarks (`GET /api/bookmarks/`) has been updated, and not archived.  Happy to add this if needed or desired, but didn't want to go too far down a rabbit hole if this isn't in-line with desired implementation.

This PR only modifies the API; no front-end changes are made to support this.