### PR TITLE
Bump playwright dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,13 +17,13 @@ django-sass-processor==1.2.1
 django-widget-tweaks==1.4.12
 django4-background-tasks==1.2.7
 djangorestframework==3.13.1
-greenlet==2.0.1
+greenlet==3.0.1
 idna==3.3
 libsass==0.21.0
 Markdown==3.4.3
-playwright==1.29.1
+playwright==1.40.0
 psycopg2-binary==2.9.5
-pyee==9.0.4
+pyee==11.0.1
 python-dateutil==2.8.2
 pytz==2022.2.1
 rcssmin==1.1.0


### PR DESCRIPTION
I'm using an M1 mac, and without these changes I was unable to install the requirements.txt on my local machine. 