### PR TITLE
Allow passing title and description to new bookmark form

### DIFF
--- a/bookmarks/templates/bookmarks/bookmarklet.js
+++ b/bookmarks/templates/bookmarks/bookmarklet.js
@@ -1,10 +1,8 @@
 (function () {
   var bookmarkUrl = window.location;
-  var bookmarkTitle = document.title;
   var applicationUrl = '{{ application_url }}';
 
   applicationUrl += '?url=' + encodeURIComponent(bookmarkUrl);
-  applicationUrl += '&title=' + encodeURIComponent(bookmarkTitle);
   applicationUrl += '&auto_close';
 
   window.open(applicationUrl);

--- a/bookmarks/templates/bookmarks/bookmarklet.js
+++ b/bookmarks/templates/bookmarks/bookmarklet.js
@@ -1,8 +1,10 @@
 (function () {
   var bookmarkUrl = window.location;
+  var bookmarkTitle = document.title;
   var applicationUrl = '{{ application_url }}';
 
   applicationUrl += '?url=' + encodeURIComponent(bookmarkUrl);
+  applicationUrl += '&title=' + encodeURIComponent(bookmarkTitle);
   applicationUrl += '&auto_close';
 
   window.open(applicationUrl);

--- a/bookmarks/tests/test_bookmark_new_view.py
+++ b/bookmarks/tests/test_bookmark_new_view.py
@@ -75,6 +75,25 @@ class BookmarkNewViewTestCase(TestCase, BookmarkFactoryMixin):
             'placeholder=" " autofocus class="form-input" required '
             'id="id_url">',
             html)
+    
+    def test_should_prefill_title_from_url_parameter(self):
+        response = self.client.get(reverse('bookmarks:new') + '?title=Example%20Title')
+        html = response.content.decode()
+
+        self.assertInHTML(
+            '<input type="text" name="title" value="Example Title" '
+            'class="form-input" maxlength="512" autocomplete="off" '
+            'id="id_title">',
+            html)
+        
+    def test_should_prefill_description_from_url_parameter(self):
+        response = self.client.get(reverse('bookmarks:new') + '?description=Example%20Site%20Description')
+        html = response.content.decode()
+
+        self.assertInHTML(
+            '<textarea name="description" class="form-input" cols="40" '
+            'rows="2" id="id_description">Example Site Description</textarea>',
+            html)
 
     def test_should_enable_auto_close_when_specified_in_url_parameter(self):
         response = self.client.get(

--- a/bookmarks/views/bookmarks.py
+++ b/bookmarks/views/bookmarks.py
@@ -114,6 +114,8 @@ def convert_tag_string(tag_string: str):
 @login_required
 def new(request):
     initial_url = request.GET.get('url')
+    initial_title = request.GET.get('title')
+    initial_description = request.GET.get('description')
     initial_auto_close = 'auto_close' in request.GET
 
     if request.method == 'POST':
@@ -131,6 +133,10 @@ def new(request):
         form = BookmarkForm()
         if initial_url:
             form.initial['url'] = initial_url
+        if initial_title:
+            form.initial['title'] = initial_title
+        if initial_description:
+            form.initial['description'] = initial_description
         if initial_auto_close:
             form.initial['auto_close'] = 'true'
 


### PR DESCRIPTION
Related to #118 I have made the following changes:

* Updated the New Bookmark page to accept 'title' and 'description' from the URL
* Updated the automated tests for New Bookmark