### PR TITLE
Allow bulk editing unread and shared state of bookmarks

### DIFF
--- a/bookmarks/e2e/e2e_test_bookmark_page_bulk_edit.py
+++ b/bookmarks/e2e/e2e_test_bookmark_page_bulk_edit.py
@@ -1,5 +1,5 @@
 from django.urls import reverse
-from playwright.sync_api import sync_playwright
+from playwright.sync_api import sync_playwright, expect
 
 from bookmarks.e2e.helpers import LinkdingE2ETestCase
 from bookmarks.models import Bookmark
@@ -92,3 +92,141 @@ class BookmarkPagePartialUpdatesE2ETestCase(LinkdingE2ETestCase):
         self.assertEqual(50, Bookmark.objects.filter(is_archived=True, title__startswith='Archived Bookmark').count())
         self.assertEqual(50, Bookmark.objects.filter(is_archived=False, title__startswith='foo').count())
         self.assertEqual(0, Bookmark.objects.filter(is_archived=True, title__startswith='foo').count())
+
+    def test_select_all_toggles_all_checkboxes(self):
+        self.setup_numbered_bookmarks(5)
+
+        with sync_playwright() as p:
+            url = reverse('bookmarks:index')
+            page = self.open(url, p)
+
+            self.locate_bulk_edit_toggle().click()
+
+            checkboxes = page.locator('label[ld-bulk-edit-checkbox] input')
+            self.assertEqual(6, checkboxes.count())
+            for i in range(checkboxes.count()):
+                expect(checkboxes.nth(i)).not_to_be_checked()
+
+            self.locate_bulk_edit_select_all().click()
+
+            for i in range(checkboxes.count()):
+                expect(checkboxes.nth(i)).to_be_checked()
+
+            self.locate_bulk_edit_select_all().click()
+
+            for i in range(checkboxes.count()):
+                expect(checkboxes.nth(i)).not_to_be_checked()
+
+    def test_select_all_shows_select_across(self):
+        self.setup_numbered_bookmarks(5)
+
+        with sync_playwright() as p:
+            url = reverse('bookmarks:index')
+            self.open(url, p)
+
+            self.locate_bulk_edit_toggle().click()
+
+            expect(self.locate_bulk_edit_select_across()).not_to_be_visible()
+
+            self.locate_bulk_edit_select_all().click()
+            expect(self.locate_bulk_edit_select_across()).to_be_visible()
+
+            self.locate_bulk_edit_select_all().click()
+            expect(self.locate_bulk_edit_select_across()).not_to_be_visible()
+
+    def test_select_across_is_unchecked_when_toggling_all(self):
+        self.setup_numbered_bookmarks(5)
+
+        with sync_playwright() as p:
+            url = reverse('bookmarks:index')
+            self.open(url, p)
+
+            self.locate_bulk_edit_toggle().click()
+
+            # Show select across, check it
+            self.locate_bulk_edit_select_all().click()
+            self.locate_bulk_edit_select_across().click()
+            expect(self.locate_bulk_edit_select_across()).to_be_checked()
+
+            # Hide select across by toggling select all
+            self.locate_bulk_edit_select_all().click()
+            expect(self.locate_bulk_edit_select_across()).not_to_be_visible()
+
+            # Show select across again, verify it is unchecked
+            self.locate_bulk_edit_select_all().click()
+            expect(self.locate_bulk_edit_select_across()).not_to_be_checked()
+
+    def test_select_across_is_unchecked_when_toggling_bookmark(self):
+        self.setup_numbered_bookmarks(5)
+
+        with sync_playwright() as p:
+            url = reverse('bookmarks:index')
+            self.open(url, p)
+
+            self.locate_bulk_edit_toggle().click()
+
+            # Show select across, check it
+            self.locate_bulk_edit_select_all().click()
+            self.locate_bulk_edit_select_across().click()
+            expect(self.locate_bulk_edit_select_across()).to_be_checked()
+
+            # Hide select across by toggling a single bookmark
+            self.locate_bookmark('Bookmark 1').locator('label[ld-bulk-edit-checkbox]').click()
+            expect(self.locate_bulk_edit_select_across()).not_to_be_visible()
+
+            # Show select across again, verify it is unchecked
+            self.locate_bookmark('Bookmark 1').locator('label[ld-bulk-edit-checkbox]').click()
+            expect(self.locate_bulk_edit_select_across()).not_to_be_checked()
+
+    def test_execute_resets_all_checkboxes(self):
+        self.setup_numbered_bookmarks(100)
+
+        with sync_playwright() as p:
+            url = reverse('bookmarks:index')
+            page = self.open(url, p)
+
+            # Select all bookmarks, enable select across
+            self.locate_bulk_edit_toggle().click()
+            self.locate_bulk_edit_select_all().click()
+            self.locate_bulk_edit_select_across().click()
+
+            # Get reference for bookmark list
+            bookmark_list = page.locator('ul[ld-bookmark-list]')
+
+            # Execute bulk action
+            self.select_bulk_action('Mark as unread')
+            self.locate_bulk_edit_bar().get_by_text('Execute').click()
+            self.locate_bulk_edit_bar().get_by_text('Confirm').click()
+
+            # Wait until bookmark list is updated (old reference becomes invisible)
+            expect(bookmark_list).not_to_be_visible()
+
+            # Verify bulk edit checkboxes are reset
+            checkboxes = page.locator('label[ld-bulk-edit-checkbox] input')
+            self.assertEqual(31, checkboxes.count())
+            for i in range(checkboxes.count()):
+                expect(checkboxes.nth(i)).not_to_be_checked()
+
+            # Toggle select all and verify select across is reset
+            self.locate_bulk_edit_select_all().click()
+            expect(self.locate_bulk_edit_select_across()).not_to_be_checked()
+
+    def test_update_select_across_bookmark_count(self):
+        self.setup_numbered_bookmarks(100)
+
+        with sync_playwright() as p:
+            url = reverse('bookmarks:index')
+            self.open(url, p)
+
+            self.locate_bulk_edit_toggle().click()
+            self.locate_bulk_edit_select_all().click()
+
+            expect(self.locate_bulk_edit_bar().get_by_text('All pages (100 bookmarks)')).to_be_visible()
+
+            self.select_bulk_action('Delete')
+            self.locate_bulk_edit_bar().get_by_text('Execute').click()
+            self.locate_bulk_edit_bar().get_by_text('Confirm').click()
+
+            self.locate_bulk_edit_select_all().click()
+
+            expect(self.locate_bulk_edit_bar().get_by_text('All pages (70 bookmarks)')).to_be_visible()

--- a/bookmarks/e2e/e2e_test_bookmark_page_bulk_edit.py
+++ b/bookmarks/e2e/e2e_test_bookmark_page_bulk_edit.py
@@ -1,0 +1,94 @@
+from django.urls import reverse
+from playwright.sync_api import sync_playwright
+
+from bookmarks.e2e.helpers import LinkdingE2ETestCase
+from bookmarks.models import Bookmark
+
+
+class BookmarkPagePartialUpdatesE2ETestCase(LinkdingE2ETestCase):
+    def setup_test_data(self):
+        self.setup_numbered_bookmarks(50)
+        self.setup_numbered_bookmarks(50, archived=True)
+        self.setup_numbered_bookmarks(50, prefix='foo')
+        self.setup_numbered_bookmarks(50, archived=True, prefix='foo')
+
+        self.assertEqual(50, Bookmark.objects.filter(is_archived=False, title__startswith='Bookmark').count())
+        self.assertEqual(50, Bookmark.objects.filter(is_archived=True, title__startswith='Archived Bookmark').count())
+        self.assertEqual(50, Bookmark.objects.filter(is_archived=False, title__startswith='foo').count())
+        self.assertEqual(50, Bookmark.objects.filter(is_archived=True, title__startswith='foo').count())
+
+    def test_active_bookmarks_bulk_select_across(self):
+        self.setup_test_data()
+
+        with sync_playwright() as p:
+            self.open(reverse('bookmarks:index'), p)
+
+            self.locate_bulk_edit_toggle().click()
+            self.locate_bulk_edit_select_all().click()
+            self.locate_bulk_edit_select_across().click()
+
+            self.select_bulk_action('Delete')
+            self.locate_bulk_edit_bar().get_by_text('Execute').click()
+            self.locate_bulk_edit_bar().get_by_text('Confirm').click()
+
+        self.assertEqual(0, Bookmark.objects.filter(is_archived=False, title__startswith='Bookmark').count())
+        self.assertEqual(50, Bookmark.objects.filter(is_archived=True, title__startswith='Archived Bookmark').count())
+        self.assertEqual(0, Bookmark.objects.filter(is_archived=False, title__startswith='foo').count())
+        self.assertEqual(50, Bookmark.objects.filter(is_archived=True, title__startswith='foo').count())
+
+    def test_archived_bookmarks_bulk_select_across(self):
+        self.setup_test_data()
+
+        with sync_playwright() as p:
+            self.open(reverse('bookmarks:archived'), p)
+
+            self.locate_bulk_edit_toggle().click()
+            self.locate_bulk_edit_select_all().click()
+            self.locate_bulk_edit_select_across().click()
+
+            self.select_bulk_action('Delete')
+            self.locate_bulk_edit_bar().get_by_text('Execute').click()
+            self.locate_bulk_edit_bar().get_by_text('Confirm').click()
+
+        self.assertEqual(50, Bookmark.objects.filter(is_archived=False, title__startswith='Bookmark').count())
+        self.assertEqual(0, Bookmark.objects.filter(is_archived=True, title__startswith='Archived Bookmark').count())
+        self.assertEqual(50, Bookmark.objects.filter(is_archived=False, title__startswith='foo').count())
+        self.assertEqual(0, Bookmark.objects.filter(is_archived=True, title__startswith='foo').count())
+
+    def test_active_bookmarks_bulk_select_across_respects_query(self):
+        self.setup_test_data()
+
+        with sync_playwright() as p:
+            self.open(reverse('bookmarks:index') + '?q=foo', p)
+
+            self.locate_bulk_edit_toggle().click()
+            self.locate_bulk_edit_select_all().click()
+            self.locate_bulk_edit_select_across().click()
+
+            self.select_bulk_action('Delete')
+            self.locate_bulk_edit_bar().get_by_text('Execute').click()
+            self.locate_bulk_edit_bar().get_by_text('Confirm').click()
+
+        self.assertEqual(50, Bookmark.objects.filter(is_archived=False, title__startswith='Bookmark').count())
+        self.assertEqual(50, Bookmark.objects.filter(is_archived=True, title__startswith='Archived Bookmark').count())
+        self.assertEqual(0, Bookmark.objects.filter(is_archived=False, title__startswith='foo').count())
+        self.assertEqual(50, Bookmark.objects.filter(is_archived=True, title__startswith='foo').count())
+
+    def test_archived_bookmarks_bulk_select_across_respects_query(self):
+        self.setup_test_data()
+
+        with sync_playwright() as p:
+            self.open(reverse('bookmarks:archived') + '?q=foo', p)
+
+            self.locate_bulk_edit_toggle().click()
+            self.locate_bulk_edit_select_all().click()
+            self.locate_bulk_edit_select_across().click()
+
+            self.select_bulk_action('Delete')
+            self.locate_bulk_edit_bar().get_by_text('Execute').click()
+            self.locate_bulk_edit_bar().get_by_text('Confirm').click()
+
+        self.assertEqual(50, Bookmark.objects.filter(is_archived=False, title__startswith='Bookmark').count())
+        self.assertEqual(50, Bookmark.objects.filter(is_archived=True, title__startswith='Archived Bookmark').count())
+        self.assertEqual(50, Bookmark.objects.filter(is_archived=False, title__startswith='foo').count())
+        self.assertEqual(0, Bookmark.objects.filter(is_archived=True, title__startswith='foo').count())

