### PR TITLE
Increase tag limit in tag autocomplete

### DIFF
--- a/bookmarks/frontend/components/TagAutocomplete.svelte
+++ b/bookmarks/frontend/components/TagAutocomplete.svelte
@@ -22,7 +22,7 @@
   async function init() {
     // For now we cache all tags on load as the template did before
     try {
-      tags = await apiClient.getTags({limit: 1000, offset: 0});
+      tags = await apiClient.getTags({limit: 5000, offset: 0});
       tags.sort((left, right) => left.name.toLowerCase().localeCompare(right.name.toLowerCase()))
     } catch (e) {
       console.warn('TagAutocomplete: Error loading tag list');


### PR DESCRIPTION
Increased tag limit to 5000. It looks like that the tag limit of 1000 is reached by some users.

Fixes #580 