### PR TITLE
Add OCI source annotation to link back to source repo

### DIFF
--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -69,6 +69,7 @@ RUN wget https://www.sqlite.org/${SQLITE_RELEASE_YEAR}/sqlite-amalgamation-${SQL
 
 
 FROM python:3.11.8-alpine3.19 AS linkding
+LABEL org.opencontainers.image.source="https://github.com/sissbruecker/linkding"
 # install runtime dependencies
 RUN apk update && apk add bash curl icu libpq mailcap libssl3
 # create www-data user and group
@@ -127,5 +128,3 @@ COPY --from=ublock-build /etc/linkding/uBlock0.chromium uBlock0.chromium/
 RUN mkdir -p chromium-profile && chown -R www-data:www-data chromium-profile
 # enable snapshot support
 ENV LD_ENABLE_SNAPSHOTS=True
-
-LABEL org.opencontainers.image.source="https://github.com/sissbruecker/linkding"

--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -127,3 +127,5 @@ COPY --from=ublock-build /etc/linkding/uBlock0.chromium uBlock0.chromium/
 RUN mkdir -p chromium-profile && chown -R www-data:www-data chromium-profile
 # enable snapshot support
 ENV LD_ENABLE_SNAPSHOTS=True
+
+LABEL org.opencontainers.image.source="https://github.com/sissbruecker/linkding"

--- a/docker/default.Dockerfile
+++ b/docker/default.Dockerfile
@@ -131,3 +131,5 @@ RUN mkdir -p chromium-profile && chown -R www-data:www-data chromium-profile
 COPY --from=ublock-build /etc/linkding/uBlock0.chromium uBlock0.chromium/
 # enable snapshot support
 ENV LD_ENABLE_SNAPSHOTS=True
+
+LABEL org.opencontainers.image.source="https://github.com/sissbruecker/linkding"

--- a/docker/default.Dockerfile
+++ b/docker/default.Dockerfile
@@ -71,6 +71,7 @@ RUN wget https://www.sqlite.org/${SQLITE_RELEASE_YEAR}/sqlite-amalgamation-${SQL
 
 
 FROM python:3.11.8-slim-bookworm as linkding
+LABEL org.opencontainers.image.source="https://github.com/sissbruecker/linkding"
 RUN apt-get update && apt-get -y install mime-support libpq-dev libicu-dev libssl3 curl
 WORKDIR /etc/linkding
 # copy prod dependencies
@@ -131,5 +132,3 @@ RUN mkdir -p chromium-profile && chown -R www-data:www-data chromium-profile
 COPY --from=ublock-build /etc/linkding/uBlock0.chromium uBlock0.chromium/
 # enable snapshot support
 ENV LD_ENABLE_SNAPSHOTS=True
-
-LABEL org.opencontainers.image.source="https://github.com/sissbruecker/linkding"


### PR DESCRIPTION
This commit adds the `org.opencontainers.image.source` label to the built container images.

This label is helpful for tools to be able to link back from the container image to the source repo.

For example, for those that use Renovate to help auto update dependencies, this will result in the latest releases release notes/changelog being included in the PR which is very handy!