--- a/bookmarks/e2e/e2e_test_bookmark_page_partial_updates.py
+++ b/bookmarks/e2e/e2e_test_bookmark_page_partial_updates.py
@@ -150,7 +150,8 @@ class BookmarkPagePartialUpdatesE2ETestCase(LinkdingE2ETestCase):
 
             self.locate_bulk_edit_toggle().click()
             self.locate_bookmark('Bookmark 2').locator('label[ld-bulk-edit-checkbox]').click()
-            self.locate_bulk_edit_bar().get_by_text('Archive').click()
+            self.select_bulk_action('Archive')
+            self.locate_bulk_edit_bar().get_by_text('Execute').click()
             self.locate_bulk_edit_bar().get_by_text('Confirm').click()
 
             self.assertVisibleBookmarks(['Bookmark 1', 'Bookmark 3'])
@@ -165,7 +166,8 @@ class BookmarkPagePartialUpdatesE2ETestCase(LinkdingE2ETestCase):
 
             self.locate_bulk_edit_toggle().click()
             self.locate_bookmark('Bookmark 2').locator('label[ld-bulk-edit-checkbox]').click()
-            self.locate_bulk_edit_bar().get_by_text('Delete').click()
+            self.select_bulk_action('Delete')
+            self.locate_bulk_edit_bar().get_by_text('Execute').click()
             self.locate_bulk_edit_bar().get_by_text('Confirm').click()
 
             self.assertVisibleBookmarks(['Bookmark 1', 'Bookmark 3'])
@@ -197,7 +199,7 @@ class BookmarkPagePartialUpdatesE2ETestCase(LinkdingE2ETestCase):
             self.assertVisibleTags(['Archived Tag 1', 'Archived Tag 3'])
             self.assertReloads(0)
 
-    def test_archived_bookmarks_partial_update_on_bulk_archive(self):
+    def test_archived_bookmarks_partial_update_on_bulk_unarchive(self):
         self.setup_fixture()
 
         with sync_playwright() as p:
@@ -205,7 +207,8 @@ class BookmarkPagePartialUpdatesE2ETestCase(LinkdingE2ETestCase):
 
             self.locate_bulk_edit_toggle().click()
             self.locate_bookmark('Archived Bookmark 2').locator('label[ld-bulk-edit-checkbox]').click()
-            self.locate_bulk_edit_bar().get_by_text('Archive').click()
+            self.select_bulk_action('Unarchive')
+            self.locate_bulk_edit_bar().get_by_text('Execute').click()
             self.locate_bulk_edit_bar().get_by_text('Confirm').click()
 
             self.assertVisibleBookmarks(['Archived Bookmark 1', 'Archived Bookmark 3'])
@@ -220,7 +223,8 @@ class BookmarkPagePartialUpdatesE2ETestCase(LinkdingE2ETestCase):
 
             self.locate_bulk_edit_toggle().click()
             self.locate_bookmark('Archived Bookmark 2').locator('label[ld-bulk-edit-checkbox]').click()
-            self.locate_bulk_edit_bar().get_by_text('Delete').click()
+            self.select_bulk_action('Delete')
+            self.locate_bulk_edit_bar().get_by_text('Execute').click()
             self.locate_bulk_edit_bar().get_by_text('Confirm').click()
 
             self.assertVisibleBookmarks(['Archived Bookmark 1', 'Archived Bookmark 3'])

--- a/bookmarks/e2e/helpers.py
+++ b/bookmarks/e2e/helpers.py
@@ -41,6 +41,12 @@ class LinkdingE2ETestCase(LiveServerTestCase, BookmarkFactoryMixin):
     def locate_bulk_edit_bar(self):
         return self.page.locator('.bulk-edit-bar')
 
+    def locate_bulk_edit_select_all(self):
+        return self.locate_bulk_edit_bar().locator('label[ld-bulk-edit-checkbox][all]')
+
+    def locate_bulk_edit_select_across(self):
+        return self.locate_bulk_edit_bar().locator('label.select-across')
+
     def locate_bulk_edit_toggle(self):
         return self.page.get_by_title('Bulk edit')
 

--- a/bookmarks/e2e/helpers.py
+++ b/bookmarks/e2e/helpers.py
@@ -43,3 +43,6 @@ class LinkdingE2ETestCase(LiveServerTestCase, BookmarkFactoryMixin):
 
     def locate_bulk_edit_toggle(self):
         return self.page.get_by_title('Bulk edit')
+
+    def select_bulk_action(self, value: str):
+        return self.locate_bulk_edit_bar().locator('select[name="bulk_action"]').select_option(value)

--- a/bookmarks/frontend/behaviors/bookmark-page.js
+++ b/bookmarks/frontend/behaviors/bookmark-page.js
@@ -36,8 +36,18 @@ class BookmarkPage {
       swap(this.bookmarkList, bookmarkListHtml);
       swap(this.tagCloud, tagCloudHtml);
 
+      // Dispatch list updated event
+      const listElement = this.bookmarkList.querySelector(
+        "ul[data-bookmarks-total]",
+      );
+      const bookmarksTotal =
+        (listElement && listElement.dataset.bookmarksTotal) || 0;
+
       this.bookmarkList.dispatchEvent(
-        new CustomEvent("bookmark-list-updated", { bubbles: true }),
+        new CustomEvent("bookmark-list-updated", {
+          bubbles: true,
+          detail: { bookmarksTotal },
+        }),
       );
     });
   }

