### PR TITLE
Insert 'Show more' if description exceeds two lines.

### DIFF
--- a/bookmarks/frontend/behaviors/bookmark-page.js
+++ b/bookmarks/frontend/behaviors/bookmark-page.js
@@ -71,6 +71,28 @@ class BookmarkItem {
     if (titleSpan.offsetWidth > titleAnchor.offsetWidth) {
       titleAnchor.dataset.tooltip = titleSpan.textContent;
     }
+    // Enable show more if description is truncated.
+    const showMoreBtn = this.element.querySelector(".show-more.btn")
+    const showMore = this.element.querySelector(".show-more")
+    showMoreBtn.addEventListener("click", this.onToggleMore.bind(this))
+    const description = this.element.querySelector(".description")
+    const text = this.element.querySelector(".description span")
+    if (text.offsetHeight > description.offsetHeight) {
+      showMore.classList.remove("hidden")
+    }
+  }
+
+  onToggleMore(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    const desc = this.element.querySelector(".description")
+    const btn = this.element.querySelector(".show-more.btn")
+    if (btn.textContent == "Show more") {
+      btn.textContent = "Show less"
+    } else {
+      btn.textContent = "Show more"
+    }
+    desc.classList.toggle("desc-no-overflow")
   }
 
   onToggleNotes(event) {

--- a/bookmarks/styles/base.scss
+++ b/bookmarks/styles/base.scss
@@ -142,3 +142,11 @@ span.confirmation {
     align-self: center;
   }
 }
+
+.pointer {
+  cursor: pointer;
+}
+
+.hidden {
+  display: none;
+}

--- a/bookmarks/styles/bookmark-page.scss
+++ b/bookmarks/styles/bookmark-page.scss
@@ -172,6 +172,11 @@ li[ld-bookmark-item] {
     color: $secondary-link-color;
   }
 
+  .desc-no-overflow {
+    max-height: 2lh;
+    overflow: hidden;
+  }
+
   .description {
     color: $gray-color-dark;
 

--- a/bookmarks/templates/bookmarks/bookmark_list.html
+++ b/bookmarks/templates/bookmarks/bookmark_list.html
@@ -29,6 +29,11 @@
             </a>
           </div>
         {% endif %}
+        {% if bookmark_item.description %}
+        <div class="description desc-no-overflow">
+            <span>{{ bookmark_item.description }}</span>
+        </div>
+        {% endif %}
         <div class="description truncate">
           {% if bookmark_item.tag_names %}
             <span>
@@ -36,10 +41,6 @@
                 <a href="?{% add_tag_to_query tag_name %}">{{ tag_name|hash_tag }}</a>
               {% endfor %}
             </span>
-          {% endif %}
-          {% if bookmark_item.tag_names and bookmark_item.description %} | {% endif %}
-          {% if bookmark_item.description %}
-            <span>{{ bookmark_item.description }}</span>
           {% endif %}
         </div>
         {% if bookmark_item.notes %}
@@ -78,6 +79,10 @@
             <button ld-confirm-button type="submit" name="remove" value="{{ bookmark_item.id }}"
                     class="btn btn-link btn-sm">Remove
             </button>
+            <div class="hidden show-more">
+              <span class="separator">|</span>
+              <button class="btn btn-link btn-sm show-more">Show more</button>
+            </div>
           {% else %}
             {# Shared bookmark actions #}
             <span>Shared by


### PR DESCRIPTION
Similar to the title, the description can easily become truncated. So this patch separates tags and description into two different lines, and if the description becomes truncated there is an option to click "Show more" among the actions to see the full description. 