### PR TITLE
removed version line from docker compose yaml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   linkding:
     container_name: "${LD_CONTAINER_NAME:-linkding}"


### PR DESCRIPTION
Removing version line from docker compose. This line is now obsolete and will throw a warning when starting the docker compose stack.