### PR TITLE
Add title to link so you can see the entire title when hover

### DIFF
--- a/bookmarks/frontend/behaviors/bookmark-page.js
+++ b/bookmarks/frontend/behaviors/bookmark-page.js
@@ -73,3 +73,24 @@ class BookmarkItem {
 }
 
 registerBehavior("ld-bookmark-item", BookmarkItem);
+
+
+class LinkItem {
+  constructor(element) {
+    this.element = element
+    element.addEventListener("mouseover", this.onHover.bind(this))
+  }
+
+  getRect(element) {
+      return element.getBoundingClientRect();
+  }
+
+  onHover(event) {
+    let parent = this.element.parentElement
+    if (this.getRect(this.element).right > this.getRect(parent).right) {
+      parent.classList.add("shouldHover")
+    }
+  }
+}
+
+registerBehavior("ld-link-item", LinkItem)

--- a/bookmarks/frontend/behaviors/bookmark-page.js
+++ b/bookmarks/frontend/behaviors/bookmark-page.js
@@ -59,9 +59,17 @@ class BookmarkItem {
   constructor(element) {
     this.element = element;
 
+    // Toggle notes
     const notesToggle = element.querySelector(".toggle-notes");
     if (notesToggle) {
       notesToggle.addEventListener("click", this.onToggleNotes.bind(this));
+    }
+
+    // Add tooltip to title if it is truncated
+    const titleAnchor = element.querySelector(".title > a");
+    const titleSpan = titleAnchor.querySelector("span");
+    if (titleSpan.offsetWidth > titleAnchor.offsetWidth) {
+      titleAnchor.dataset.tooltip = titleSpan.textContent;
     }
   }
 
@@ -73,24 +81,3 @@ class BookmarkItem {
 }
 
 registerBehavior("ld-bookmark-item", BookmarkItem);
-
-
-class LinkItem {
-  constructor(element) {
-    this.element = element
-    element.addEventListener("mouseover", this.onHover.bind(this))
-  }
-
-  getRect(element) {
-      return element.getBoundingClientRect();
-  }
-
-  onHover(event) {
-    let parent = this.element.parentElement
-    if (this.getRect(this.element).right > this.getRect(parent).right) {
-      parent.classList.add("shouldHover")
-    }
-  }
-}
-
-registerBehavior("ld-link-item", LinkItem)

--- a/bookmarks/styles/bookmark-page.scss
+++ b/bookmarks/styles/bookmark-page.scss
@@ -107,6 +107,18 @@ ul.bookmark-list {
   padding: 0;
 }
 
+@keyframes appear {
+  0% {
+    opacity: 0;
+  }
+  90% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
 /* Bookmarks */
 li[ld-bookmark-item] {
   position: relative;
@@ -122,6 +134,23 @@ li[ld-bookmark-item] {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+
+    &[data-title].shouldHover:hover::after {
+      content: attr(data-title);
+      position: absolute;
+      top: 18px;
+      left: 50%;
+      transform: translateX(-50%);
+      height: fit-content;
+      background-color: #292f62;
+      color: #fff;
+      padding: 0.3em 0.5em;
+      border-radius: 0.3em;
+      border: 1px solid #424a8c;
+      font-size: 0.80em;
+      white-space: nowrap;
+      animation: 0.3s ease 0s appear;
+    }
   }
 
   &.unread .title a {

--- a/bookmarks/styles/bookmark-page.scss
+++ b/bookmarks/styles/bookmark-page.scss
@@ -135,20 +135,24 @@ li[ld-bookmark-item] {
     overflow: hidden;
     text-overflow: ellipsis;
 
-    &[data-title].shouldHover:hover::after {
-      content: attr(data-title);
+    &[data-tooltip]:hover::after, &[data-tooltip]:focus::after {
+      content: attr(data-tooltip);
       position: absolute;
-      top: 18px;
+      z-index: 10;
+      top: 20px;
       left: 50%;
       transform: translateX(-50%);
+      width: max-content;
+      max-width: 100%;
       height: fit-content;
       background-color: #292f62;
       color: #fff;
-      padding: 0.3em 0.5em;
-      border-radius: 0.3em;
+      padding: $unit-1;
+      border-radius: $border-radius;
       border: 1px solid #424a8c;
-      font-size: 0.80em;
-      white-space: nowrap;
+      font-size: $font-size-sm;
+      font-style: normal;
+      white-space: normal;
       animation: 0.3s ease 0s appear;
     }
   }

--- a/bookmarks/templates/bookmarks/bookmark_list.html
+++ b/bookmarks/templates/bookmarks/bookmark_list.html
@@ -14,11 +14,11 @@
           <i class="form-icon"></i>
         </label>
         <div class="title">
-          <a href="{{ bookmark_item.url }}" target="{{ bookmark_list.link_target }}" rel="noopener" data-title="{{ bookmark_item.title }}">
+          <a href="{{ bookmark_item.url }}" target="{{ bookmark_list.link_target }}" rel="noopener" >
             {% if bookmark_item.favicon_file and bookmark_list.show_favicons %}
               <img src="{% static bookmark_item.favicon_file %}" alt="">
             {% endif %}
-              <span ld-link-item>{{ bookmark_item.title }}</span>
+              <span>{{ bookmark_item.title }}</span>
           </a>
         </div>
         {% if bookmark_list.show_url %}

--- a/bookmarks/templates/bookmarks/bookmark_list.html
+++ b/bookmarks/templates/bookmarks/bookmark_list.html
@@ -14,11 +14,11 @@
           <i class="form-icon"></i>
         </label>
         <div class="title">
-          <a href="{{ bookmark_item.url }}" target="{{ bookmark_list.link_target }}" rel="noopener">
+          <a href="{{ bookmark_item.url }}" target="{{ bookmark_list.link_target }}" rel="noopener" data-title="{{ bookmark_item.title }}">
             {% if bookmark_item.favicon_file and bookmark_list.show_favicons %}
               <img src="{% static bookmark_item.favicon_file %}" alt="">
             {% endif %}
-            {{ bookmark_item.title }}
+              <span ld-link-item>{{ bookmark_item.title }}</span>
           </a>
         </div>
         {% if bookmark_list.show_url %}

--- a/bookmarks/tests/test_bookmarks_list_template.py
+++ b/bookmarks/tests/test_bookmarks_list_template.py
@@ -24,7 +24,7 @@ class BookmarkListTemplateTest(TestCase, BookmarkFactoryMixin):
                 target="{link_target}" 
                 rel="noopener">
                 {favicon_img}
-                {bookmark.resolved_title}
+                <span>{bookmark.resolved_title}</span>
             </a>
             ''',
             html


### PR DESCRIPTION
Fixes #606 

This is what it looks like with a custom hover over a link that has an overly long title. 

<img width="643" alt="Screenshot 2024-01-19 at 16 04 59" src="https://github.com/sissbruecker/linkding/assets/2124818/82f38686-fda7-4129-8e41-ee6d2c2f8a88">

Light theme.
<img width="652" alt="Screenshot 2024-01-19 at 16 37 49" src="https://github.com/sissbruecker/linkding/assets/2124818/b08d3b9f-9b88-4b9f-a475-b1328d4e3b1e">
