### PR TITLE
Thumbnails lazy loading

### DIFF
--- a/bookmarks/templates/bookmarks/bookmark_list.html
+++ b/bookmarks/templates/bookmarks/bookmark_list.html
@@ -145,7 +145,7 @@
           </div>
         </div>
         {% if bookmark_list.show_preview_images and bookmark_item.preview_image_file %}
-          <img class="preview-image" src="{% static bookmark_item.preview_image_file %}"/>
+          <img class="preview-image" src="{% static bookmark_item.preview_image_file %}" loading="lazy"/>
         {% endif %}
       </li>
     {% endfor %}


### PR DESCRIPTION
Prefer IntersectionObserver over loading=lazy because Safari still loads images when loading=lazy