### PR TITLE
Document backup when using `user` setting. Fixes #626

### DIFF
--- a/docs/backup.md
+++ b/docs/backup.md
@@ -40,7 +40,7 @@ To restore the backup, just copy the backup file to the data folder of your new 
 
 #### Rootless
 
-If you are running rootless container, you may be passing a `user` that has owns a folder binded to `/etc/linkding/data`.
+If you are running rootless container, you may be passing a `user` that owns the folder binded to `/etc/linkding/data`.
 
 Given that `/etc/linkding` can only be writted by `root`, you will need to export the backup to `/etc/linkding/data` instead. 
 

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -38,11 +38,9 @@ Now you can move that file to your backup location.
 
 To restore the backup, just copy the backup file to the data folder of your new installation and rename it to `db.sqlite3`. Then start the Docker container.
 
-#### Rootless
+#### Custom `user`
 
-If you are running rootless container, you may be passing a `user` that owns the folder binded to `/etc/linkding/data`.
-
-Given that `/etc/linkding` can only be writted by `root`, you will need to export the backup to `/etc/linkding/data` instead. 
+The default instructions assumes that the process has permissions to write to `/etc/linkding` (`root` by default). However, that may not be the case in case the containers is being ran with a custom `user`. In those cases, you can export the backup to  `/etc/linkding/data` where the same user should have permissions to write to.
 
 In summary, execute the following command:
 ```shell

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -29,7 +29,7 @@ docker exec -it linkding python manage.py backup backup.sqlite3
 ```
 This creates a `backup.sqlite3` file in the Docker container.
 
-To copy the backup file to your host system, execute the following command:
+Finally, to copy the backup file to your host system, execute the following command:
 ```shell
 docker cp linkding:/etc/linkding/backup.sqlite3 backup.sqlite3
 ```
@@ -37,6 +37,22 @@ This copies the backup file from the Docker container to the current folder on y
 Now you can move that file to your backup location.
 
 To restore the backup, just copy the backup file to the data folder of your new installation and rename it to `db.sqlite3`. Then start the Docker container.
+
+#### Rootless
+
+If you are running rootless container, you may be passing a `user` that has owns a folder binded to `/etc/linkding/data`.
+
+Given that `/etc/linkding` can only be writted by `root`, you will need to export the backup to `/etc/linkding/data` instead. 
+
+In summary, execute the following command:
+```shell
+docker exec -u "${PUID}:${PGID}" linkding python manage.py backup /etc/linkding/data/backup.sqlite3
+```
+
+Then copy the file:
+```shell
+docker cp linkding:/etc/linkding/data/backup.sqlite3 backup.sqlite3
+```
 
 ### Using the SQLite dump function
 

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -46,7 +46,7 @@ Given that `/etc/linkding` can only be writted by `root`, you will need to expor
 
 In summary, execute the following command:
 ```shell
-docker exec -u "${PUID}:${PGID}" linkding python manage.py backup /etc/linkding/data/backup.sqlite3
+docker exec linkding python manage.py backup /etc/linkding/data/backup.sqlite3
 ```
 
 Then copy the file:

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -29,7 +29,7 @@ docker exec -it linkding python manage.py backup backup.sqlite3
 ```
 This creates a `backup.sqlite3` file in the Docker container.
 
-Finally, to copy the backup file to your host system, execute the following command:
+To copy the backup file to your host system, execute the following command:
 ```shell
 docker cp linkding:/etc/linkding/backup.sqlite3 backup.sqlite3
 ```

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -40,7 +40,7 @@ To restore the backup, just copy the backup file to the data folder of your new 
 
 #### Custom `user`
 
-The default instructions assumes that the process has permissions to write to `/etc/linkding` (`root` by default). However, that may not be the case in case the containers is being ran with a custom `user`. In those cases, you can export the backup to  `/etc/linkding/data` where the same user should have permissions to write to.
+The default instructions assumes that the process has permissions to write to `/etc/linkding` (`root`). However, that may not be the case in case the container is being ran with `user` set. In those cases, you can export the backup to  `/etc/linkding/data` where the same user has write permissions.
 
 In summary, execute the following command:
 ```shell


### PR DESCRIPTION
~Document rootless backup~
Document backup when using a custom `user`.

Fixes #626

Edit: After checking, I am actually not running as rootless but just setting up `user`. [Actual rootless](https://docs.docker.com/engine/security/rootless/) does not work atm.