### PR TITLE
Bump requests version to 3.23.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -57,7 +57,7 @@ pyopenssl==24.1.0
     # via josepy
 python-dateutil==2.8.2
     # via -r requirements.in
-requests==2.32.0
+requests==2.32.3
     # via
     #   -r requirements.in
     #   mozilla-django-oidc


### PR DESCRIPTION
This avoids the yanked 3.23.0 version and allows pip-compile to work without --upgrade again.

Fixes #838 