### PR TITLE
Add button for creating missing HTML snapshots

### DIFF
--- a/bookmarks/templates/settings/general.html
+++ b/bookmarks/templates/settings/general.html
@@ -173,6 +173,14 @@
               Automatically creates HTML snapshots when adding bookmarks. Alternatively, when disabled, snapshots can be
               created manually in the details view of a bookmark.
             </div>
+            <button class="btn mt-2" name="create_missing_html_snapshots">Create missing HTML snapshots</button>
+            {% if create_missing_html_snapshots_success_message %}
+              <div class="has-success">
+                <p class="form-input-hint">
+                  {{ create_missing_html_snapshots_success_message}}
+                </p>
+              </div>
+            {% endif %}
           </div>
         {% endif %}
         <div class="form-group">

--- a/bookmarks/templates/settings/general.html
+++ b/bookmarks/templates/settings/general.html
@@ -8,6 +8,12 @@
 
     {# Profile section #}
     <section class="content-area">
+      {% if success_message %}
+        <div class="toast toast-success mb-4">{{ success_message }}</div>
+      {% endif %}
+      {% if error_message %}
+        <div class="toast toast-error mb-4">{{ error_message }}</div>
+      {% endif %}
       <h2>Profile</h2>
       <p>
         <a href="{% url 'change_password' %}">Change password</a>
@@ -177,7 +183,7 @@
             {% if create_missing_html_snapshots_success_message %}
               <div class="has-success">
                 <p class="form-input-hint">
-                  {{ create_missing_html_snapshots_success_message}}
+                  {{ create_missing_html_snapshots_success_message }}
                 </p>
               </div>
             {% endif %}
@@ -232,20 +238,6 @@
             <input class="form-input" type="file" name="import_file">
             <input type="submit" class="input-group-btn btn btn-primary" value="Upload">
           </div>
-          {% if import_success_message %}
-            <div class="has-success">
-              <p class="form-input-hint">
-                {{ import_success_message }}
-              </p>
-            </div>
-          {% endif %}
-          {% if import_errors_message %}
-            <div class="has-error">
-              <p class="form-input-hint">
-                {{ import_errors_message }}
-              </p>
-            </div>
-          {% endif %}
         </div>
       </form>
     </section>

--- a/bookmarks/templates/settings/general.html
+++ b/bookmarks/templates/settings/general.html
@@ -126,13 +126,6 @@
           {% if request.user_profile.enable_favicons and enable_refresh_favicons %}
             <button class="btn mt-2" name="refresh_favicons">Refresh Favicons</button>
           {% endif %}
-          {% if refresh_favicons_success_message %}
-            <div class="has-success">
-              <p class="form-input-hint">
-                {{ refresh_favicons_success_message }}
-              </p>
-            </div>
-          {% endif %}
         </div>
         <div class="form-group">
           <label for="{{ form.web_archive_integration.id_for_label }}" class="form-label">Internet Archive
@@ -180,13 +173,6 @@
               created manually in the details view of a bookmark.
             </div>
             <button class="btn mt-2" name="create_missing_html_snapshots">Create missing HTML snapshots</button>
-            {% if create_missing_html_snapshots_success_message %}
-              <div class="has-success">
-                <p class="form-input-hint">
-                  {{ create_missing_html_snapshots_success_message }}
-                </p>
-              </div>
-            {% endif %}
           </div>
         {% endif %}
         <div class="form-group">
@@ -203,13 +189,6 @@
         </div>
         <div class="form-group">
           <input type="submit" name="update_profile" value="Save" class="btn btn-primary mt-2">
-          {% if update_profile_success_message %}
-            <div class="has-success">
-              <p class="form-input-hint">
-                {{ update_profile_success_message }}
-              </p>
-            </div>
-          {% endif %}
         </div>
       </form>
     </section>

--- a/bookmarks/tests/test_settings_general_view.py
+++ b/bookmarks/tests/test_settings_general_view.py
@@ -44,6 +44,24 @@ class SettingsGeneralViewTestCase(TestCase, BookmarkFactoryMixin):
 
         return {**form_data, **overrides}
 
+    def assertSuccessMessage(self, html, message: str, count=1):
+        self.assertInHTML(
+            f"""
+            <div class="toast toast-success mb-4">{ message }</div>
+        """,
+            html,
+            count=count,
+        )
+
+    def assertErrorMessage(self, html, message: str, count=1):
+        self.assertInHTML(
+            f"""
+            <div class="toast toast-error mb-4">{ message }</div>
+        """,
+            html,
+            count=count,
+        )
+
     def test_should_render_successfully(self):
         response = self.client.get(reverse("bookmarks:settings.general"))
 
@@ -138,12 +156,7 @@ class SettingsGeneralViewTestCase(TestCase, BookmarkFactoryMixin):
             self.user.profile.permanent_notes, form_data["permanent_notes"]
         )
         self.assertEqual(self.user.profile.custom_css, form_data["custom_css"])
