### PR TITLE
Activate CI for contributors and when pushing tags

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,6 +1,14 @@
 name: linkding CI
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "*"
+  pull_request:
+    branches:
+      - "*"
 
 jobs:
   unit_tests:


### PR DESCRIPTION
I noticed that CI is not running when making a PR. It would make it easier if CI was actually running for people making a PR, both for yourself and for the contributor. 

There is the following setting as well. I think requiring approval for first time contributors is probably the sane choice to have here (which should be the default one). 

<img width="792" alt="Screenshot 2024-01-28 at 12 29 35" src="https://github.com/sissbruecker/linkding/assets/2124818/68525bf1-43cf-407c-afaf-2b93d1dae793">
