### PR TITLE
Fix RSS feed not handling None values 

### DIFF
--- a/bookmarks/feeds.py
+++ b/bookmarks/feeds.py
@@ -16,6 +16,8 @@ class FeedContext:
 
 
 def sanitize(text: str):
+    if not text:
+        return ''
     # remove control characters
     valid_chars = ['\n', '\r', '\t']
     return ''.join(ch for ch in text if ch in valid_chars or unicodedata.category(ch)[0] != 'C')

--- a/bookmarks/tests/test_feeds.py
+++ b/bookmarks/tests/test_feeds.py
@@ -7,6 +7,8 @@ from django.urls import reverse
 
 from bookmarks.tests.helpers import BookmarkFactoryMixin
 from bookmarks.models import FeedToken, User
+from bookmarks.feeds import sanitize
+
 
 
 def rfc2822_date(date):
@@ -111,6 +113,9 @@ class FeedsTestCase(TestCase, BookmarkFactoryMixin):
         self.assertContains(response, '<item>', count=1)
         self.assertContains(response, f'<title>test\n\r\ttitle</title>', count=1)
         self.assertContains(response, f'<description>test\n\r\tdescription</description>', count=1)
+
+    def test_sanitize_with_none_text(self):
+        self.assertEqual('', sanitize(None))
 
     def test_unread_returns_404_for_unknown_feed_token(self):
         response = self.client.get(reverse('bookmarks:feeds.unread', args=['foo']))


### PR DESCRIPTION
Previously, the 'sanitize' function would throw an error when 'text' was None. This commit fixes the issue by adding a check to handle the case where 'text' is None, returning an empty string instead.

Closes #568