### PR TITLE
Fix memory leak with SQLite

### DIFF
--- a/siteroot/settings/base.py
+++ b/siteroot/settings/base.py
@@ -225,6 +225,11 @@ else:
         'ENGINE': 'django.db.backends.sqlite3',
         'NAME': os.path.join(BASE_DIR, 'data', 'db.sqlite3'),
         'OPTIONS': LD_DB_OPTIONS,
+        # Creating a connection loads the ICU extension into the SQLite
+        # connection, and also loads an ICU collation. The latter causes a
+        # memory leak, so try to counter that by making connections indefinitely
+        # persistent.
+        'CONN_MAX_AGE': None
     }
 
 DATABASES = {


### PR DESCRIPTION
#520 introduced a memory leak which is caused by loading an ICU collation into new database connections. Whatever memory is reserved by that is not released when closing the connection, and as each request creates a new connection, memory usage just keeps increasing. As the collation loading is external code I don't see how I could fix that. I also don't want to rollback the fix from #520 as the new sort by title feature relies on that as well. As a workaround, this makes SQLite database connections persistent, so that they are only created once and then reused indefinitely. Hoping that this doesn't cause any other issues.