### PR TITLE
Add support for PRIVATE flag in import and export

### DIFF
--- a/bookmarks/services/exporter.py
+++ b/bookmarks/services/exporter.py
@@ -33,9 +33,10 @@ def append_bookmark(doc: BookmarkDocument, bookmark: Bookmark):
     desc = html.escape(bookmark.resolved_description or '')
     tags = ','.join(bookmark.tag_names)
     toread = '1' if bookmark.unread else '0'
+    private = '0' if bookmark.shared else '1'
     added = int(bookmark.date_added.timestamp())
 
-    doc.append(f'<DT><A HREF="{url}" ADD_DATE="{added}" PRIVATE="0" TOREAD="{toread}" TAGS="{tags}">{title}</A>')
+    doc.append(f'<DT><A HREF="{url}" ADD_DATE="{added}" PRIVATE="{private}" TOREAD="{toread}" TAGS="{tags}">{title}</A>')
 
     if desc:
         doc.append(f'<DD>{desc}')

--- a/bookmarks/services/parser.py
+++ b/bookmarks/services/parser.py
@@ -11,6 +11,7 @@ class NetscapeBookmark:
     date_added: str
     tag_string: str
     to_read: bool
+    private: bool
 
 
 class BookmarkParser(HTMLParser):
@@ -26,6 +27,7 @@ class BookmarkParser(HTMLParser):
         self.title = ''
         self.description = ''
         self.toread = ''
+        self.private = ''
 
     def handle_starttag(self, tag: str, attrs: list):
         name = 'handle_start_' + tag.lower()
@@ -58,7 +60,9 @@ class BookmarkParser(HTMLParser):
             description='',
             date_added=self.add_date,
             tag_string=self.tags,
-            to_read=self.toread == '1'
+            to_read=self.toread == '1',
+            # Mark as private by default, also when attribute is not specified
+            private=self.private != '0',
         )
 
     def handle_a_data(self, data):
@@ -79,6 +83,7 @@ class BookmarkParser(HTMLParser):
         self.title = ''
         self.description = ''
         self.toread = ''
+        self.private = ''
 
 
 def parse(html: str) -> List[NetscapeBookmark]:

--- a/bookmarks/templates/settings/general.html
+++ b/bookmarks/templates/settings/general.html
@@ -145,6 +145,16 @@
       <form method="post" enctype="multipart/form-data" action="{% url 'bookmarks:settings.import' %}">
         {% csrf_token %}
         <div class="form-group">
+          <label for="import_map_private_flag" class="form-checkbox">
+            <input type="checkbox" id="import_map_private_flag" name="map_private_flag">
+            <i class="form-icon"></i> Import public bookmarks as shared
+          </label>
+          <div class="form-input-hint">
+            When importing bookmarks from a service that supports marking bookmarks as public or private (using the <code>PRIVATE</code> attribute), enabling this option will import all bookmarks that are marked as not private as shared bookmarks.
+            Otherwise, all bookmarks will be imported as private bookmarks.
+          </div>
+        </div>
+        <div class="form-group">
           <div class="input-group col-8 col-md-12">
             <input class="form-input" type="file" name="import_file">
             <input type="submit" class="input-group-btn col-2 btn btn-primary" value="Upload">

--- a/bookmarks/templates/settings/general.html
+++ b/bookmarks/templates/settings/general.html
@@ -181,6 +181,10 @@
     <section class="content-area">
       <h2>Export</h2>
       <p>Export all bookmarks in Netscape HTML format.</p>
+      <p>
+        Note that exporting bookmark notes is currently not supported due to limitations of the format.
+        For proper backups please use a database backup as described in the documentation.
+      </p>
       <a class="btn btn-primary" href="{% url 'bookmarks:settings.export' %}">Download (.html)</a>
       {% if export_error %}
         <div class="has-error">

--- a/bookmarks/tests/helpers.py
+++ b/bookmarks/tests/helpers.py
@@ -147,7 +147,8 @@ class ImportTestMixin:
         <A {f'HREF="{tag.href}"' if tag.href else ''}
            {f'ADD_DATE="{tag.add_date}"' if tag.add_date else ''}
            {f'TAGS="{tag.tags}"' if tag.tags else ''}
-           TOREAD="{1 if tag.to_read else 0}">
+           TOREAD="{1 if tag.to_read else 0}"
+           PRIVATE="{1 if tag.private else 0}">
            {tag.title if tag.title else ''}
         </A>
         {f'<DD>{tag.description}' if tag.description else ''}

--- a/bookmarks/tests/helpers.py
+++ b/bookmarks/tests/helpers.py
@@ -1,5 +1,6 @@
 import random
 import logging
+import datetime
 from typing import List
 
 from bs4 import BeautifulSoup
@@ -35,6 +36,7 @@ class BookmarkFactoryMixin:
                        website_description: str = '',
                        web_archive_snapshot_url: str = '',
                        favicon_file: str = '',
+                       added: datetime = None,
                        ):
         if not title:
             title = get_random_string(length=32)
@@ -45,6 +47,8 @@ class BookmarkFactoryMixin:
         if not url:
             unique_id = get_random_string(length=32)
             url = 'https://example.com/' + unique_id
+        if added is None:
+            added = timezone.now()
         bookmark = Bookmark(
             url=url,
             title=title,
@@ -52,7 +56,7 @@ class BookmarkFactoryMixin:
             notes=notes,
             website_title=website_title,
             website_description=website_description,
-            date_added=timezone.now(),
+            date_added=added,
             date_modified=timezone.now(),
             owner=user,
             is_archived=is_archived,

--- a/bookmarks/tests/helpers.py
+++ b/bookmarks/tests/helpers.py
@@ -125,13 +125,15 @@ class BookmarkHtmlTag:
                  description: str = '',
                  add_date: str = '',
                  tags: str = '',
-                 to_read: bool = False):
+                 to_read: bool = False,
+                 private: bool = True):
         self.href = href
         self.title = title
         self.description = description
         self.add_date = add_date
         self.tags = tags
         self.to_read = to_read
