### PR TITLE
Add API endpoint (`api/bookmarks/export`) to allow exporting the bookmarks in netscape html format

### DIFF
--- a/bookmarks/api/routes.py
+++ b/bookmarks/api/routes.py
@@ -6,6 +6,9 @@ from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.routers import DefaultRouter
 
+from django.http import HttpResponse
+from django.db.models import prefetch_related_objects
+
 from bookmarks import queries
 from bookmarks.api.serializers import (
     BookmarkSerializer,
@@ -20,6 +23,7 @@ from bookmarks.services.bookmarks import (
     website_loader,
 )
 from bookmarks.services.website_loader import WebsiteMetadata
+from bookmarks.services import exporter
 
 logger = logging.getLogger(__name__)
 
@@ -132,6 +136,28 @@ class BookmarkViewSet(
             },
             status=status.HTTP_200_OK,
         )
+
+    @action(methods=["get"], detail=False)
+    def export(self, request):
+        # noinspection PyBroadException
+        try:
+            bookmarks = Bookmark.objects.filter(owner=request.user)
+            # Prefetch tags to prevent n+1 queries
+            prefetch_related_objects(bookmarks, "tags")
+            file_content = exporter.export_netscape_html(bookmarks)
+
+            response = HttpResponse(content_type="text/plain; charset=UTF-8")
+            response["Content-Disposition"] = 'attachment; filename="bookmarks.html"'
+            response.write(file_content)
+
+            return response
+        except:
+            return Response(
+                {
+                    "error": "Failed to export bookmarks."
+                },
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
 
 
 class TagViewSet(


### PR DESCRIPTION
I am not familiar at all with Django development, but I wanted this feature for personal use. Because your project doesn't really have any guidelines for contributing, I don't know what you expect from a pull request (or if you even accept any).

I would be willing to add to my changes to make my branch ready for merging.