### PR TITLE
Allow use of standard docker `TZ` env var

### DIFF
--- a/siteroot/settings/base.py
+++ b/siteroot/settings/base.py
@@ -114,7 +114,7 @@ LOGOUT_REDIRECT_URL = "/" + LD_CONTEXT_PATH + "login"
 
 LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = os.environ.get("TZ", "UTC")
+TIME_ZONE = os.getenv("TZ", "UTC")
 
 USE_I18N = True
 

--- a/siteroot/settings/base.py
+++ b/siteroot/settings/base.py
@@ -114,7 +114,7 @@ LOGOUT_REDIRECT_URL = "/" + LD_CONTEXT_PATH + "login"
 
 LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = "UTC"
+TIME_ZONE = os.environ.get("TZ", "UTC")
 
 USE_I18N = True
 


### PR DESCRIPTION
I noticed that the time zone wasn't set up right for me, and eventually came across [this](https://github.com/sissbruecker/linkding/issues/179#issuecomment-986292357) which got me up and running.

However, both that issue and [this more recent one](https://github.com/sissbruecker/linkding/issues/764) were opened by people trying to use the standard docker `TZ` var to set the app time zone. That seems like a reasonable thing to do.

If you agree, what do you think of this small fix?

> [!NOTE]
> An alternate approach might be to use the system time zone instead of UTC as the default. That would give the benefit of working for both bare metal installs as well as docker containers configured with `TZ`.

Closes https://github.com/sissbruecker/linkding/issues/764