### PR TITLE
Added Dev Container support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,35 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+	"name": "Python 3",
+	"image": "mcr.microsoft.com/devcontainers/python:0-3.10",
+	"features": {
+		"ghcr.io/devcontainers/features/node:1": {}
+	},
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [8000],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": [
+		"pip3 install --user -r requirements.txt",
+		"npm install",
+		"mkdir -p data",
+		"python3 manage.py migrate",
+		"python3 manage.py createsuperuser --username=joe --email=joe@example.com --password=joe"
+	],
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-python.python"
+			]
+		}
+	},
+
+	"remoteUser": "vscode"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,13 +14,7 @@
 	"forwardPorts": [8000],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": [
-		"pip3 install --user -r requirements.txt",
-		"npm install",
-		"mkdir -p data",
-		"python3 manage.py migrate",
-		"python3 manage.py createsuperuser --username=joe --email=joe@example.com --password=joe"
-	],
+	"postCreateCommand": "pip3 install --user -r requirements.txt && npm install && mkdir -p data && python3 manage.py migrate",
 
 	// Configure tool-specific properties.
 	"customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
 	"forwardPorts": [8000],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "pip3 install --user -r requirements.txt && npm install && mkdir -p data && python3 manage.py migrate",
+	"postCreateCommand": "pip3 install --user -r requirements.txt && npm install && mkdir -p data && python3 manage.py migrate && playwright install chromium && playwright install-deps",
 
 	// Configure tool-specific properties.
 	"customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
 	"forwardPorts": [8000],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "pip3 install --user -r requirements.txt && npm install && mkdir -p data && python3 manage.py migrate && playwright install chromium && playwright install-deps",
+	"postCreateCommand": "pip3 install --user -r requirements.txt && npm install && mkdir -p data && python3 manage.py migrate",
 
 	// Configure tool-specific properties.
 	"customizations": {

--- a/.dockerignore
+++ b/.dockerignore
@@ -9,9 +9,11 @@
 /build
 /out
 /.git
+/.devcontainer
 
 /.dockerignore
 /.gitignore
+/.gitattributes
 /Dockerfile
 /docker-compose.yml
 /*.sh

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.sh text eol=lf

--- a/README.md
+++ b/README.md
@@ -243,3 +243,23 @@ Start the Django development server with:
 python3 manage.py runserver
 ```
 The frontend is now available under http://localhost:8000
+
+### DevContainers
+
+This repository also supports DevContainers: [![Open in Remote - Containers](https://img.shields.io/static/v1?label=Remote%20-%20Containers&message=Open&color=blue&logo=visualstudiocode)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=git@github.com:sissbruecker/linkding.git)
+
+Once checked out, only the following commands are required to get started:
+
+Create a user for the frontend:
+```
+python3 manage.py createsuperuser --username=joe --email=joe@example.com
+```
+Start the Node.js development server (used for compiling JavaScript components like tag auto-completion) with:
+```
+npm run dev
+```
+Start the Django development server with:
+```
+python3 manage.py runserver
+```
+The frontend is now available under http://localhost:8000


### PR DESCRIPTION
For #473 

This adds the necessary files to support developing with Dev Containers. It should have no impact on anyone who chooses to develop without Dev Containers, it simply adds it as an option.

The changes:
* devcontainer.json - The Dev Container configuration. Uses an image with Python 3.10 and NodeJS support added. It also automatically runs several of the necessary commands on creation making it easier for new users
* .gitattributes - Dev Containers appear to have this issue on Windows where the files are checked out with Windows file endings, then loaded into a Linux dev container where it expects different line endings. This resolves that. It should have no impact on anyone else
* readme.md - Added that Dev Containers are supported, and added a link which would automatically check the code out in a Dev Container. Note that the link will not work until the change has been merged due to the repository currently not having the necessary files.

If you have any questions on how this works let me know and I can add further detail. I'd be happy to more detail to the documentation around this.