-        self.assertInHTML(
-            """
-                <p class="form-input-hint">Profile updated</p>
-            """,
-            html,
-        )
+        self.assertSuccessMessage(html, "Profile updated")
 
     def test_update_profile_should_not_be_called_without_respective_form_action(self):
         form_data = {
@@ -156,13 +169,7 @@ class SettingsGeneralViewTestCase(TestCase, BookmarkFactoryMixin):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(self.user.profile.theme, UserProfile.THEME_AUTO)
-        self.assertInHTML(
-            """
-                <p class="form-input-hint">Profile updated</p>
-            """,
-            html,
-            count=0,
-        )
+        self.assertSuccessMessage(html, "Profile updated", count=0)
 
     def test_enable_favicons_should_schedule_icon_update(self):
         with patch.object(
@@ -210,13 +217,8 @@ class SettingsGeneralViewTestCase(TestCase, BookmarkFactoryMixin):
             html = response.content.decode()
 
             mock_schedule_refresh_favicons.assert_called_once()
-            self.assertInHTML(
-                """
-                <p class="form-input-hint">
-                    Scheduled favicon update. This may take a while...
-                </p>
-            """,
-                html,
+            self.assertSuccessMessage(
+                html, "Scheduled favicon update. This may take a while..."
             )
 
     def test_refresh_favicons_should_not_be_called_without_respective_form_action(self):
@@ -230,14 +232,8 @@ class SettingsGeneralViewTestCase(TestCase, BookmarkFactoryMixin):
             html = response.content.decode()
 
             mock_schedule_refresh_favicons.assert_not_called()
-            self.assertInHTML(
-                """
-                <p class="form-input-hint">
-                    Scheduled favicon update. This may take a while...
-                </p>
-            """,
-                html,
-                count=0,
+            self.assertSuccessMessage(
+                html, "Scheduled favicon update. This may take a while...", count=0
             )
 
     def test_refresh_favicons_should_be_visible_when_favicons_enabled_in_profile(self):
@@ -381,13 +377,8 @@ class SettingsGeneralViewTestCase(TestCase, BookmarkFactoryMixin):
             html = response.content.decode()
 
             mock_create_missing_html_snapshots.assert_called_once()
-            self.assertInHTML(
-                """
-                <p class="form-input-hint">
-                    Queued 5 missing snapshots. This may take a while...
-                </p>
-            """,
-                html,
+            self.assertSuccessMessage(
+                html, "Queued 5 missing snapshots. This may take a while..."
             )
 
     def test_create_missing_html_snapshots_should_not_be_called_without_respective_form_action(
@@ -404,12 +395,6 @@ class SettingsGeneralViewTestCase(TestCase, BookmarkFactoryMixin):
             html = response.content.decode()
 
             mock_create_missing_html_snapshots.assert_not_called()
-            self.assertInHTML(
-                """
-                <p class="form-input-hint">
-                    Queued 5 missing snapshots. This may take a while...
-                </p>
-            """,
-                html,
-                count=0,
+            self.assertSuccessMessage(
+                html, "Queued 5 missing snapshots. This may take a while...", count=0
             )

--- a/bookmarks/tests/test_settings_general_view.py
+++ b/bookmarks/tests/test_settings_general_view.py
@@ -381,6 +381,23 @@ class SettingsGeneralViewTestCase(TestCase, BookmarkFactoryMixin):
                 html, "Queued 5 missing snapshots. This may take a while..."
             )
 
+    @override_settings(LD_ENABLE_SNAPSHOTS=True)
+    def test_create_missing_html_snapshots_no_missing_snapshots(self):
+        with patch.object(
+            tasks, "create_missing_html_snapshots"
+        ) as mock_create_missing_html_snapshots:
+            mock_create_missing_html_snapshots.return_value = 0
+            form_data = {
+                "create_missing_html_snapshots": "",
+            }
+            response = self.client.post(
+                reverse("bookmarks:settings.general"), form_data
+            )
+            html = response.content.decode()
+
+            mock_create_missing_html_snapshots.assert_called_once()
+            self.assertSuccessMessage(html, "No missing snapshots found.")
+
     def test_create_missing_html_snapshots_should_not_be_called_without_respective_form_action(
         self,
     ):

--- a/bookmarks/views/settings.py
+++ b/bookmarks/views/settings.py
@@ -42,9 +42,12 @@ def general(request):
             success_message = "Scheduled favicon update. This may take a while..."
         if "create_missing_html_snapshots" in request.POST:
             count = tasks.create_missing_html_snapshots(request.user)
-            success_message = (
-                f"Queued {count} missing snapshots. This may take a while..."
-            )
+            if count > 0:
+                success_message = (
+                    f"Queued {count} missing snapshots. This may take a while..."
+                )
+            else:
+                success_message = "No missing snapshots found."
 
     if not profile_form:
         profile_form = UserProfileForm(instance=request.user_profile)

--- a/bookmarks/views/settings.py
+++ b/bookmarks/views/settings.py
@@ -25,13 +25,10 @@ def general(request):
     profile_form = None
     enable_refresh_favicons = django_settings.LD_ENABLE_REFRESH_FAVICONS
     has_snapshot_support = django_settings.LD_ENABLE_SNAPSHOTS
-    update_profile_success_message = None
-    refresh_favicons_success_message = None
-    create_missing_html_snapshots_success_message = None
-    import_success_message = _find_message_with_tag(
+    success_message = _find_message_with_tag(
         messages.get_messages(request), "bookmark_import_success"
     )
-    import_errors_message = _find_message_with_tag(
+    error_message = _find_message_with_tag(
         messages.get_messages(request), "bookmark_import_errors"
     )
     version_info = get_version_info(get_ttl_hash())
@@ -39,15 +36,13 @@ def general(request):
     if request.method == "POST":
         if "update_profile" in request.POST:
             profile_form = update_profile(request)
-            update_profile_success_message = "Profile updated"
+            success_message = "Profile updated"
         if "refresh_favicons" in request.POST:
             tasks.schedule_refresh_favicons(request.user)
-            refresh_favicons_success_message = (
-                "Scheduled favicon update. This may take a while..."
-            )
+            success_message = "Scheduled favicon update. This may take a while..."
         if "create_missing_html_snapshots" in request.POST:
             count = tasks.create_missing_html_snapshots(request.user)
-            create_missing_html_snapshots_success_message = (
+            success_message = (
                 f"Queued {count} missing snapshots. This may take a while..."
             )
 
@@ -61,11 +56,8 @@ def general(request):
             "form": profile_form,
             "enable_refresh_favicons": enable_refresh_favicons,
             "has_snapshot_support": has_snapshot_support,
-            "update_profile_success_message": update_profile_success_message,
-            "refresh_favicons_success_message": refresh_favicons_success_message,
-            "create_missing_html_snapshots_success_message": create_missing_html_snapshots_success_message,
-            "import_success_message": import_success_message,
-            "import_errors_message": import_errors_message,
+            "success_message": success_message,
+            "error_message": error_message,
             "version_info": version_info,
         },
     )

--- a/bookmarks/views/settings.py
+++ b/bookmarks/views/settings.py
@@ -27,6 +27,7 @@ def general(request):
     has_snapshot_support = django_settings.LD_ENABLE_SNAPSHOTS
     update_profile_success_message = None
     refresh_favicons_success_message = None
+    create_missing_html_snapshots_success_message = None
     import_success_message = _find_message_with_tag(
         messages.get_messages(request), "bookmark_import_success"
     )
@@ -44,6 +45,11 @@ def general(request):
             refresh_favicons_success_message = (
                 "Scheduled favicon update. This may take a while..."
             )
+        if "create_missing_html_snapshots" in request.POST:
+            count = tasks.create_missing_html_snapshots(request.user)
+            create_missing_html_snapshots_success_message = (
+                f"Queued {count} missing snapshots. This may take a while..."
+            )
 
     if not profile_form:
         profile_form = UserProfileForm(instance=request.user_profile)
@@ -57,6 +63,7 @@ def general(request):
             "has_snapshot_support": has_snapshot_support,
             "update_profile_success_message": update_profile_success_message,
             "refresh_favicons_success_message": refresh_favicons_success_message,
+            "create_missing_html_snapshots_success_message": create_missing_html_snapshots_success_message,
             "import_success_message": import_success_message,
             "import_errors_message": import_errors_message,
             "version_info": version_info,


### PR DESCRIPTION
Adds a button to the settings for creating HTML snapshots for bookmarks that don't have one yet. This is mostly intended to help users migrating from a version of linkding that didn't include the snapshot feature, allowing them to bulk create snapshots for bookmarks added before the migration.

The feature will only create a snapshot if the bookmark doesn't already have a successful or a queued snapshot.

Closes https://github.com/sissbruecker/linkding/issues/676

--- 

![Bildschirmfoto 2024-04-14 um 13 14 37](https://github.com/sissbruecker/linkding/assets/357820/a4999d9f-275f-4d37-8348-8e3a5fa13e0a)

--- 

![Bildschirmfoto 2024-04-14 um 13 14 56](https://github.com/sissbruecker/linkding/assets/357820/c7c8c3e6-fcf4-4ebd-ae60-ba3e3e084c89)