+        self.private = private
 
 
 class ImportTestMixin:

--- a/bookmarks/tests/test_exporter.py
+++ b/bookmarks/tests/test_exporter.py
@@ -1,10 +1,36 @@
 from django.test import TestCase
+from django.utils import timezone
 
 from bookmarks.services import exporter
 from bookmarks.tests.helpers import BookmarkFactoryMixin
 
 
 class ExporterTestCase(TestCase, BookmarkFactoryMixin):
+    def test_export_bookmarks(self):
+        added = timezone.now()
+        timestamp = int(added.timestamp())
+
+        bookmarks = [
+            self.setup_bookmark(url='https://example.com/1', title='Title 1', added=added,
+                                description='Example description'),
+            self.setup_bookmark(url='https://example.com/2', title='Title 2', added=added,
+                                tags=[self.setup_tag(name='tag1'), self.setup_tag(name='tag2'),
+                                      self.setup_tag(name='tag3')]),
+            self.setup_bookmark(url='https://example.com/3', title='Title 3', added=added, unread=True),
+            self.setup_bookmark(url='https://example.com/4', title='Title 4', added=added, shared=True),
+
+        ]
+        html = exporter.export_netscape_html(bookmarks)
+
+        lines = [
+            f'<DT><A HREF="https://example.com/1" ADD_DATE="{timestamp}" PRIVATE="1" TOREAD="0" TAGS="">Title 1</A>',
+            '<DD>Example description',
+            f'<DT><A HREF="https://example.com/2" ADD_DATE="{timestamp}" PRIVATE="1" TOREAD="0" TAGS="tag1,tag2,tag3">Title 2</A>',
+            f'<DT><A HREF="https://example.com/3" ADD_DATE="{timestamp}" PRIVATE="1" TOREAD="1" TAGS="">Title 3</A>',
+            f'<DT><A HREF="https://example.com/4" ADD_DATE="{timestamp}" PRIVATE="0" TOREAD="0" TAGS="">Title 4</A>',
+        ]
+        self.assertIn('\n\r'.join(lines), html)
+
     def test_escape_html_in_title_and_description(self):
         bookmark = self.setup_bookmark(
             title='<style>: The Style Information element',

--- a/bookmarks/tests/test_parser.py
+++ b/bookmarks/tests/test_parser.py
@@ -18,6 +18,7 @@ class ParserTestCase(TestCase, ImportTestMixin):
             self.assertEqual(bookmark.description, html_tag.description)
             self.assertEqual(bookmark.tag_string, html_tag.tags)
             self.assertEqual(bookmark.to_read, html_tag.to_read)
+            self.assertEqual(bookmark.private, html_tag.private)
 
     def test_parse_bookmarks(self):
         html_tags = [
@@ -123,3 +124,28 @@ class ParserTestCase(TestCase, ImportTestMixin):
         bookmarks = parse(html)
 
         self.assertTagsEqual(bookmarks, html_tags)
+
+    def test_private_flag(self):
+        # is private by default
+        html = self.render_html(tags_html='''
+        <DT><A HREF="https://example.com" ADD_DATE="1">Example title</A>
+        <DD>Example description</DD>
+        ''')
+        bookmarks = parse(html)
+        self.assertEqual(bookmarks[0].private, True)
+
+        # explicitly marked as private
+        html = self.render_html(tags_html='''
+        <DT><A HREF="https://example.com" ADD_DATE="1" PRIVATE="1">Example title</A>
+        <DD>Example description</DD>
+        ''')
+        bookmarks = parse(html)
+        self.assertEqual(bookmarks[0].private, True)
+
+        # explicitly marked as public
+        html = self.render_html(tags_html='''
+        <DT><A HREF="https://example.com" ADD_DATE="1" PRIVATE="0">Example title</A>
+        <DD>Example description</DD>
+        ''')
+        bookmarks = parse(html)
+        self.assertEqual(bookmarks[0].private, False)

--- a/bookmarks/views/settings.py
+++ b/bookmarks/views/settings.py
@@ -116,6 +116,7 @@ def integrations(request):
 @login_required
 def bookmark_import(request):
     import_file = request.FILES.get('import_file')
+    import_options = importer.ImportOptions(map_private_flag=request.POST.get('map_private_flag') == 'on')
 
     if import_file is None:
         messages.error(request, 'Please select a file to import.', 'bookmark_import_errors')
@@ -123,7 +124,7 @@ def bookmark_import(request):
 
     try:
         content = import_file.read().decode()
-        result = importer.import_netscape_html(content, request.user)
+        result = importer.import_netscape_html(content, request.user, import_options)
         success_msg = str(result.success) + ' bookmarks were successfully imported.'
         messages.success(request, success_msg, 'bookmark_import_success')
         if result.failed > 0:


### PR DESCRIPTION
Adds support for the `PRIVATE` flag when importing / exporting in the Netscape HTML format in order to improve compatibility with other bookmark apps that support marking bookmarks as public / private.

When importing bookmarks, a new option allows to import non private bookmarks (`PRIVATE="0"`) as shared bookmarks. This is opt-in because:
- it keeps the existing default behavior which imports all bookmarks as private
- the export function previously did set `PRIVATE="0"` (=public) on all exported bookmarks, regardless whether they were shared or not

The export has been changed to properly set the `PRIVATE` flag, depending on whether a bookmark is marked as shared or not.

Part of https://github.com/sissbruecker/linkding/issues/484