--- a/bookmarks/frontend/behaviors/bulk-edit.js
+++ b/bookmarks/frontend/behaviors/bulk-edit.js
@@ -4,6 +4,8 @@ class BulkEdit {
   constructor(element) {
     this.element = element;
     this.active = false;
+    this.actionSelect = element.querySelector("select[name='bulk_action']");
+    this.bulkActions = element.querySelector(".bulk-edit-actions");
 
     element.addEventListener(
       "bulk-edit-toggle-active",
@@ -20,6 +22,11 @@ class BulkEdit {
     element.addEventListener(
       "bookmark-list-updated",
       this.onListUpdated.bind(this),
+    );
+
+    this.actionSelect.addEventListener(
+      "change",
+      this.onActionSelected.bind(this),
     );
   }
 
@@ -58,6 +65,16 @@ class BulkEdit {
     this.bookmarkCheckboxes.forEach((checkbox) => {
       checkbox.checked = checked;
     });
+  }
+
+  onActionSelected() {
+    const action = this.actionSelect.value;
+
+    if (action === "bulk_tag" || action === "bulk_untag") {
+      this.bulkActions.classList.add("bulk-tag-action");
+    } else {
+      this.bulkActions.classList.remove("bulk-tag-action");
+    }
   }
 
   onListUpdated() {

--- a/bookmarks/frontend/behaviors/bulk-edit.js
+++ b/bookmarks/frontend/behaviors/bulk-edit.js
@@ -6,6 +6,7 @@ class BulkEdit {
     this.active = false;
     this.actionSelect = element.querySelector("select[name='bulk_action']");
     this.bulkActions = element.querySelector(".bulk-edit-actions");
+    this.selectAcross = element.querySelector("label.select-across");
 
     element.addEventListener(
       "bulk-edit-toggle-active",
@@ -55,16 +56,19 @@ class BulkEdit {
   }
 
   onToggleBookmark() {
-    this.allCheckbox.checked = this.bookmarkCheckboxes.every((checkbox) => {
+    const allChecked = this.bookmarkCheckboxes.every((checkbox) => {
       return checkbox.checked;
     });
+    this.allCheckbox.checked = allChecked;
+    this.updateSelectAcross(allChecked);
   }
 
   onToggleAll() {
-    const checked = this.allCheckbox.checked;
+    const allChecked = this.allCheckbox.checked;
     this.bookmarkCheckboxes.forEach((checkbox) => {
-      checkbox.checked = checked;
+      checkbox.checked = allChecked;
     });
+    this.updateSelectAcross(allChecked);
   }
 
   onActionSelected() {
@@ -77,11 +81,31 @@ class BulkEdit {
     }
   }
 
-  onListUpdated() {
+  onListUpdated(event) {
+    // Reset checkbox states
+    this.reset();
+
+    // Update total number of bookmarks
+    const total = event.detail.bookmarksTotal;
+    const totalSpan = this.selectAcross.querySelector("span.total");
+    totalSpan.textContent = total;
+  }
+
+  updateSelectAcross(allChecked) {
+    if (allChecked) {
+      this.selectAcross.classList.remove("d-none");
+    } else {
+      this.selectAcross.classList.add("d-none");
+      this.selectAcross.querySelector("input").checked = false;
+    }
+  }
+
+  reset() {
     this.allCheckbox.checked = false;
     this.bookmarkCheckboxes.forEach((checkbox) => {
       checkbox.checked = false;
     });
+    this.updateSelectAcross(false);
   }
 }
 

--- a/bookmarks/frontend/behaviors/bulk-edit.js
+++ b/bookmarks/frontend/behaviors/bulk-edit.js
@@ -5,7 +5,7 @@ class BulkEdit {
     this.element = element;
     this.active = false;
     this.actionSelect = element.querySelector("select[name='bulk_action']");
-    this.bulkActions = element.querySelector(".bulk-edit-actions");
+    this.tagAutoComplete = element.querySelector(".tag-autocomplete");
     this.selectAcross = element.querySelector("label.select-across");
 
     element.addEventListener(
@@ -75,9 +75,9 @@ class BulkEdit {
     const action = this.actionSelect.value;
 
     if (action === "bulk_tag" || action === "bulk_untag") {
-      this.bulkActions.classList.add("bulk-tag-action");
+      this.tagAutoComplete.classList.remove("d-none");
     } else {
-      this.bulkActions.classList.remove("bulk-tag-action");
+      this.tagAutoComplete.classList.add("d-none");
     }
   }
 

--- a/bookmarks/frontend/behaviors/tag-autocomplete.js
+++ b/bookmarks/frontend/behaviors/tag-autocomplete.js
@@ -14,12 +14,13 @@ class TagAutocomplete {
         id: element.id,
         name: element.name,
         value: element.value,
+        placeholder: element.getAttribute("placeholder") || "",
         apiClient: apiClient,
         variant: element.getAttribute("variant"),
       },
     });
 
-    element.replaceWith(wrapper);
+    element.replaceWith(wrapper.firstElementChild);
   }
 }
 

--- a/bookmarks/frontend/components/TagAutocomplete.svelte
+++ b/bookmarks/frontend/components/TagAutocomplete.svelte
@@ -4,6 +4,7 @@
   export let id;
   export let name;
   export let value;
+  export let placeholder;
   export let apiClient;
   export let variant = 'default';
 
@@ -118,7 +119,7 @@
   <!-- autocomplete input container -->
   <div class="form-autocomplete-input form-input" class:is-focused={isFocus}>
     <!-- autocomplete real input box -->
-    <input id="{id}" name="{name}" value="{value ||''}" placeholder="&nbsp;"
+    <input id="{id}" name="{name}" value="{value ||''}" placeholder="{placeholder || ' '}"
            class="form-input" type="text" autocomplete="off" autocapitalize="off"
            on:input={handleInput} on:keydown={handleKeyDown}
            on:focus={handleFocus} on:blur={handleBlur}>
@@ -152,6 +153,7 @@
     .form-autocomplete.small .form-autocomplete-input {
         height: 1.4rem;
         min-height: 1.4rem;
+        padding: 0.05rem 0.3rem;
     }
 
     .form-autocomplete.small .form-autocomplete-input input {

--- a/bookmarks/services/bookmarks.py
+++ b/bookmarks/services/bookmarks.py
@@ -133,6 +133,20 @@ def mark_bookmarks_as_unread(bookmark_ids: [Union[int, str]], current_user: User
     bookmarks.update(unread=True, date_modified=timezone.now())
 
 
+def share_bookmarks(bookmark_ids: [Union[int, str]], current_user: User):
+    sanitized_bookmark_ids = _sanitize_id_list(bookmark_ids)
+    bookmarks = Bookmark.objects.filter(owner=current_user, id__in=sanitized_bookmark_ids)
+
+    bookmarks.update(shared=True, date_modified=timezone.now())
+
+
+def unshare_bookmarks(bookmark_ids: [Union[int, str]], current_user: User):
+    sanitized_bookmark_ids = _sanitize_id_list(bookmark_ids)
+    bookmarks = Bookmark.objects.filter(owner=current_user, id__in=sanitized_bookmark_ids)
+
+    bookmarks.update(shared=False, date_modified=timezone.now())
+
+
 def _merge_bookmark_data(from_bookmark: Bookmark, to_bookmark: Bookmark):
     to_bookmark.title = from_bookmark.title
     to_bookmark.description = from_bookmark.description

--- a/bookmarks/services/bookmarks.py
+++ b/bookmarks/services/bookmarks.py
@@ -119,6 +119,20 @@ def untag_bookmarks(bookmark_ids: [Union[int, str]], tag_string: str, current_us
     Bookmark.objects.bulk_update(bookmarks, ['date_modified'])
 
 
+def mark_bookmarks_as_read(bookmark_ids: [Union[int, str]], current_user: User):
+    sanitized_bookmark_ids = _sanitize_id_list(bookmark_ids)
+    bookmarks = Bookmark.objects.filter(owner=current_user, id__in=sanitized_bookmark_ids)
+
+    bookmarks.update(unread=False, date_modified=timezone.now())
+
+
+def mark_bookmarks_as_unread(bookmark_ids: [Union[int, str]], current_user: User):
+    sanitized_bookmark_ids = _sanitize_id_list(bookmark_ids)
+    bookmarks = Bookmark.objects.filter(owner=current_user, id__in=sanitized_bookmark_ids)
+
+    bookmarks.update(unread=True, date_modified=timezone.now())
+
+
 def _merge_bookmark_data(from_bookmark: Bookmark, to_bookmark: Bookmark):
     to_bookmark.title = from_bookmark.title
     to_bookmark.description = from_bookmark.description

--- a/bookmarks/styles/base.scss
+++ b/bookmarks/styles/base.scss
@@ -118,6 +118,10 @@ span.confirmation {
   margin-right: auto;
 }
 
+.ml-auto {
+  margin-left: auto;
+}
+
 .btn.btn-wide {
   padding-left: $unit-6;
   padding-right: $unit-6;

--- a/bookmarks/styles/bookmark-page.scss
+++ b/bookmarks/styles/bookmark-page.scss
@@ -292,10 +292,20 @@ $bulk-edit-transition-duration: 400ms;
       text-decoration: underline;
     }
 
-    > input, .form-autocomplete {
+    > input, .form-autocomplete, select {
       width: auto;
       max-width: 200px;
       -webkit-appearance: none;
+    }
+
+    input[name='bulk_tag_string'], .form-autocomplete {
+      display: none;
+    }
+
+    &.bulk-tag-action {
+      input[name='bulk_tag_string'], .form-autocomplete {
+        display: initial;
+      }
     }
   }
 }

--- a/bookmarks/styles/bookmark-page.scss
+++ b/bookmarks/styles/bookmark-page.scss
@@ -307,5 +307,10 @@ $bulk-edit-transition-duration: 400ms;
         display: initial;
       }
     }
+
+    .select-across {
+      margin: 0 0 0 auto;
+      font-size: $font-size-sm;
+    }
   }
 }

--- a/bookmarks/styles/bookmark-page.scss
+++ b/bookmarks/styles/bookmark-page.scss
@@ -294,18 +294,8 @@ $bulk-edit-transition-duration: 400ms;
 
     > input, .form-autocomplete, select {
       width: auto;
-      max-width: 200px;
+      max-width: 140px;
       -webkit-appearance: none;
-    }
-
-    input[name='bulk_tag_string'], .form-autocomplete {
-      display: none;
-    }
-
-    &.bulk-tag-action {
-      input[name='bulk_tag_string'], .form-autocomplete {
-        display: initial;
-      }
     }
 
     .select-across {

--- a/bookmarks/templates/bookmarks/archive.html
+++ b/bookmarks/templates/bookmarks/archive.html
@@ -20,7 +20,7 @@
         </div>
       </div>
 
-      <form class="bookmark-actions" action="{% url 'bookmarks:action' %}?return_url={{ bookmark_list.return_url }}"
+      <form class="bookmark-actions" action="{% url 'bookmarks:archived.action' %}?q={{ bookmark_list.filters.query }}&return_url={{ bookmark_list.return_url }}"
             method="post">
         {% csrf_token %}
         {% include 'bookmarks/bulk_edit/bar.html' with disable_actions='bulk_archive' %}

--- a/bookmarks/templates/bookmarks/archive.html
+++ b/bookmarks/templates/bookmarks/archive.html
@@ -23,7 +23,7 @@
       <form class="bookmark-actions" action="{% url 'bookmarks:action' %}?return_url={{ bookmark_list.return_url }}"
             method="post">
         {% csrf_token %}
-        {% include 'bookmarks/bulk_edit/bar.html' with mode='archive' %}
+        {% include 'bookmarks/bulk_edit/bar.html' with disable_actions='bulk_archive' %}
 
         <div class="bookmark-list-container">
           {% include 'bookmarks/bookmark_list.html' %}

--- a/bookmarks/templates/bookmarks/bookmark_list.html
+++ b/bookmarks/templates/bookmarks/bookmark_list.html
@@ -5,7 +5,8 @@
 {% if bookmark_list.is_empty %}
   {% include 'bookmarks/empty_bookmarks.html' %}
 {% else %}
-  <ul class="bookmark-list{% if bookmark_list.show_notes %} show-notes{% endif %}">
+  <ul class="bookmark-list{% if bookmark_list.show_notes %} show-notes{% endif %}"
+      data-bookmarks-total="{{ bookmark_list.bookmarks_total }}">
     {% for bookmark_item in bookmark_list.items %}
       <li ld-bookmark-item{% if bookmark_item.css_classes %} class="{{ bookmark_item.css_classes }}"{% endif %}>
         <label ld-bulk-edit-checkbox class="form-checkbox">

--- a/bookmarks/templates/bookmarks/bulk_edit/bar.html
+++ b/bookmarks/templates/bookmarks/bulk_edit/bar.html
@@ -3,7 +3,7 @@
   <div class="bulk-edit-bar">
     <div class="bulk-edit-actions bg-gray">
       <label ld-bulk-edit-checkbox all class="form-checkbox">
-        <input type="checkbox" style="display: none">
+        <input type="checkbox">
         <i class="form-icon"></i>
       </label>
       <select name="bulk_action" class="form-select select-sm">
@@ -24,6 +24,12 @@
       <input ld-tag-autocomplete variant="small"
              name="bulk_tag_string" class="form-input input-sm" placeholder="Tag names...">
       <button ld-confirm-button type="submit" name="bulk_execute" class="btn btn-link btn-sm">Execute</button>
+
+      <label class="form-checkbox select-across">
+        <input type="checkbox" name="bulk_select_across">
+        <i class="form-icon"></i>
+        All pages ({{ bookmark_list.bookmarks_total }} bookmarks)
+      </label>
     </div>
   </div>
 {% endhtmlmin %}

--- a/bookmarks/templates/bookmarks/bulk_edit/bar.html
+++ b/bookmarks/templates/bookmarks/bulk_edit/bar.html
@@ -23,8 +23,10 @@
           <option value="bulk_unshare">Unshare</option>
         {% endif %}
       </select>
-      <input ld-tag-autocomplete variant="small"
-             name="bulk_tag_string" class="form-input input-sm" placeholder="Tag names...">
+      <div class="tag-autocomplete d-none">
+        <input ld-tag-autocomplete variant="small"
+               name="bulk_tag_string" class="form-input input-sm" placeholder="Tag names...">
+      </div>
       <button ld-confirm-button type="submit" name="bulk_execute" class="btn btn-link btn-sm">Execute</button>
 
       <label class="form-checkbox select-across d-none">

--- a/bookmarks/templates/bookmarks/bulk_edit/bar.html
+++ b/bookmarks/templates/bookmarks/bulk_edit/bar.html
@@ -25,10 +25,10 @@
              name="bulk_tag_string" class="form-input input-sm" placeholder="Tag names...">
       <button ld-confirm-button type="submit" name="bulk_execute" class="btn btn-link btn-sm">Execute</button>
 
-      <label class="form-checkbox select-across">
+      <label class="form-checkbox select-across d-none">
         <input type="checkbox" name="bulk_select_across">
         <i class="form-icon"></i>
-        All pages ({{ bookmark_list.bookmarks_total }} bookmarks)
+        All pages (<span class="total">{{ bookmark_list.bookmarks_total }}</span> bookmarks)
       </label>
     </div>
   </div>

--- a/bookmarks/templates/bookmarks/bulk_edit/bar.html
+++ b/bookmarks/templates/bookmarks/bulk_edit/bar.html
@@ -18,8 +18,10 @@
         <option value="bulk_untag">Remove tags</option>
         <option value="bulk_read">Mark as read</option>
         <option value="bulk_unread">Mark as unread</option>
-        <option value="bulk_share">Share</option>
-        <option value="bulk_unshare">Unshare</option>
+        {% if request.user_profile.enable_sharing %}
+          <option value="bulk_share">Share</option>
+          <option value="bulk_unshare">Unshare</option>
+        {% endif %}
       </select>
       <input ld-tag-autocomplete variant="small"
              name="bulk_tag_string" class="form-input input-sm" placeholder="Tag names...">

--- a/bookmarks/templates/bookmarks/bulk_edit/bar.html
+++ b/bookmarks/templates/bookmarks/bulk_edit/bar.html
@@ -7,8 +7,12 @@
         <i class="form-icon"></i>
       </label>
       <select name="bulk_action" class="form-select select-sm">
-        <option value="bulk_archive">Archive</option>
-        <option value="bulk_unarchive">Unarchive</option>
+        {% if not 'bulk_archive' in disable_actions %}
+          <option value="bulk_archive">Archive</option>
+        {% endif %}
+        {% if not 'bulk_unarchive' in disable_actions %}
+          <option value="bulk_unarchive">Unarchive</option>
+        {% endif %}
         <option value="bulk_delete">Delete</option>
         <option value="bulk_tag">Add tags</option>
         <option value="bulk_untag">Remove tags</option>

--- a/bookmarks/templates/bookmarks/bulk_edit/bar.html
+++ b/bookmarks/templates/bookmarks/bulk_edit/bar.html
@@ -6,29 +6,20 @@
         <input type="checkbox" style="display: none">
         <i class="form-icon"></i>
       </label>
-      {% if mode == 'archive' %}
-        <button ld-confirm-button type="submit" name="bulk_unarchive" class="btn btn-link btn-sm"
-                title="Unarchive selected bookmarks">Unarchive
-        </button>
-      {% else %}
-        <button ld-confirm-button type="submit" name="bulk_archive" class="btn btn-link btn-sm"
-                title="Archive selected bookmarks">Archive
-        </button>
-      {% endif %}
-      <span class="text-sm text-gray-dark">•</span>
-      <button ld-confirm-button type="submit" name="bulk_delete" class="btn btn-link btn-sm"
-              title="Delete selected bookmarks">Delete
-      </button>
-      <span class="text-sm text-gray-dark">•</span>
-      <span class="text-sm text-gray-dark"><label for="bulk-edit-tags-input">Tags:</label></span>
+      <select name="bulk_action" class="form-select select-sm">
+        <option value="bulk_archive">Archive</option>
+        <option value="bulk_unarchive">Unarchive</option>
+        <option value="bulk_delete">Delete</option>
+        <option value="bulk_tag">Add tags</option>
+        <option value="bulk_untag">Remove tags</option>
+        <option value="bulk_read">Mark as read</option>
+        <option value="bulk_unread">Mark as unread</option>
+        <option value="bulk_share">Share</option>
+        <option value="bulk_unshare">Unshare</option>
+      </select>
       <input ld-tag-autocomplete variant="small"
-             name="bulk_tag_string" class="form-input input-sm" placeholder="&nbsp;">
-      <button type="submit" name="bulk_tag" class="btn btn-link btn-sm"
-              title="Add tags to selected bookmarks">Add
-      </button>
-      <button type="submit" name="bulk_untag" class="btn btn-link btn-sm"
-              title="Remove tags from selected bookmarks">Remove
-      </button>
+             name="bulk_tag_string" class="form-input input-sm" placeholder="Tag names...">
+      <button ld-confirm-button type="submit" name="bulk_execute" class="btn btn-link btn-sm">Execute</button>
     </div>
   </div>
 {% endhtmlmin %}

--- a/bookmarks/templates/bookmarks/index.html
+++ b/bookmarks/templates/bookmarks/index.html
@@ -20,8 +20,8 @@
         </div>
       </div>
 
-      <form class="bookmark-actions" action="{% url 'bookmarks:action' %}?return_url={{ bookmark_list.return_url }}"
-            method="post">
+      <form class="bookmark-actions" action="{% url 'bookmarks:index.action' %}?q={{ bookmark_list.filters.query }}&return_url={{ bookmark_list.return_url }}"
+            method="post" autocomplete="off">
         {% csrf_token %}
         {% include 'bookmarks/bulk_edit/bar.html' with disable_actions='bulk_unarchive' %}
 

--- a/bookmarks/templates/bookmarks/index.html
+++ b/bookmarks/templates/bookmarks/index.html
@@ -23,7 +23,7 @@
       <form class="bookmark-actions" action="{% url 'bookmarks:action' %}?return_url={{ bookmark_list.return_url }}"
             method="post">
         {% csrf_token %}
-        {% include 'bookmarks/bulk_edit/bar.html' with mode='default' %}
+        {% include 'bookmarks/bulk_edit/bar.html' with disable_actions='bulk_unarchive' %}
 
         <div class="bookmark-list-container">
           {% include 'bookmarks/bookmark_list.html' %}

--- a/bookmarks/templates/bookmarks/shared.html
+++ b/bookmarks/templates/bookmarks/shared.html
@@ -16,7 +16,7 @@
         {% bookmark_search bookmark_list.filters tag_cloud.tags mode='shared' %}
       </div>
 
-      <form class="bookmark-actions" action="{% url 'bookmarks:action' %}?return_url={{ bookmark_list.return_url }}"
+      <form class="bookmark-actions" action="{% url 'bookmarks:shared.action' %}?return_url={{ bookmark_list.return_url }}"
             method="post">
         {% csrf_token %}
 

--- a/bookmarks/tests/helpers.py
+++ b/bookmarks/tests/helpers.py
@@ -252,3 +252,8 @@ def disable_logging(f):
         return result
 
     return wrapper
+
+
+def collapse_whitespace(text: str):
+    text = text.replace('\n', '').replace('\r', '')
+    return ' '.join(text.split())

--- a/bookmarks/tests/helpers.py
+++ b/bookmarks/tests/helpers.py
@@ -100,11 +100,12 @@ class BookmarkFactoryMixin:
 
         for i in range(1, count + 1):
             title = f'{prefix} {i}{suffix}'
+            url = f'https://example.com/{prefix}/{i}'
             tags = []
             if with_tags:
                 tag_name = f'{tag_prefix} {i}{suffix}'
                 tags = [self.setup_tag(name=tag_name)]
-            self.setup_bookmark(title=title, is_archived=archived, shared=shared, tags=tags, user=user)
+            self.setup_bookmark(url=url, title=title, is_archived=archived, shared=shared, tags=tags, user=user)
 
     def get_numbered_bookmark(self, title: str):
         return Bookmark.objects.get(title=title)

--- a/bookmarks/tests/test_bookmark_action_view.py
+++ b/bookmarks/tests/test_bookmark_action_view.py
@@ -124,7 +124,8 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
         bookmark3 = self.setup_bookmark()
 
         self.client.post(reverse('bookmarks:action'), {
-            'bulk_archive': [''],
+            'bulk_action': ['bulk_archive'],
+            'bulk_execute': [''],
             'bookmark_id': [str(bookmark1.id), str(bookmark2.id), str(bookmark3.id)],
         })
 
@@ -139,7 +140,8 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
         bookmark3 = self.setup_bookmark(user=other_user)
 
         self.client.post(reverse('bookmarks:action'), {
-            'bulk_archive': [''],
+            'bulk_action': ['bulk_archive'],
+            'bulk_execute': [''],
             'bookmark_id': [str(bookmark1.id), str(bookmark2.id), str(bookmark3.id)],
         })
 
@@ -153,7 +155,8 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
         bookmark3 = self.setup_bookmark(is_archived=True)
 
         self.client.post(reverse('bookmarks:action'), {
-            'bulk_unarchive': [''],
+            'bulk_action': ['bulk_unarchive'],
+            'bulk_execute': [''],
             'bookmark_id': [str(bookmark1.id), str(bookmark2.id), str(bookmark3.id)],
         })
 
@@ -168,7 +171,8 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
         bookmark3 = self.setup_bookmark(is_archived=True, user=other_user)
 
         self.client.post(reverse('bookmarks:action'), {
-            'bulk_unarchive': [''],
+            'bulk_action': ['bulk_unarchive'],
+            'bulk_execute': [''],
             'bookmark_id': [str(bookmark1.id), str(bookmark2.id), str(bookmark3.id)],
         })
 
@@ -182,7 +186,8 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
         bookmark3 = self.setup_bookmark()
 
         self.client.post(reverse('bookmarks:action'), {
-            'bulk_delete': [''],
+            'bulk_action': ['bulk_delete'],
+            'bulk_execute': [''],
             'bookmark_id': [str(bookmark1.id), str(bookmark2.id), str(bookmark3.id)],
         })
 
@@ -197,7 +202,8 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
         bookmark3 = self.setup_bookmark(user=other_user)
 
         self.client.post(reverse('bookmarks:action'), {
-            'bulk_delete': [''],
+            'bulk_action': ['bulk_delete'],
+            'bulk_execute': [''],
             'bookmark_id': [str(bookmark1.id), str(bookmark2.id), str(bookmark3.id)],
         })
 
@@ -213,7 +219,8 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
         tag2 = self.setup_tag()
 
         self.client.post(reverse('bookmarks:action'), {
-            'bulk_tag': [''],
+            'bulk_action': ['bulk_tag'],
+            'bulk_execute': [''],
             'bulk_tag_string': [f'{tag1.name} {tag2.name}'],
             'bookmark_id': [str(bookmark1.id), str(bookmark2.id), str(bookmark3.id)],
         })
@@ -235,7 +242,8 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
         tag2 = self.setup_tag()
 
         self.client.post(reverse('bookmarks:action'), {
-            'bulk_tag': [''],
+            'bulk_action': ['bulk_tag'],
+            'bulk_execute': [''],
             'bulk_tag_string': [f'{tag1.name} {tag2.name}'],
             'bookmark_id': [str(bookmark1.id), str(bookmark2.id), str(bookmark3.id)],
         })
@@ -256,7 +264,8 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
         bookmark3 = self.setup_bookmark(tags=[tag1, tag2])
 
         self.client.post(reverse('bookmarks:action'), {
-            'bulk_untag': [''],
+            'bulk_action': ['bulk_untag'],
+            'bulk_execute': [''],
             'bulk_tag_string': [f'{tag1.name} {tag2.name}'],
             'bookmark_id': [str(bookmark1.id), str(bookmark2.id), str(bookmark3.id)],
         })
@@ -278,7 +287,8 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
         bookmark3 = self.setup_bookmark(tags=[tag1, tag2], user=other_user)
 
         self.client.post(reverse('bookmarks:action'), {
-            'bulk_untag': [''],
+            'bulk_action': ['bulk_untag'],
+            'bulk_execute': [''],
             'bulk_tag_string': [f'{tag1.name} {tag2.name}'],
             'bookmark_id': [str(bookmark1.id), str(bookmark2.id), str(bookmark3.id)],
         })
@@ -297,12 +307,14 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
         bookmark3 = self.setup_bookmark()
 
         response = self.client.post(reverse('bookmarks:action'), {
-            'bulk_archive': [''],
+            'bulk_action': ['bulk_archive'],
+            'bulk_execute': [''],
         })
         self.assertEqual(response.status_code, 302)
 
         response = self.client.post(reverse('bookmarks:action'), {
-            'bulk_archive': [''],
+            'bulk_action': ['bulk_archive'],
+            'bulk_execute': [''],
             'bookmark_id': [],
         })
         self.assertEqual(response.status_code, 302)
@@ -327,7 +339,8 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
 
         url = reverse('bookmarks:action') + '?return_url=' + reverse('bookmarks:settings.index')
         response = self.client.post(url, {
-            'bulk_archive': [''],
+            'bulk_action': ['bulk_archive'],
+            'bulk_execute': [''],
             'bookmark_id': [str(bookmark1.id), str(bookmark2.id), str(bookmark3.id)],
         })
 
@@ -341,7 +354,8 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
         def post_with(return_url, follow=None):
             url = reverse('bookmarks:action') + f'?return_url={return_url}'
             return self.client.post(url, {
-                'bulk_archive': [''],
+                'bulk_action': ['bulk_archive'],
+                'bulk_execute': [''],
                 'bookmark_id': [str(bookmark1.id), str(bookmark2.id), str(bookmark3.id)],
             }, follow=follow)
 

--- a/bookmarks/tests/test_bookmark_action_view.py
+++ b/bookmarks/tests/test_bookmark_action_view.py
@@ -22,7 +22,7 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
     def test_archive_should_archive_bookmark(self):
         bookmark = self.setup_bookmark()
 
-        self.client.post(reverse('bookmarks:action'), {
+        self.client.post(reverse('bookmarks:index.action'), {
             'archive': [bookmark.id],
         })
 
@@ -34,7 +34,7 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
         other_user = User.objects.create_user('otheruser', 'otheruser@example.com', 'password123')
         bookmark = self.setup_bookmark(user=other_user)
 
-        response = self.client.post(reverse('bookmarks:action'), {
+        response = self.client.post(reverse('bookmarks:index.action'), {
             'archive': [bookmark.id],
         })
 
@@ -46,7 +46,7 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
     def test_unarchive_should_unarchive_bookmark(self):
         bookmark = self.setup_bookmark(is_archived=True)
 
-        self.client.post(reverse('bookmarks:action'), {
+        self.client.post(reverse('bookmarks:index.action'), {
             'unarchive': [bookmark.id],
         })
         bookmark.refresh_from_db()
@@ -57,7 +57,7 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
         other_user = User.objects.create_user('otheruser', 'otheruser@example.com', 'password123')
         bookmark = self.setup_bookmark(is_archived=True, user=other_user)
 
-        response = self.client.post(reverse('bookmarks:action'), {
+        response = self.client.post(reverse('bookmarks:index.action'), {
             'unarchive': [bookmark.id],
         })
         bookmark.refresh_from_db()
@@ -68,7 +68,7 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
     def test_delete_should_delete_bookmark(self):
         bookmark = self.setup_bookmark()
 
-        self.client.post(reverse('bookmarks:action'), {
+        self.client.post(reverse('bookmarks:index.action'), {
             'remove': [bookmark.id],
         })
 
@@ -78,7 +78,7 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
         other_user = User.objects.create_user('otheruser', 'otheruser@example.com', 'password123')
         bookmark = self.setup_bookmark(user=other_user)
 
-        response = self.client.post(reverse('bookmarks:action'), {
+        response = self.client.post(reverse('bookmarks:index.action'), {
             'remove': [bookmark.id],
         })
         self.assertEqual(response.status_code, 404)
@@ -87,7 +87,7 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
     def test_mark_as_read(self):
         bookmark = self.setup_bookmark(unread=True)
 
-        self.client.post(reverse('bookmarks:action'), {
+        self.client.post(reverse('bookmarks:index.action'), {
             'mark_as_read': [bookmark.id],
         })
         bookmark.refresh_from_db()
@@ -97,7 +97,7 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
     def test_unshare_should_unshare_bookmark(self):
         bookmark = self.setup_bookmark(shared=True)
 
-        self.client.post(reverse('bookmarks:action'), {
+        self.client.post(reverse('bookmarks:index.action'), {
             'unshare': [bookmark.id],
         })
 
@@ -109,7 +109,7 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
         other_user = User.objects.create_user('otheruser', 'otheruser@example.com', 'password123')
         bookmark = self.setup_bookmark(user=other_user, shared=True)
 
-        response = self.client.post(reverse('bookmarks:action'), {
+        response = self.client.post(reverse('bookmarks:index.action'), {
             'unshare': [bookmark.id],
         })
 
@@ -123,7 +123,7 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
         bookmark2 = self.setup_bookmark()
         bookmark3 = self.setup_bookmark()
 
-        self.client.post(reverse('bookmarks:action'), {
+        self.client.post(reverse('bookmarks:index.action'), {
             'bulk_action': ['bulk_archive'],
             'bulk_execute': [''],
             'bookmark_id': [str(bookmark1.id), str(bookmark2.id), str(bookmark3.id)],
@@ -139,7 +139,7 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
         bookmark2 = self.setup_bookmark(user=other_user)
         bookmark3 = self.setup_bookmark(user=other_user)
 
-        self.client.post(reverse('bookmarks:action'), {
+        self.client.post(reverse('bookmarks:index.action'), {
             'bulk_action': ['bulk_archive'],
             'bulk_execute': [''],
             'bookmark_id': [str(bookmark1.id), str(bookmark2.id), str(bookmark3.id)],
@@ -154,7 +154,7 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
         bookmark2 = self.setup_bookmark(is_archived=True)
         bookmark3 = self.setup_bookmark(is_archived=True)
 
-        self.client.post(reverse('bookmarks:action'), {
+        self.client.post(reverse('bookmarks:archived.action'), {
             'bulk_action': ['bulk_unarchive'],
             'bulk_execute': [''],
             'bookmark_id': [str(bookmark1.id), str(bookmark2.id), str(bookmark3.id)],
@@ -170,7 +170,7 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
         bookmark2 = self.setup_bookmark(is_archived=True, user=other_user)
         bookmark3 = self.setup_bookmark(is_archived=True, user=other_user)
 
-        self.client.post(reverse('bookmarks:action'), {
+        self.client.post(reverse('bookmarks:archived.action'), {
             'bulk_action': ['bulk_unarchive'],
             'bulk_execute': [''],
             'bookmark_id': [str(bookmark1.id), str(bookmark2.id), str(bookmark3.id)],
@@ -185,7 +185,7 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
         bookmark2 = self.setup_bookmark()
         bookmark3 = self.setup_bookmark()
 
-        self.client.post(reverse('bookmarks:action'), {
+        self.client.post(reverse('bookmarks:index.action'), {
             'bulk_action': ['bulk_delete'],
             'bulk_execute': [''],
             'bookmark_id': [str(bookmark1.id), str(bookmark2.id), str(bookmark3.id)],
@@ -201,7 +201,7 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
         bookmark2 = self.setup_bookmark(user=other_user)
         bookmark3 = self.setup_bookmark(user=other_user)
 
-        self.client.post(reverse('bookmarks:action'), {
+        self.client.post(reverse('bookmarks:index.action'), {
             'bulk_action': ['bulk_delete'],
             'bulk_execute': [''],
             'bookmark_id': [str(bookmark1.id), str(bookmark2.id), str(bookmark3.id)],
@@ -218,7 +218,7 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
         tag1 = self.setup_tag()
         tag2 = self.setup_tag()
 
-        self.client.post(reverse('bookmarks:action'), {
+        self.client.post(reverse('bookmarks:index.action'), {
             'bulk_action': ['bulk_tag'],
             'bulk_execute': [''],
             'bulk_tag_string': [f'{tag1.name} {tag2.name}'],
@@ -241,7 +241,7 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
         tag1 = self.setup_tag()
         tag2 = self.setup_tag()
 
-        self.client.post(reverse('bookmarks:action'), {
+        self.client.post(reverse('bookmarks:index.action'), {
             'bulk_action': ['bulk_tag'],
             'bulk_execute': [''],
             'bulk_tag_string': [f'{tag1.name} {tag2.name}'],
@@ -263,7 +263,7 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
         bookmark2 = self.setup_bookmark(tags=[tag1, tag2])
         bookmark3 = self.setup_bookmark(tags=[tag1, tag2])
 
-        self.client.post(reverse('bookmarks:action'), {
+        self.client.post(reverse('bookmarks:index.action'), {
             'bulk_action': ['bulk_untag'],
             'bulk_execute': [''],
             'bulk_tag_string': [f'{tag1.name} {tag2.name}'],
@@ -286,7 +286,7 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
         bookmark2 = self.setup_bookmark(tags=[tag1, tag2], user=other_user)
         bookmark3 = self.setup_bookmark(tags=[tag1, tag2], user=other_user)
 
-        self.client.post(reverse('bookmarks:action'), {
+        self.client.post(reverse('bookmarks:index.action'), {
             'bulk_action': ['bulk_untag'],
             'bulk_execute': [''],
             'bulk_tag_string': [f'{tag1.name} {tag2.name}'],
@@ -306,7 +306,7 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
         bookmark2 = self.setup_bookmark(unread=True)
         bookmark3 = self.setup_bookmark(unread=True)
 
-        self.client.post(reverse('bookmarks:action'), {
+        self.client.post(reverse('bookmarks:index.action'), {
             'bulk_action': ['bulk_read'],
             'bulk_execute': [''],
             'bookmark_id': [str(bookmark1.id), str(bookmark2.id), str(bookmark3.id)],
@@ -322,7 +322,7 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
         bookmark2 = self.setup_bookmark(unread=True, user=other_user)
         bookmark3 = self.setup_bookmark(unread=True, user=other_user)
 
-        self.client.post(reverse('bookmarks:action'), {
+        self.client.post(reverse('bookmarks:index.action'), {
             'bulk_action': ['bulk_read'],
             'bulk_execute': [''],
             'bookmark_id': [str(bookmark1.id), str(bookmark2.id), str(bookmark3.id)],
@@ -337,7 +337,7 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
         bookmark2 = self.setup_bookmark(unread=False)
         bookmark3 = self.setup_bookmark(unread=False)
 
-        self.client.post(reverse('bookmarks:action'), {
+        self.client.post(reverse('bookmarks:index.action'), {
             'bulk_action': ['bulk_unread'],
             'bulk_execute': [''],
             'bookmark_id': [str(bookmark1.id), str(bookmark2.id), str(bookmark3.id)],
@@ -353,7 +353,7 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
         bookmark2 = self.setup_bookmark(unread=False, user=other_user)
         bookmark3 = self.setup_bookmark(unread=False, user=other_user)
 
-        self.client.post(reverse('bookmarks:action'), {
+        self.client.post(reverse('bookmarks:index.action'), {
             'bulk_action': ['bulk_unread'],
             'bulk_execute': [''],
             'bookmark_id': [str(bookmark1.id), str(bookmark2.id), str(bookmark3.id)],
@@ -368,7 +368,7 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
         bookmark2 = self.setup_bookmark(shared=False)
         bookmark3 = self.setup_bookmark(shared=False)
 
-        self.client.post(reverse('bookmarks:action'), {
+        self.client.post(reverse('bookmarks:index.action'), {
             'bulk_action': ['bulk_share'],
             'bulk_execute': [''],
             'bookmark_id': [str(bookmark1.id), str(bookmark2.id), str(bookmark3.id)],
@@ -384,7 +384,7 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
         bookmark2 = self.setup_bookmark(shared=False, user=other_user)
         bookmark3 = self.setup_bookmark(shared=False, user=other_user)
 
-        self.client.post(reverse('bookmarks:action'), {
+        self.client.post(reverse('bookmarks:index.action'), {
             'bulk_action': ['bulk_share'],
             'bulk_execute': [''],
             'bookmark_id': [str(bookmark1.id), str(bookmark2.id), str(bookmark3.id)],
@@ -399,7 +399,7 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
         bookmark2 = self.setup_bookmark(shared=True)
         bookmark3 = self.setup_bookmark(shared=True)
 
-        self.client.post(reverse('bookmarks:action'), {
+        self.client.post(reverse('bookmarks:index.action'), {
             'bulk_action': ['bulk_unshare'],
             'bulk_execute': [''],
             'bookmark_id': [str(bookmark1.id), str(bookmark2.id), str(bookmark3.id)],
@@ -415,7 +415,7 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
         bookmark2 = self.setup_bookmark(shared=True, user=other_user)
         bookmark3 = self.setup_bookmark(shared=True, user=other_user)
 
-        self.client.post(reverse('bookmarks:action'), {
+        self.client.post(reverse('bookmarks:index.action'), {
             'bulk_action': ['bulk_unshare'],
             'bulk_execute': [''],
             'bookmark_id': [str(bookmark1.id), str(bookmark2.id), str(bookmark3.id)],
@@ -425,18 +425,114 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
         self.assertTrue(Bookmark.objects.get(id=bookmark2.id).shared)
         self.assertTrue(Bookmark.objects.get(id=bookmark3.id).shared)
 
+    def test_bulk_select_across(self):
+        bookmark1 = self.setup_bookmark()
+        bookmark2 = self.setup_bookmark()
+        bookmark3 = self.setup_bookmark()
+
+        self.client.post(reverse('bookmarks:index.action'), {
+            'bulk_action': ['bulk_archive'],
+            'bulk_execute': [''],
+            'bulk_select_across': ['on'],
+        })
+
+        self.assertTrue(Bookmark.objects.get(id=bookmark1.id).is_archived)
+        self.assertTrue(Bookmark.objects.get(id=bookmark2.id).is_archived)
+        self.assertTrue(Bookmark.objects.get(id=bookmark3.id).is_archived)
+
+    def test_bulk_select_across_respects_query(self):
+        self.setup_numbered_bookmarks(3, prefix='foo')
+        self.setup_numbered_bookmarks(3, prefix='bar')
+
+        self.assertEqual(3, Bookmark.objects.filter(title__startswith='foo').count())
+
+        self.client.post(reverse('bookmarks:index.action') + '?q=foo', {
+            'bulk_action': ['bulk_delete'],
+            'bulk_execute': [''],
+            'bulk_select_across': ['on'],
+        })
+
+        self.assertEqual(0, Bookmark.objects.filter(title__startswith='foo').count())
+        self.assertEqual(3, Bookmark.objects.filter(title__startswith='bar').count())
+
+    def test_bulk_select_across_ignores_page(self):
+        self.setup_numbered_bookmarks(100)
+
+        self.client.post(reverse('bookmarks:index.action') + '?page=2', {
+            'bulk_action': ['bulk_delete'],
+            'bulk_execute': [''],
+            'bulk_select_across': ['on'],
+        })
+
+        self.assertEqual(0, Bookmark.objects.count())
+
+    def setup_bulk_edit_scope_test_data(self):
+        # create a number of bookmarks with different states / visibility
+        self.setup_numbered_bookmarks(3, with_tags=True)
+        self.setup_numbered_bookmarks(3, with_tags=True, archived=True)
+        self.setup_numbered_bookmarks(3,
+                                      shared=True,
+                                      prefix="Joe's Bookmark",
+                                      user=self.setup_user(enable_sharing=True))
+
+    def test_index_action_bulk_select_across_only_affects_active_bookmarks(self):
+        self.setup_bulk_edit_scope_test_data()
+
+        self.assertIsNotNone(Bookmark.objects.filter(title='Bookmark 1').first())
+        self.assertIsNotNone(Bookmark.objects.filter(title='Bookmark 2').first())
+        self.assertIsNotNone(Bookmark.objects.filter(title='Bookmark 3').first())
+
+        self.client.post(reverse('bookmarks:index.action'), {
+            'bulk_action': ['bulk_delete'],
+            'bulk_execute': [''],
+            'bulk_select_across': ['on'],
+        })
+
+        self.assertEqual(6, Bookmark.objects.count())
+        self.assertIsNone(Bookmark.objects.filter(title='Bookmark 1').first())
+        self.assertIsNone(Bookmark.objects.filter(title='Bookmark 2').first())
+        self.assertIsNone(Bookmark.objects.filter(title='Bookmark 3').first())
+
+    def test_archived_action_bulk_select_across_only_affects_archived_bookmarks(self):
+        self.setup_bulk_edit_scope_test_data()
+
+        self.assertIsNotNone(Bookmark.objects.filter(title='Archived Bookmark 1').first())
+        self.assertIsNotNone(Bookmark.objects.filter(title='Archived Bookmark 2').first())
+        self.assertIsNotNone(Bookmark.objects.filter(title='Archived Bookmark 3').first())
+
+        self.client.post(reverse('bookmarks:archived.action'), {
+            'bulk_action': ['bulk_delete'],
+            'bulk_execute': [''],
+            'bulk_select_across': ['on'],
+        })
+
+        self.assertEqual(6, Bookmark.objects.count())
+        self.assertIsNone(Bookmark.objects.filter(title='Archived Bookmark 1').first())
+        self.assertIsNone(Bookmark.objects.filter(title='Archived Bookmark 2').first())
+        self.assertIsNone(Bookmark.objects.filter(title='Archived Bookmark 3').first())
+
+    def test_shared_action_bulk_select_across_not_supported(self):
+        self.setup_bulk_edit_scope_test_data()
+
+        response = self.client.post(reverse('bookmarks:shared.action'), {
+            'bulk_action': ['bulk_delete'],
+            'bulk_execute': [''],
+            'bulk_select_across': ['on'],
+        })
+        self.assertEqual(response.status_code, 400)
+
     def test_handles_empty_bookmark_id(self):
         bookmark1 = self.setup_bookmark()
         bookmark2 = self.setup_bookmark()
         bookmark3 = self.setup_bookmark()
 
-        response = self.client.post(reverse('bookmarks:action'), {
+        response = self.client.post(reverse('bookmarks:index.action'), {
             'bulk_action': ['bulk_archive'],
             'bulk_execute': [''],
         })
         self.assertEqual(response.status_code, 302)
 
-        response = self.client.post(reverse('bookmarks:action'), {
+        response = self.client.post(reverse('bookmarks:index.action'), {
             'bulk_action': ['bulk_archive'],
             'bulk_execute': [''],
             'bookmark_id': [],
@@ -450,7 +546,7 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
         bookmark2 = self.setup_bookmark()
         bookmark3 = self.setup_bookmark()
 
-        self.client.post(reverse('bookmarks:action'), {
+        self.client.post(reverse('bookmarks:index.action'), {
             'bookmark_id': [str(bookmark1.id), str(bookmark2.id), str(bookmark3.id)],
         })
 
@@ -461,7 +557,7 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
         bookmark2 = self.setup_bookmark()
         bookmark3 = self.setup_bookmark()
 
-        url = reverse('bookmarks:action') + '?return_url=' + reverse('bookmarks:settings.index')
+        url = reverse('bookmarks:index.action') + '?return_url=' + reverse('bookmarks:settings.index')
         response = self.client.post(url, {
             'bulk_action': ['bulk_archive'],
             'bulk_execute': [''],
@@ -476,7 +572,7 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
         bookmark3 = self.setup_bookmark()
 
         def post_with(return_url, follow=None):
-            url = reverse('bookmarks:action') + f'?return_url={return_url}'
+            url = reverse('bookmarks:index.action') + f'?return_url={return_url}'
             return self.client.post(url, {
                 'bulk_action': ['bulk_archive'],
                 'bulk_execute': [''],

--- a/bookmarks/tests/test_bookmark_action_view.py
+++ b/bookmarks/tests/test_bookmark_action_view.py
@@ -332,6 +332,99 @@ class BookmarkActionViewTestCase(TestCase, BookmarkFactoryMixin):
         self.assertTrue(Bookmark.objects.get(id=bookmark2.id).unread)
         self.assertTrue(Bookmark.objects.get(id=bookmark3.id).unread)
 
+    def test_bulk_mark_as_unread(self):
+        bookmark1 = self.setup_bookmark(unread=False)
+        bookmark2 = self.setup_bookmark(unread=False)
+        bookmark3 = self.setup_bookmark(unread=False)
+
+        self.client.post(reverse('bookmarks:action'), {
+            'bulk_action': ['bulk_unread'],
+            'bulk_execute': [''],
+            'bookmark_id': [str(bookmark1.id), str(bookmark2.id), str(bookmark3.id)],
+        })
+
+        self.assertTrue(Bookmark.objects.get(id=bookmark1.id).unread)
+        self.assertTrue(Bookmark.objects.get(id=bookmark2.id).unread)
+        self.assertTrue(Bookmark.objects.get(id=bookmark3.id).unread)
+
+    def test_can_only_bulk_mark_as_unread_own_bookmarks(self):
+        other_user = User.objects.create_user('otheruser', 'otheruser@example.com', 'password123')
+        bookmark1 = self.setup_bookmark(unread=False, user=other_user)
+        bookmark2 = self.setup_bookmark(unread=False, user=other_user)
+        bookmark3 = self.setup_bookmark(unread=False, user=other_user)
+
+        self.client.post(reverse('bookmarks:action'), {
+            'bulk_action': ['bulk_unread'],
+            'bulk_execute': [''],
+            'bookmark_id': [str(bookmark1.id), str(bookmark2.id), str(bookmark3.id)],
+        })
+
+        self.assertFalse(Bookmark.objects.get(id=bookmark1.id).unread)
+        self.assertFalse(Bookmark.objects.get(id=bookmark2.id).unread)
+        self.assertFalse(Bookmark.objects.get(id=bookmark3.id).unread)
+
+    def test_bulk_share(self):
+        bookmark1 = self.setup_bookmark(shared=False)
+        bookmark2 = self.setup_bookmark(shared=False)
+        bookmark3 = self.setup_bookmark(shared=False)
+
+        self.client.post(reverse('bookmarks:action'), {
+            'bulk_action': ['bulk_share'],
+            'bulk_execute': [''],
+            'bookmark_id': [str(bookmark1.id), str(bookmark2.id), str(bookmark3.id)],
+        })
+
+        self.assertTrue(Bookmark.objects.get(id=bookmark1.id).shared)
+        self.assertTrue(Bookmark.objects.get(id=bookmark2.id).shared)
+        self.assertTrue(Bookmark.objects.get(id=bookmark3.id).shared)
+
+    def test_can_only_bulk_share_own_bookmarks(self):
+        other_user = User.objects.create_user('otheruser', 'otheruser@example.com', 'password123')
+        bookmark1 = self.setup_bookmark(shared=False, user=other_user)
+        bookmark2 = self.setup_bookmark(shared=False, user=other_user)
+        bookmark3 = self.setup_bookmark(shared=False, user=other_user)
+
+        self.client.post(reverse('bookmarks:action'), {
+            'bulk_action': ['bulk_share'],
+            'bulk_execute': [''],
+            'bookmark_id': [str(bookmark1.id), str(bookmark2.id), str(bookmark3.id)],
+        })
+
+        self.assertFalse(Bookmark.objects.get(id=bookmark1.id).shared)
+        self.assertFalse(Bookmark.objects.get(id=bookmark2.id).shared)
+        self.assertFalse(Bookmark.objects.get(id=bookmark3.id).shared)
+
+    def test_bulk_unshare(self):
+        bookmark1 = self.setup_bookmark(shared=True)
+        bookmark2 = self.setup_bookmark(shared=True)
+        bookmark3 = self.setup_bookmark(shared=True)
+
+        self.client.post(reverse('bookmarks:action'), {
+            'bulk_action': ['bulk_unshare'],
+            'bulk_execute': [''],
+            'bookmark_id': [str(bookmark1.id), str(bookmark2.id), str(bookmark3.id)],
+        })
+
+        self.assertFalse(Bookmark.objects.get(id=bookmark1.id).shared)
+        self.assertFalse(Bookmark.objects.get(id=bookmark2.id).shared)
+        self.assertFalse(Bookmark.objects.get(id=bookmark3.id).shared)
+
+    def test_can_only_bulk_unshare_own_bookmarks(self):
+        other_user = User.objects.create_user('otheruser', 'otheruser@example.com', 'password123')
+        bookmark1 = self.setup_bookmark(shared=True, user=other_user)
+        bookmark2 = self.setup_bookmark(shared=True, user=other_user)
+        bookmark3 = self.setup_bookmark(shared=True, user=other_user)
+
+        self.client.post(reverse('bookmarks:action'), {
+            'bulk_action': ['bulk_unshare'],
+            'bulk_execute': [''],
+            'bookmark_id': [str(bookmark1.id), str(bookmark2.id), str(bookmark3.id)],
+        })
+
+        self.assertTrue(Bookmark.objects.get(id=bookmark1.id).shared)
+        self.assertTrue(Bookmark.objects.get(id=bookmark2.id).shared)
+        self.assertTrue(Bookmark.objects.get(id=bookmark3.id).shared)
+
     def test_handles_empty_bookmark_id(self):
         bookmark1 = self.setup_bookmark()
         bookmark2 = self.setup_bookmark()

--- a/bookmarks/tests/test_bookmark_archived_view.py
+++ b/bookmarks/tests/test_bookmark_archived_view.py
@@ -218,3 +218,41 @@ class BookmarkArchivedViewTestCase(TestCase, BookmarkFactoryMixin, HtmlTestMixin
         response = self.client.get(reverse('bookmarks:archived'))
 
         self.assertVisibleBookmarks(response, visible_bookmarks, '_self')
+
+    def test_allowed_bulk_actions(self):
+        url = reverse('bookmarks:archived')
+        response = self.client.get(url)
+        html = response.content.decode()
+
+        self.assertInHTML(f'''
+          <select name="bulk_action" class="form-select select-sm">
+            <option value="bulk_unarchive">Unarchive</option>
+            <option value="bulk_delete">Delete</option>
+            <option value="bulk_tag">Add tags</option>
+            <option value="bulk_untag">Remove tags</option>
+            <option value="bulk_read">Mark as read</option>
+            <option value="bulk_unread">Mark as unread</option>
+          </select>
+        ''', html)
+
+    def test_allowed_bulk_actions_with_sharing_enabled(self):
+        user_profile = self.user.profile
+        user_profile.enable_sharing = True
+        user_profile.save()
+
+        url = reverse('bookmarks:archived')
+        response = self.client.get(url)
+        html = response.content.decode()
+
+        self.assertInHTML(f'''
+          <select name="bulk_action" class="form-select select-sm">
+            <option value="bulk_unarchive">Unarchive</option>
+            <option value="bulk_delete">Delete</option>
+            <option value="bulk_tag">Add tags</option>
+            <option value="bulk_untag">Remove tags</option>
+            <option value="bulk_read">Mark as read</option>
+            <option value="bulk_unread">Mark as unread</option>
+            <option value="bulk_share">Share</option>
+            <option value="bulk_unshare">Unshare</option>
+          </select>
+        ''', html)

--- a/bookmarks/tests/test_bookmark_archived_view.py
+++ b/bookmarks/tests/test_bookmark_archived_view.py
@@ -5,7 +5,7 @@ from django.test import TestCase
 from django.urls import reverse
 
 from bookmarks.models import Bookmark, Tag, UserProfile
-from bookmarks.tests.helpers import BookmarkFactoryMixin, HtmlTestMixin
+from bookmarks.tests.helpers import BookmarkFactoryMixin, HtmlTestMixin, collapse_whitespace
 
 
 class BookmarkArchivedViewTestCase(TestCase, BookmarkFactoryMixin, HtmlTestMixin):
@@ -68,8 +68,10 @@ class BookmarkArchivedViewTestCase(TestCase, BookmarkFactoryMixin, HtmlTestMixin
         ]
 
         response = self.client.get(reverse('bookmarks:archived'))
+        html = collapse_whitespace(response.content.decode())
 
-        self.assertContains(response, '<ul class="bookmark-list">')  # Should render list
+        # Should render list
+        self.assertIn('<ul class="bookmark-list" data-bookmarks-total="3">', html)
         self.assertVisibleBookmarks(response, visible_bookmarks)
         self.assertInvisibleBookmarks(response, invisible_bookmarks)
 
@@ -86,8 +88,10 @@ class BookmarkArchivedViewTestCase(TestCase, BookmarkFactoryMixin, HtmlTestMixin
         ]
 
         response = self.client.get(reverse('bookmarks:archived') + '?q=searchvalue')
+        html = collapse_whitespace(response.content.decode())
 
-        self.assertContains(response, '<ul class="bookmark-list">')  # Should render list
+        # Should render list
+        self.assertIn('<ul class="bookmark-list" data-bookmarks-total="3">', html)
         self.assertVisibleBookmarks(response, visible_bookmarks)
         self.assertInvisibleBookmarks(response, invisible_bookmarks)
 

--- a/bookmarks/tests/test_bookmark_index_view.py
+++ b/bookmarks/tests/test_bookmark_index_view.py
@@ -6,7 +6,7 @@ from django.test import TestCase
 from django.urls import reverse
 
 from bookmarks.models import Bookmark, Tag, UserProfile
-from bookmarks.tests.helpers import BookmarkFactoryMixin, HtmlTestMixin
+from bookmarks.tests.helpers import BookmarkFactoryMixin, HtmlTestMixin, collapse_whitespace
 
 
 class BookmarkIndexViewTestCase(TestCase, BookmarkFactoryMixin, HtmlTestMixin):
@@ -69,8 +69,10 @@ class BookmarkIndexViewTestCase(TestCase, BookmarkFactoryMixin, HtmlTestMixin):
         ]
 
         response = self.client.get(reverse('bookmarks:index'))
+        html = collapse_whitespace(response.content.decode())
 
-        self.assertContains(response, '<ul class="bookmark-list">')  # Should render list
+        # Should render list
+        self.assertIn('<ul class="bookmark-list" data-bookmarks-total="3">', html)
         self.assertVisibleBookmarks(response, visible_bookmarks)
         self.assertInvisibleBookmarks(response, invisible_bookmarks)
 
@@ -87,8 +89,10 @@ class BookmarkIndexViewTestCase(TestCase, BookmarkFactoryMixin, HtmlTestMixin):
         ]
 
         response = self.client.get(reverse('bookmarks:index') + '?q=searchvalue')
+        html = collapse_whitespace(response.content.decode())
 
-        self.assertContains(response, '<ul class="bookmark-list">')  # Should render list
+        # Should render list
+        self.assertIn('<ul class="bookmark-list" data-bookmarks-total="3">', html)
         self.assertVisibleBookmarks(response, visible_bookmarks)
         self.assertInvisibleBookmarks(response, invisible_bookmarks)
 

--- a/bookmarks/tests/test_bookmark_index_view.py
+++ b/bookmarks/tests/test_bookmark_index_view.py
@@ -244,3 +244,41 @@ class BookmarkIndexViewTestCase(TestCase, BookmarkFactoryMixin, HtmlTestMixin):
         self.assertInHTML(f'''
             <a href="{edit_url}?return_url={return_url}">Edit</a>        
         ''', html)
+
+    def test_allowed_bulk_actions(self):
+        url = reverse('bookmarks:index')
+        response = self.client.get(url)
+        html = response.content.decode()
+
+        self.assertInHTML(f'''
+          <select name="bulk_action" class="form-select select-sm">
+            <option value="bulk_archive">Archive</option>
+            <option value="bulk_delete">Delete</option>
+            <option value="bulk_tag">Add tags</option>
+            <option value="bulk_untag">Remove tags</option>
+            <option value="bulk_read">Mark as read</option>
+            <option value="bulk_unread">Mark as unread</option>
+          </select>
+        ''', html)
+
+    def test_allowed_bulk_actions_with_sharing_enabled(self):
+        user_profile = self.user.profile
+        user_profile.enable_sharing = True
+        user_profile.save()
+
+        url = reverse('bookmarks:index')
+        response = self.client.get(url)
+        html = response.content.decode()
+
+        self.assertInHTML(f'''
+          <select name="bulk_action" class="form-select select-sm">
+            <option value="bulk_archive">Archive</option>
+            <option value="bulk_delete">Delete</option>
+            <option value="bulk_tag">Add tags</option>
+            <option value="bulk_untag">Remove tags</option>
+            <option value="bulk_read">Mark as read</option>
+            <option value="bulk_unread">Mark as unread</option>
+            <option value="bulk_share">Share</option>
+            <option value="bulk_unshare">Unshare</option>
+          </select>
+        ''', html)

--- a/bookmarks/tests/test_bookmark_shared_view.py
+++ b/bookmarks/tests/test_bookmark_shared_view.py
@@ -5,7 +5,7 @@ from django.test import TestCase
 from django.urls import reverse
 
 from bookmarks.models import Bookmark, Tag, UserProfile
-from bookmarks.tests.helpers import BookmarkFactoryMixin
+from bookmarks.tests.helpers import BookmarkFactoryMixin, collapse_whitespace
 
 
 class BookmarkSharedViewTestCase(TestCase, BookmarkFactoryMixin):
@@ -84,8 +84,10 @@ class BookmarkSharedViewTestCase(TestCase, BookmarkFactoryMixin):
         ]
 
         response = self.client.get(reverse('bookmarks:shared'))
+        html = collapse_whitespace(response.content.decode())
 
-        self.assertContains(response, '<ul class="bookmark-list">')  # Should render list
+        # Should render list
+        self.assertIn('<ul class="bookmark-list" data-bookmarks-total="3">', html)
         self.assertVisibleBookmarks(response, visible_bookmarks)
         self.assertInvisibleBookmarks(response, invisible_bookmarks)
 
@@ -124,8 +126,10 @@ class BookmarkSharedViewTestCase(TestCase, BookmarkFactoryMixin):
         ]
 
         response = self.client.get(reverse('bookmarks:shared') + '?q=searchvalue')
+        html = collapse_whitespace(response.content.decode())
 
-        self.assertContains(response, '<ul class="bookmark-list">')  # Should render list
+        # Should render list
+        self.assertIn('<ul class="bookmark-list" data-bookmarks-total="3">', html)
         self.assertVisibleBookmarks(response, visible_bookmarks)
         self.assertInvisibleBookmarks(response, invisible_bookmarks)
 
@@ -145,8 +149,10 @@ class BookmarkSharedViewTestCase(TestCase, BookmarkFactoryMixin):
         ]
 
         response = self.client.get(reverse('bookmarks:shared'))
+        html = collapse_whitespace(response.content.decode())
 
-        self.assertContains(response, '<ul class="bookmark-list">')  # Should render list
+        # Should render list
+        self.assertIn('<ul class="bookmark-list" data-bookmarks-total="3">', html)
         self.assertVisibleBookmarks(response, visible_bookmarks)
         self.assertInvisibleBookmarks(response, invisible_bookmarks)
 

--- a/bookmarks/tests/test_bookmarks_list_template.py
+++ b/bookmarks/tests/test_bookmarks_list_template.py
@@ -10,7 +10,7 @@ from django.utils import timezone, formats
 
 from bookmarks.middlewares import UserProfileMiddleware
 from bookmarks.models import Bookmark, UserProfile, User
-from bookmarks.tests.helpers import BookmarkFactoryMixin
+from bookmarks.tests.helpers import BookmarkFactoryMixin, collapse_whitespace
 from bookmarks.views.partials import contexts
 
 
@@ -454,9 +454,9 @@ class BookmarkListTemplateTest(TestCase, BookmarkFactoryMixin):
 
     def test_notes_are_hidden_initially_by_default(self):
         self.setup_bookmark(notes='Test note')
-        html = self.render_template()
+        html = collapse_whitespace(self.render_template())
 
-        self.assertIn('<ul class="bookmark-list">', html)
+        self.assertIn('<ul class="bookmark-list" data-bookmarks-total="1">', html)
 
     def test_notes_are_hidden_initially_with_permanent_notes_disabled(self):
         profile = self.get_or_create_test_user().profile
@@ -464,9 +464,9 @@ class BookmarkListTemplateTest(TestCase, BookmarkFactoryMixin):
         profile.save()
 
         self.setup_bookmark(notes='Test note')
-        html = self.render_template()
+        html = collapse_whitespace(self.render_template())
 
-        self.assertIn('<ul class="bookmark-list">', html)
+        self.assertIn('<ul class="bookmark-list" data-bookmarks-total="1">', html)
 
     def test_notes_are_visible_initially_with_permanent_notes_enabled(self):
         profile = self.get_or_create_test_user().profile
@@ -474,9 +474,9 @@ class BookmarkListTemplateTest(TestCase, BookmarkFactoryMixin):
         profile.save()
 
         self.setup_bookmark(notes='Test note')
-        html = self.render_template()
+        html = collapse_whitespace(self.render_template())
 
-        self.assertIn('<ul class="bookmark-list show-notes">', html)
+        self.assertIn('<ul class="bookmark-list show-notes" data-bookmarks-total="1">', html)
 
     def test_toggle_notes_is_visible_by_default(self):
         self.setup_bookmark(notes='Test note')

--- a/bookmarks/urls.py
+++ b/bookmarks/urls.py
@@ -13,12 +13,14 @@ urlpatterns = [
     re_path(r'^$', RedirectView.as_view(pattern_name='bookmarks:index', permanent=False)),
     # Bookmarks
     path('bookmarks', views.bookmarks.index, name='index'),
+    path('bookmarks/action', views.bookmarks.index_action, name='index.action'),
     path('bookmarks/archived', views.bookmarks.archived, name='archived'),
+    path('bookmarks/archived/action', views.bookmarks.archived_action, name='archived.action'),
     path('bookmarks/shared', views.bookmarks.shared, name='shared'),
+    path('bookmarks/shared/action', views.bookmarks.shared_action, name='shared.action'),
     path('bookmarks/new', views.bookmarks.new, name='new'),
     path('bookmarks/close', views.bookmarks.close, name='close'),
     path('bookmarks/<int:bookmark_id>/edit', views.bookmarks.edit, name='edit'),
-    path('bookmarks/action', views.bookmarks.action, name='action'),
     # Partials
     path('bookmarks/partials/bookmark-list/active', partials.active_bookmark_list,
          name='partials.bookmark_list.active'),

--- a/bookmarks/views/bookmarks.py
+++ b/bookmarks/views/bookmarks.py
@@ -6,7 +6,8 @@ from django.urls import reverse
 from bookmarks import queries
 from bookmarks.models import Bookmark, BookmarkForm, BookmarkFilters, build_tag_string
 from bookmarks.services.bookmarks import create_bookmark, update_bookmark, archive_bookmark, archive_bookmarks, \
-    unarchive_bookmark, unarchive_bookmarks, delete_bookmarks, tag_bookmarks, untag_bookmarks
+    unarchive_bookmark, unarchive_bookmarks, delete_bookmarks, tag_bookmarks, untag_bookmarks, mark_bookmarks_as_read, \
+    mark_bookmarks_as_unread
 from bookmarks.utils import get_safe_return_url
 from bookmarks.views.partials import contexts
 
@@ -199,6 +200,12 @@ def action(request):
             bookmark_ids = request.POST.getlist('bookmark_id')
             tag_string = convert_tag_string(request.POST['bulk_tag_string'])
             untag_bookmarks(bookmark_ids, tag_string, request.user)
+        if 'bulk_read' == bulk_action:
+            bookmark_ids = request.POST.getlist('bookmark_id')
+            mark_bookmarks_as_read(bookmark_ids, request.user)
+        if 'bulk_unread' == bulk_action:
+            bookmark_ids = request.POST.getlist('bookmark_id')
+            mark_bookmarks_as_unread(bookmark_ids, request.user)
 
     return_url = get_safe_return_url(request.GET.get('return_url'), reverse('bookmarks:index'))
     return HttpResponseRedirect(return_url)

--- a/bookmarks/views/bookmarks.py
+++ b/bookmarks/views/bookmarks.py
@@ -7,7 +7,7 @@ from bookmarks import queries
 from bookmarks.models import Bookmark, BookmarkForm, BookmarkFilters, build_tag_string
 from bookmarks.services.bookmarks import create_bookmark, update_bookmark, archive_bookmark, archive_bookmarks, \
     unarchive_bookmark, unarchive_bookmarks, delete_bookmarks, tag_bookmarks, untag_bookmarks, mark_bookmarks_as_read, \
-    mark_bookmarks_as_unread
+    mark_bookmarks_as_unread, share_bookmarks, unshare_bookmarks
 from bookmarks.utils import get_safe_return_url
 from bookmarks.views.partials import contexts
 
@@ -206,6 +206,12 @@ def action(request):
         if 'bulk_unread' == bulk_action:
             bookmark_ids = request.POST.getlist('bookmark_id')
             mark_bookmarks_as_unread(bookmark_ids, request.user)
+        if 'bulk_share' == bulk_action:
+            bookmark_ids = request.POST.getlist('bookmark_id')
+            share_bookmarks(bookmark_ids, request.user)
+        if 'bulk_unshare' == bulk_action:
+            bookmark_ids = request.POST.getlist('bookmark_id')
+            unshare_bookmarks(bookmark_ids, request.user)
 
     return_url = get_safe_return_url(request.GET.get('return_url'), reverse('bookmarks:index'))
     return HttpResponseRedirect(return_url)

--- a/bookmarks/views/bookmarks.py
+++ b/bookmarks/views/bookmarks.py
@@ -167,7 +167,7 @@ def mark_as_read(request, bookmark_id: int):
 
 @login_required
 def action(request):
-    # Determine action
+    # Single bookmark actions
     if 'archive' in request.POST:
         archive(request, request.POST['archive'])
     if 'unarchive' in request.POST:
@@ -178,23 +178,27 @@ def action(request):
         mark_as_read(request, request.POST['mark_as_read'])
     if 'unshare' in request.POST:
         unshare(request, request.POST['unshare'])
-    if 'bulk_archive' in request.POST:
-        bookmark_ids = request.POST.getlist('bookmark_id')
-        archive_bookmarks(bookmark_ids, request.user)
-    if 'bulk_unarchive' in request.POST:
-        bookmark_ids = request.POST.getlist('bookmark_id')
-        unarchive_bookmarks(bookmark_ids, request.user)
-    if 'bulk_delete' in request.POST:
-        bookmark_ids = request.POST.getlist('bookmark_id')
-        delete_bookmarks(bookmark_ids, request.user)
-    if 'bulk_tag' in request.POST:
-        bookmark_ids = request.POST.getlist('bookmark_id')
-        tag_string = convert_tag_string(request.POST['bulk_tag_string'])
-        tag_bookmarks(bookmark_ids, tag_string, request.user)
-    if 'bulk_untag' in request.POST:
-        bookmark_ids = request.POST.getlist('bookmark_id')
-        tag_string = convert_tag_string(request.POST['bulk_tag_string'])
-        untag_bookmarks(bookmark_ids, tag_string, request.user)
+
+    # Bulk actions
+    if 'bulk_execute' in request.POST:
+        bulk_action = request.POST['bulk_action']
+        if 'bulk_archive' == bulk_action:
+            bookmark_ids = request.POST.getlist('bookmark_id')
+            archive_bookmarks(bookmark_ids, request.user)
+        if 'bulk_unarchive' == bulk_action:
+            bookmark_ids = request.POST.getlist('bookmark_id')
+            unarchive_bookmarks(bookmark_ids, request.user)
+        if 'bulk_delete' == bulk_action:
+            bookmark_ids = request.POST.getlist('bookmark_id')
+            delete_bookmarks(bookmark_ids, request.user)
+        if 'bulk_tag' == bulk_action:
+            bookmark_ids = request.POST.getlist('bookmark_id')
+            tag_string = convert_tag_string(request.POST['bulk_tag_string'])
+            tag_bookmarks(bookmark_ids, tag_string, request.user)
+        if 'bulk_untag' == bulk_action:
+            bookmark_ids = request.POST.getlist('bookmark_id')
+            tag_string = convert_tag_string(request.POST['bulk_tag_string'])
+            untag_bookmarks(bookmark_ids, tag_string, request.user)
 
     return_url = get_safe_return_url(request.GET.get('return_url'), reverse('bookmarks:index'))
     return HttpResponseRedirect(return_url)

--- a/bookmarks/views/partials/contexts.py
+++ b/bookmarks/views/partials/contexts.py
@@ -70,6 +70,7 @@ class BookmarkListContext:
 
         self.is_empty = paginator.count == 0
         self.bookmarks_page = bookmarks_page
+        self.bookmarks_total = paginator.count
         self.return_url = self.generate_return_url(page_number)
         self.link_target = user_profile.bookmark_link_target
         self.date_display = user_profile.bookmark_date_display


### PR DESCRIPTION
Adds the following bulk edit actions:
- Mark as read
- Mark as unread
- Share
- Unshare

Also adds a toggle that allows bulk editing bookmarks across all pages matching the current query.

Closes https://github.com/sissbruecker/linkding/issues/308
Closes https://github.com/sissbruecker/linkding/issues/208
Closes https://github.com/sissbruecker/linkding/issues/397