### PR TITLE
Show proper name for bookmark assets in admin

### DIFF
--- a/bookmarks/admin.py
+++ b/bookmarks/admin.py
@@ -200,9 +200,13 @@ class AdminBookmark(admin.ModelAdmin):
 
 
 class AdminBookmarkAsset(admin.ModelAdmin):
-    list_display = ("display_name", "date_created", "status")
+    @admin.display(description="Display Name")
+    def custom_display_name(self, obj):
+        return str(obj)
+
+    list_display = ("custom_display_name", "date_created", "status")
     search_fields = (
-        "display_name",
+        "custom_display_name",
         "file",
     )
     list_filter = ("status",)

--- a/bookmarks/models.py
+++ b/bookmarks/models.py
@@ -118,6 +118,9 @@ class BookmarkAsset(models.Model):
                 pass
         super().save(*args, **kwargs)
 
+    def __str__(self):
+        return self.display_name or f"Bookmark Asset #{self.pk}"
+
 
 @receiver(post_delete, sender=BookmarkAsset)
 def bookmark_asset_deleted(sender, instance, **kwargs):


### PR DESCRIPTION
When viewing the detail of a BookmarkAsset in the admin panel, it shows as the default object string.

![image](https://github.com/sissbruecker/linkding/assets/3438974/65fe4a44-cdaf-48df-8ad5-d3b4ae37807c)

I have added a very basic string method, which uses the display_name or if that is not present (as its not mandatory), defaults to a simple string.

**With no display_name**
![image](https://github.com/sissbruecker/linkding/assets/3438974/b08cdd4e-5204-4894-9e11-f9b636156f78)

**With display_name**
![image](https://github.com/sissbruecker/linkding/assets/3438974/91aec7c0-53b2-497c-9b48-384392134445)

This is also reflected on the list page also

![image](https://github.com/sissbruecker/linkding/assets/3438974/77614b13-8b78-4c20-9219-a994c2f44b17)

