### PR TITLE
Hide tooltip on mobile

### DIFF
--- a/bookmarks/styles/bookmark-page.scss
+++ b/bookmarks/styles/bookmark-page.scss
@@ -199,6 +199,12 @@ li[ld-bookmark-item] {
     animation: 0.3s ease 0s appear;
   }
 
+  @media (pointer:coarse) {
+    .title a[data-tooltip]::after {
+      display: none;
+    }
+  }
+
   &.unread .title a {
     font-style: italic;
   }


### PR DESCRIPTION
If you click on a link on mobile (I tried on iOS), then go back, the link will be in focus and the tooltip will overlap half of the link, which is annoying because it's hard to take the focus off on mobile.