### PR TITLE
Display descriptions with linebreaks correctly

### DIFF
--- a/bookmarks/templates/bookmarks/bookmark_list.html
+++ b/bookmarks/templates/bookmarks/bookmark_list.html
@@ -47,7 +47,7 @@
         {% else %}
           {% if bookmark_item.description %}
             <div class="description separate">
-              {{ bookmark_item.description }}
+              {{ bookmark_item.description|linebreaks }}
             </div>
           {% endif %}
           {% if bookmark_item.tag_names %}

--- a/bookmarks/templates/bookmarks/details/form.html
+++ b/bookmarks/templates/bookmarks/details/form.html
@@ -85,7 +85,7 @@
     {% if details.bookmark.resolved_description %}
       <div class="description col-2">
         <dt>Description</dt>
-        <dd>{{ details.bookmark.resolved_description }}</dd>
+        <dd>{{ details.bookmark.resolved_description|linebreaks }}</dd>
       </div>
     {% endif %}
     {% if details.bookmark.notes %}


### PR DESCRIPTION
Fixes #709.

- On the details page, linebreaks will always be shown if the description has them
- On the main bookmarks index page, linebreaks will only be shown if `Bookmark description` is set to `Separate` (description will still be truncated if it contains more lines then the `Bookmark description max lines` setting