### PR TITLE
Enable WAL to avoid locked databases

### DIFF
--- a/bookmarks/management/commands/enable_wal.py
+++ b/bookmarks/management/commands/enable_wal.py
@@ -1,0 +1,24 @@
+import logging
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.db import connections
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Enable WAL journal mode when using an SQLite database"
+
+    def handle(self, *args, **options):
+        if settings.DATABASES['default']['ENGINE'] != 'django.db.backends.sqlite3':
+            return
+
+        connection = connections['default']
+        with connection.cursor() as cursor:
+            cursor.execute("PRAGMA journal_mode")
+            current_mode = cursor.fetchone()[0]
+            logger.info(f'Current journal mode: {current_mode}')
+            if current_mode != 'wal':
+                cursor.execute("PRAGMA journal_mode=wal;")
+                logger.info('Switched to WAL journal mode')

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -10,6 +10,8 @@ mkdir -p data/favicons
 
 # Run database migration
 python manage.py migrate
+# Enable WAL journal mode for SQLite databases
+python manage.py enable_wal
 # Generate secret key file if it does not exist
 python manage.py generate_secret_key
 # Create initial superuser if defined in options / environment variables


### PR DESCRIPTION
Enables WAL journal mode for SQLite databases when starting the container, which should avoid lock errors on concurrent writes.