### PR TITLE
Implement IPv6 capability

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,9 +1,7 @@
 # Docker container name
 LD_CONTAINER_NAME=linkding
 # Port on the host system that the application should be published on
-LD_SERVER_HOST=[::]
-# Port on the host system that the application should be published on
-LD_SERVER_PORT=9090
+LD_HOST_PORT=9090
 # Directory on the host system that should be mounted as data dir into the Docker container
 LD_HOST_DATA_DIR=./data
 

--- a/.env.sample
+++ b/.env.sample
@@ -1,7 +1,9 @@
 # Docker container name
 LD_CONTAINER_NAME=linkding
 # Port on the host system that the application should be published on
-LD_HOST_PORT=9090
+LD_SERVER_HOST=[::]
+# Port on the host system that the application should be published on
+LD_SERVER_PORT=9090
 # Directory on the host system that should be mounted as data dir into the Docker container
 LD_HOST_DATA_DIR=./data
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Bootstrap script that gets executed in new Docker containers
 
+LD_SERVER_HOST="${LD_SERVER_HOST:-[::]}"
 LD_SERVER_PORT="${LD_SERVER_PORT:-9090}"
 
 # Create data folder if it does not exist
@@ -32,4 +33,4 @@ if [ "$LD_DISABLE_BACKGROUND_TASKS" != "True" ]; then
 fi
 
 # Start uwsgi server
-exec uwsgi --http :$LD_SERVER_PORT uwsgi.ini
+exec uwsgi --http $LD_SERVER_HOST:$LD_SERVER_PORT uwsgi.ini

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -62,6 +62,12 @@ Values: `Integer` as seconds | Default = `60`
 
 Configures the request timeout in the uwsgi application server. This can be useful if you want to import a bookmark file with a high number of bookmarks and run into request timeouts.
 
+### `LD_SERVER_HOST`
+
+Values: Valid address for socket to bind to | Default = `[::]`
+
+Allows to set a custom host for the UWSGI server running in the container. The default creates a dual stack socket, which will respond to IPv4 and IPv6 requests. IPv4 requests are logged as IPv4-mapped IPv6 addresses, such as "::ffff:127.0.0.1". If reverting to an IPv4-only socket is desired, this can be set to "0.0.0.0".
+
 ### `LD_SERVER_PORT`
 
 Values: Valid port number | Default = `9090`


### PR DESCRIPTION
I've been wanting to start using linkding and installed it into my Kubernetes cluster, but couldn't access it.

My cluster runs only using IPv6 addresses and I noticed that the default configuration for uWSGI that is used in this project, defaults to binding only to an IPv4 socket and there is no config option to change this behaviour.

In the current year, with IPv4 addresses becoming more scarce and often an addon that needs to be paid extra, I think it's reasonable to change the default to **also** allow for IPv6 connections.

**This does not break any existing configurations**, as this creates a dual stack socket, which will respond to requests on both protocols (IPv4 addresses are displayed as IPv4-mapped IPv6 addresses and look like this: "::ffff:x.x.x.x".
Yet I have also provided a configuration option to change the behaviour, if a user were to desire it for whatever reason.

If you don't like changing the default, we could swap it back to 0.0.0.0 and only allow overwriting it, if desired, but as I have outlined I think changing the default is reasonable and doesn't harm existing setups.

I have tested these changes on my IPv6-only cluster, as well as on Docker Desktop on Windows with port mapping (which uses IPv4 addressing) and tried it on both the normal default and alpine image and it worked in all cases.