### PR TITLE
Update supervisord.conf

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -5,7 +5,7 @@ loglevel=info
 [program:jobs]
 user=www-data
 command=sh background-tasks-wrapper.sh
-stdout_logfile=background_tasks.log
+stdout_logfile=data/background_tasks.log
 stdout_logfile_maxbytes=10MB
 stdout_logfile_backups=5
 redirect_stderr=true


### PR DESCRIPTION
Move background_tasks.log to data/ directory, so that it can easily be read via the docker-shared volume.

I do not know if this makes sense to you. For me this helped in getting to see, that the background task from my import kept running. Feel free to decline this PR if not needed.