### PR TITLE
Hardcode the default request timeout

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -2,6 +2,7 @@
 # Bootstrap script that gets executed in new Docker containers
 
 LD_SERVER_PORT="${LD_SERVER_PORT:-9090}"
+export LD_REQUEST_TIMEOUT="${LD_REQUEST_TIMEOUT:-60}"
 
 # Create data folder if it does not exist
 mkdir -p data


### PR DESCRIPTION
As described in [Options.md](https://github.com/sissbruecker/linkding/blob/master/docs/Options.md), the default value for `LD_REQUEST_TIMEOUT` is 60.
However, when you have something like this in your .env file

```
# Configures the request timeout (in seconds) in the uwsgi application server. Default: 60
LD_REQUEST_TIMEOUT=
```

then the variable's value will be unset (or null?).
In this case, uwsgi `http-timeout` seems to be [considered zero](https://github.com/sissbruecker/linkding/blob/38204c87cf6fdd3d871a115d9786db73b17d1be6/uwsgi.ini#L21), which will result in every request being dropped.

Using bash variable expansion rules, the default value 60 can be set as fallback.