### PR TITLE
Add backup CLI command

### DIFF
--- a/bookmarks/management/commands/backup.py
+++ b/bookmarks/management/commands/backup.py
@@ -1,0 +1,26 @@
+import sqlite3
+import os
+
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = "Creates a backup of the linkding database"
+
+    def add_arguments(self, parser):
+        parser.add_argument('destination', type=str, help='Backup file destination')
+
+    def handle(self, *args, **options):
+        destination = options['destination']
+
+        def progress(status, remaining, total):
+            self.stdout.write(f'Copied {total-remaining} of {total} pages...')
+
+        source_db = sqlite3.connect(os.path.join('data', 'db.sqlite3'))
+        backup_db = sqlite3.connect(destination)
+        with backup_db:
+            source_db.backup(backup_db, pages=50, progress=progress)
+        backup_db.close()
+        source_db.close()
+
+        self.stdout.write(self.style.SUCCESS(f'Backup created at {destination}'))

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -2,7 +2,7 @@
 
 Linkding stores all data in the application's data folder.
 The full path to that folder in the Docker container is `/etc/linkding/data`.
-As described in the installation docs, you should mount the `/etc/linkding/data` folder to a folder on your host system, from which you then can execute the backup.
+As described in the installation docs, you should mount the `/etc/linkding/data` folder to a folder on your host system.
 
 The data folder contains the following contents:
 - `db.sqlite3` - the SQLite database
@@ -17,21 +17,26 @@ This section describes several methods on how to back up the contents of the SQL
 > [!WARNING]
 > While the SQLite database is just a single file, it is not recommended to just copy that file.
 > This method is not transaction safe and may result in a [corrupted database](https://www.sqlite.org/howtocorrupt.html).
-> Use one of the official SQLite backup methods described below.
+> Use one of the backup methods described below.
 
-### Using the SQLite backup function
+### Using the backup command
 
-Requires [SQLite](https://www.sqlite.org/index.html) to be installed on your host system.
+linkding includes a CLI command for creating a backup copy of the database.
 
-With this method you create a new SQLite database, which is a copy of your linkding database.
-This method uses the backup command in the [Command Line Shell For SQLite](https://sqlite.org/cli.html).
-To create a backup, execute the following command in the data folder:
+To create a backup, execute the following command:
 ```shell
-sqlite3 db.sqlite3 ".backup 'backup.sqlite3'"
+docker exec -it linkding python manage.py backup backup.sqlite3
 ```
-This creates a `backup.sqlite3` file which you can copy to your backup location.
+This creates a `backup.sqlite3` file in the Docker container.
 
-To restore the backup, just copy the backup file as `db.sqlite3` to the data folder of your new installation before starting the Docker container.
+To copy the backup file to your host system, execute the following command:
+```shell
+docker cp linkding:/etc/linkding/backup.sqlite3 backup.sqlite3
+```
+This copies the backup file from the Docker container to the current folder on your host system.
+Now you can move that file to your backup location.
+
+To restore the backup, just copy the backup file to the data folder of your new installation and rename it to `db.sqlite3`. Then start the Docker container.
 
 ### Using the SQLite dump function
 


### PR DESCRIPTION
Adds a CLI command that allows to create a backup copy of the SQLite database within the Docker container. The file can then be moved to the host system using `docker cp`.

Closes https://github.com/sissbruecker/linkding/issues/454