### PR TITLE
Fix HTML snapshot errors related to single-file-cli

### DIFF
--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -99,7 +99,9 @@ CMD ["./bootstrap.sh"]
 
 
 FROM linkding AS linkding-plus
-# install node, chromium and single-file
-RUN apk update && apk add nodejs npm chromium && npm install -g single-file-cli
+# install node, chromium
+RUN apk update && apk add nodejs npm chromium
+# install single-file from fork for now, which contains several hotfixes
+RUN npm install -g https://github.com/sissbruecker/single-file-cli/tarball/f3730995a52f27d5041a1ad9e7528af4b6b4cf4b
 # enable snapshot support
 ENV LD_ENABLE_SNAPSHOTS=True

--- a/docker/default.Dockerfile
+++ b/docker/default.Dockerfile
@@ -96,7 +96,15 @@ CMD curl -f http://localhost:${LD_SERVER_PORT:-9090}/${LD_CONTEXT_PATH}health ||
 CMD ["./bootstrap.sh"]
 
 FROM linkding AS linkding-plus
-# install node, chromium and single-file
-RUN apt-get update && apt-get -y install nodejs npm chromium && npm install -g single-file-cli
+# install chromium
+RUN apt-get update && apt-get -y install chromium
+# install node and single-file
+ENV NODE_MAJOR=20
+RUN apt-get install -y gnupg2 apt-transport-https ca-certificates && \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
+    apt-get update && apt-get install -y nodejs && \
+    npm install -g single-file-cli
+
 # enable snapshot support
 ENV LD_ENABLE_SNAPSHOTS=True

--- a/docker/default.Dockerfile
+++ b/docker/default.Dockerfile
@@ -98,13 +98,13 @@ CMD ["./bootstrap.sh"]
 FROM linkding AS linkding-plus
 # install chromium
 RUN apt-get update && apt-get -y install chromium
-# install node and single-file
+# install node
 ENV NODE_MAJOR=20
 RUN apt-get install -y gnupg2 apt-transport-https ca-certificates && \
     curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
-    apt-get update && apt-get install -y nodejs && \
-    npm install -g single-file-cli
-
+    apt-get update && apt-get install -y nodejs
+# install single-file from fork for now, which contains several hotfixes
+RUN npm install -g https://github.com/sissbruecker/single-file-cli/tarball/f3730995a52f27d5041a1ad9e7528af4b6b4cf4b
 # enable snapshot support
 ENV LD_ENABLE_SNAPSHOTS=True


### PR DESCRIPTION
- Use Node 20 in Debian image, which is the minimum for single-file-cli
- Use forked version of single-file-cli which contains some hotfixes not present in upstream