### PR TITLE
Fix a broken link to options documentation

### DIFF
--- a/bookmarks/templates/settings/general.html
+++ b/bookmarks/templates/settings/general.html
@@ -169,7 +169,7 @@ reddit.com/r/Music music reddit</pre>
             Enabling this feature automatically downloads all missing favicons.
             By default, this feature uses a <b>Google service</b> to download favicons.
             If you don't want to use this service, check the <a
-              href="https://github.com/sissbruecker/linkding/blob/master/docs/Options.md#ld_favicon_provider"
+              href="https://linkding.link/options/#ld_favicon_provider"
               target="_blank">options documentation</a> on how to configure a custom favicon provider.
             Icons are downloaded in the background, and it may take a while for them to show up.
           </div>


### PR DESCRIPTION
This fixes a broken link on the settings page to lead to the website's documentation