### PR TITLE
Add basic fail2ban support

### DIFF
--- a/siteroot/urls.py
+++ b/siteroot/urls.py
@@ -34,6 +34,11 @@ class LinkdingLoginView(auth_views.LoginView):
         context["enable_oidc"] = settings.LD_ENABLE_OIDC
         return context
 
+    def form_invalid(self, form):
+        response = super().form_invalid(form)
+        response.status_code = 401
+        return response
+
 
 urlpatterns = [
     path("admin/", linkding_admin_site.urls),


### PR DESCRIPTION
Failed login attempts now return a `401` status code, resulting in uwsgi logs like:
```
2024-09-23 14:12:50,557 WARNING Unauthorized: /login/
[pid: 20|app: 0|req: 3/9] ::ffff:192.168.65.1 () {54 vars in 1728 bytes} [Mon Sep 23 14:12:50 2024] POST /login/ => generated 5956 bytes in 276 msecs (HTTP/1.1 401) 11 headers in 519 bytes (1 switches on core 1)
```

Closes https://github.com/sissbruecker/linkding/issues/489