### PR TITLE
Updates to BookmarkSerializer and API Documentation

### DIFF
--- a/bookmarks/api/routes.py
+++ b/bookmarks/api/routes.py
@@ -48,7 +48,7 @@ class BookmarkViewSet(viewsets.GenericViewSet,
         query_set = queries.query_shared_bookmarks(user, filters.query)
         page = self.paginate_queryset(query_set)
         serializer = self.get_serializer_class()
-        data = serializer(page, many=True).data
+        data = serializer(page, many=True, context={'user': request.user}).data
         return self.get_paginated_response(data)
 
     @action(methods=['post'], detail=True)

--- a/docs/API.md
+++ b/docs/API.md
@@ -47,9 +47,16 @@ Example response:
       "description": "Example description",
       "website_title": "Website title",
       "website_description": "Website description",
+      "favicon_file": "https_example_com.png",
+      "web_archive_snapshot_url": "https://web.archive.org/web/20230503135413/https://example.com?gi=22f80cef5487",
       "is_archived": false,
       "unread": false,
       "shared": false,
+      "is_mine": true,
+      "owner": {
+        "id": 1, 
+        "username": "example"
+      },
       "tag_names": [
         "tag1",
         "tag2"
@@ -71,6 +78,17 @@ GET /api/bookmarks/archived/
 List archived bookmarks.
 
 Parameters and response are the same as for the regular list endpoint.
+
+**List Shared**
+
+```
+GET /api/bookmarks/shared/
+```
+
+List shared bookmarks.
+
+Parameters and response are the same as for the regular list endpoint.
+
 
 **Retrieve**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linkding",
-  "version": "1.16.0",
+  "version": "1.17.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "linkding",
-      "version": "1.16.0",
+      "version": "1.17.2",
       "license": "ISC",
       "dependencies": {
         "@rollup/plugin-commonjs": "^21.0.2",


### PR DESCRIPTION
This pull request includes three changes to the project. 

🐛 Firstly, a bug was fixed in the BookmarkSerializer by adding missing fields such as favicon_file and web_archive_snapshot_url. 

✨  Secondly, new fields is_mine and owner were added to the BookmarkSerializer to indicate whether the bookmark belongs to the authenticated user, and the name and id of the owning user is included. 

📝 Finally, the shared bookmarks endpoint is now documented in the API documentation. These changes aim to improve the functionality and usability of the project.