### PR TITLE
Fix issue where description gets returned as null to extension

### DIFF
--- a/bookmarks/services/website_loader.py
+++ b/bookmarks/services/website_loader.py
@@ -60,6 +60,8 @@ def load_website_metadata(url: str):
                 else None
             )
 
+        description = description if description else ""
+        
         image_tag = soup.find("meta", attrs={"property": "og:image"})
         preview_image = image_tag["content"].strip() if image_tag else None
         if (


### PR DESCRIPTION
Issue: Some websites, such as this [mastodon page](https://mastodon.social/@AJCxZ0@infosec.exchange/113205687391468478) have no description and so the `check` endpoint was returning `null` to the extension for the description field.  When the user goes to save, they get the message "Error saving bookmark: Validation error: {"description":["This field may not be null."]}".
This error does not occur when metadata is loaded from the browser instead of the server.

Solution: When a description is not found an empty string will be returned.