### PR TITLE
Add option for customizing single-file timeout

### DIFF
--- a/bookmarks/services/singlefile.py
+++ b/bookmarks/services/singlefile.py
@@ -24,8 +24,7 @@ def create_snapshot(url: str, filepath: str):
     try:
         # Use start_new_session=True to create a new process group
         process = subprocess.Popen(args, start_new_session=True)
-        timeout = float(os.environ.get('LD_SINGLEFILE_TIMEOUT_SEC', 60))
-        process.wait(timeout=timeout)
+        process.wait(timeout=settings.LD_SINGLEFILE_TIMEOUT_SEC)
 
         # check if the file was created
         if not os.path.exists(temp_filepath):

--- a/bookmarks/services/singlefile.py
+++ b/bookmarks/services/singlefile.py
@@ -24,7 +24,8 @@ def create_snapshot(url: str, filepath: str):
     try:
         # Use start_new_session=True to create a new process group
         process = subprocess.Popen(args, start_new_session=True)
-        process.wait(timeout=60)
+        timeout = float(os.environ.get('LD_SINGLEFILE_TIMEOUT_SEC', 60))
+        process.wait(timeout=timeout)
 
         # check if the file was created
         if not os.path.exists(temp_filepath):

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -246,3 +246,10 @@ See the default URL for how to insert the placeholder to the favicon provider UR
 
 Alternative favicon providers:
 - DuckDuckGo: `https://icons.duckduckgo.com/ip3/{domain}.ico`
+
+
+### `LD_SINGLEFILE_TIMEOUT_SEC`
+
+Values: `Float` | Default =  60.0
+
+When creating archive snapshots, control the timeout for how long to wait for `single-file` to complete, in `seconds`. Defaults to 60 seconds; on lower-powered hardware you may need to increase this value. 

--- a/siteroot/settings/base.py
+++ b/siteroot/settings/base.py
@@ -295,6 +295,7 @@ LD_ENABLE_SNAPSHOTS = os.getenv("LD_ENABLE_SNAPSHOTS", False) in (
 )
 LD_SINGLEFILE_PATH = os.getenv("LD_SINGLEFILE_PATH", "single-file")
 LD_SINGLEFILE_OPTIONS = os.getenv("LD_SINGLEFILE_OPTIONS", "")
+LD_SINGLEFILE_TIMEOUT_SEC = float(os.getenv("LD_SINGLEFILE_TIMEOUT_SEC", 60))
 
 # Monolith isn't used at the moment, as the local snapshot implementation
 # switched to single-file after the prototype. Keeping this around in case


### PR DESCRIPTION
Closes #685 

Testing procedure (I did not build & deploy a container):

1. Recreate container with `LD_SINGLEFILE_TIMEOUT_SEC=360` in the compose file. 
2. `docker exec` into the running container, modify `base.py` and `singlefile.py` per below 
3. `docker restart` the container. 
4. Verified that the URL mentioned in above issue worked with a 360 second timeout on Raspberry Pi 4. 