### PR TITLE
Update cached styles and scripts after version change

### DIFF
--- a/bookmarks/context_processors.py
+++ b/bookmarks/context_processors.py
@@ -1,5 +1,6 @@
 from bookmarks import queries
 from bookmarks.models import Toast
+from bookmarks import utils
 
 
 def toasts(request):
@@ -23,3 +24,9 @@ def public_shares(request):
         }
 
     return {}
+
+
+def app_version(request):
+    return {
+        'app_version': utils.app_version
+    }

--- a/bookmarks/templates/bookmarks/archive.html
+++ b/bookmarks/templates/bookmarks/archive.html
@@ -41,5 +41,5 @@
     </section>
   </div>
 
-  <script src="{% static "bundle.js" %}"></script>
+  <script src="{% static "bundle.js" %}?v={{ app_version }}"></script>
 {% endblock %}

--- a/bookmarks/templates/bookmarks/form.html
+++ b/bookmarks/templates/bookmarks/form.html
@@ -116,8 +116,7 @@
     <a href="{{ cancel_url }}" class="btn">Nevermind</a>
   </div>
 
-  {# Replace tag input with auto-complete component #}
-  <script src="{% static "bundle.js" %}"></script>
+  <script src="{% static "bundle.js" %}?v={{ app_version }}"></script>
   <script type="application/javascript">
     /**
      * - Pre-fill title and description placeholders with metadata from website as soon as URL changes

--- a/bookmarks/templates/bookmarks/index.html
+++ b/bookmarks/templates/bookmarks/index.html
@@ -41,5 +41,5 @@
     </section>
   </div>
 
-  <script src="{% static "bundle.js" %}"></script>
+  <script src="{% static "bundle.js" %}?v={{ app_version }}"></script>
 {% endblock %}

--- a/bookmarks/templates/bookmarks/layout.html
+++ b/bookmarks/templates/bookmarks/layout.html
@@ -18,14 +18,14 @@
   {# Include SASS styles, files are resolved from bookmarks/styles #}
   {# Include specific theme variant based on user profile setting #}
   {% if request.user_profile.theme == 'light' %}
-    <link href="{% sass_src 'theme-light.scss' %}" rel="stylesheet" type="text/css"/>
+    <link href="{% sass_src 'theme-light.scss' %}?v={{ app_version }}" rel="stylesheet" type="text/css"/>
   {% elif request.user_profile.theme == 'dark' %}
-    <link href="{% sass_src 'theme-dark.scss' %}" rel="stylesheet" type="text/css"/>
+    <link href="{% sass_src 'theme-dark.scss' %}?v={{ app_version }}" rel="stylesheet" type="text/css"/>
   {% else %}
     {# Use auto theme as fallback #}
-    <link href="{% sass_src 'theme-dark.scss' %}" rel="stylesheet" type="text/css"
+    <link href="{% sass_src 'theme-dark.scss' %}?v={{ app_version }}" rel="stylesheet" type="text/css"
           media="(prefers-color-scheme: dark)"/>
-    <link href="{% sass_src 'theme-light.scss' %}" rel="stylesheet" type="text/css"
+    <link href="{% sass_src 'theme-light.scss' %}?v={{ app_version }}" rel="stylesheet" type="text/css"
           media="(prefers-color-scheme: light)"/>
   {% endif %}
 </head>

--- a/bookmarks/templates/bookmarks/shared.html
+++ b/bookmarks/templates/bookmarks/shared.html
@@ -45,5 +45,5 @@
     </section>
   </div>
 
-  <script src="{% static "bundle.js" %}"></script>
+  <script src="{% static "bundle.js" %}?v={{ app_version }}"></script>
 {% endblock %}

--- a/bookmarks/utils.py
+++ b/bookmarks/utils.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from datetime import datetime
 from typing import Optional
@@ -5,6 +6,13 @@ from typing import Optional
 from dateutil.relativedelta import relativedelta
 from django.template.defaultfilters import pluralize
 from django.utils import timezone, formats
+
+try:
+    with open("version.txt", "r") as f:
+        app_version = f.read().strip("\n")
+except Exception as exc:
+    logging.exception(exc)
+    app_version = ''
 
 
 def unique(elements, key):

--- a/bookmarks/views/settings.py
+++ b/bookmarks/views/settings.py
@@ -16,15 +16,9 @@ from bookmarks.models import UserProfileForm, FeedToken
 from bookmarks.queries import query_bookmarks
 from bookmarks.services import exporter, tasks
 from bookmarks.services import importer
+from bookmarks.utils import app_version
 
 logger = logging.getLogger(__name__)
-
-try:
-    with open("version.txt", "r") as f:
-        app_version = f.read().strip("\n")
-except Exception as exc:
-    logging.exception(exc)
-    pass
 
 
 @login_required

--- a/siteroot/settings/base.py
+++ b/siteroot/settings/base.py
@@ -73,6 +73,7 @@ TEMPLATES = [
                 'django.contrib.messages.context_processors.messages',
                 'bookmarks.context_processors.toasts',
                 'bookmarks.context_processors.public_shares',
+                'bookmarks.context_processors.app_version',
             ],
         },
     },


### PR DESCRIPTION
Force the browser to reload styles and scripts whenever a new linkding version is deployed.

Fixes https://github.com/sissbruecker/linkding/issues/509
Fixes https://github.com/sissbruecker/linkding/issues/508