### PR TITLE
Do not clear fields in POST requests (API behavior change)

### DIFF
--- a/bookmarks/services/bookmarks.py
+++ b/bookmarks/services/bookmarks.py
@@ -65,7 +65,6 @@ def update_bookmark(bookmark: Bookmark, tag_string, current_user: User):
     if has_url_changed:
         # Update web archive snapshot, if URL changed
         tasks.create_web_archive_snapshot(current_user, bookmark, True)
-        bookmark.save()
 
     return bookmark
 

--- a/bookmarks/tests/test_bookmarks_api_permissions.py
+++ b/bookmarks/tests/test_bookmarks_api_permissions.py
@@ -87,6 +87,16 @@ class BookmarksApiPermissionsTestCase(LinkdingApiTestCase, BookmarkFactoryMixin)
         self.authenticate()
         self.put(url, data, expected_status_code=status.HTTP_200_OK)
 
+    def test_update_bookmark_only_updates_own_bookmarks(self):
+        self.authenticate()
+
+        other_user = self.setup_user()
+        bookmark = self.setup_bookmark(user=other_user)
+        data = {"url": "https://example.com/"}
+        url = reverse("bookmarks:bookmark-detail", args=[bookmark.id])
+
+        self.put(url, data, expected_status_code=status.HTTP_404_NOT_FOUND)
+
     def test_patch_bookmark_requires_authentication(self):
         bookmark = self.setup_bookmark()
         data = {"url": "https://example.com"}
@@ -96,6 +106,16 @@ class BookmarksApiPermissionsTestCase(LinkdingApiTestCase, BookmarkFactoryMixin)
 
         self.authenticate()
         self.patch(url, data, expected_status_code=status.HTTP_200_OK)
+
+    def test_patch_bookmark_only_updates_own_bookmarks(self):
+        self.authenticate()
+
+        other_user = self.setup_user()
+        bookmark = self.setup_bookmark(user=other_user)
+        data = {"url": "https://example.com"}
+        url = reverse("bookmarks:bookmark-detail", args=[bookmark.id])
+
+        self.patch(url, data, expected_status_code=status.HTTP_404_NOT_FOUND)
 
     def test_delete_bookmark_requires_authentication(self):
         bookmark = self.setup_bookmark()

--- a/docs/src/content/docs/api.md
+++ b/docs/src/content/docs/api.md
@@ -155,34 +155,13 @@ Example payload:
 
 ```
 PUT /api/bookmarks/<id>/
-```
-
-Updates a bookmark.
-This is a full update, which requires at least a URL, and fields that are not specified are cleared or reset to their defaults.
-Tags are simply assigned using their names.
-
-Example payload:
-
-```json
-{
-  "url": "https://example.com",
-  "title": "Example title",
-  "description": "Example description",
-  "tag_names": [
-    "tag1",
-    "tag2"
-  ]
-}
-```
-
-**Patch**
-
-```
 PATCH /api/bookmarks/<id>/
 ```
 
-Updates a bookmark partially.
-Allows to modify individual fields of a bookmark.
+Updates a bookmark.
+When using `POST`, at least all required fields must be provided (currently only `url`).
+When using `PATCH`, only the fields that should be updated need to be provided.
+Regardless which method is used, any field that is not provided is not modified.
 Tags are simply assigned using their names.
 
 Example payload:


### PR DESCRIPTION
Previously, `POST` requests to the API would reset fields that are not provided in the request to their default values. While documented, the behavior was sort of accidental and potentially dangerous when new fields get added. Thus a small behavior change to not modify fields that are not part of the request.