### PR TITLE
Add active states to top-level nav menu items

### DIFF
--- a/bookmarks/styles/theme-dark.css
+++ b/bookmarks/styles/theme-dark.css
@@ -102,7 +102,7 @@
   --btn-error-text-color: var(--contrast-text-color);
 
   --btn-link-text-color: var(--link-color);
-  --btn-link-hover-text-color: var(--link-color);
+  --btn-link-hover-text-color: var(--secondary-link-color);
 }
 
 :root {

--- a/bookmarks/styles/theme/buttons.css
+++ b/bookmarks/styles/theme/buttons.css
@@ -21,7 +21,7 @@
   --btn-error-text-color: var(--contrast-text-color);
 
   --btn-link-text-color: var(--link-color);
-  --btn-link-hover-text-color: var(--link-color);
+  --btn-link-hover-text-color: var(--secondary-link-color);
 }
 
 .btn {
@@ -135,9 +135,15 @@
 
     &:focus,
     &:hover,
-    &:active,
-    &.active {
+    &:active {
       text-decoration: none;
+    }
+
+    &.active {
+      text-decoration: underline;
+      text-decoration-color: var(--btn-link-text-color);
+      text-decoration-thickness: 2px;
+      text-underline-offset: 0.5em;
     }
   }
 

--- a/bookmarks/templates/bookmarks/nav_menu.html
+++ b/bookmarks/templates/bookmarks/nav_menu.html
@@ -4,11 +4,11 @@
   <div class="hide-md">
     <a href="{% url 'bookmarks:new' %}" class="btn btn-primary mr-2">Add bookmark</a>
     <div class="dropdown">
-      <button class="btn btn-link dropdown-toggle" tabindex="0">
+      <button class="btn btn-link dropdown-toggle {% if request.path|starts_with:'/bookmarks' and not request.path|starts_with:'/bookmarks/new' %}active{% endif %}" tabindex="0">
         Bookmarks
       </button>
       <ul class="menu">
-        <li class="menu-item">
+        <li class="menu-item ">
           <a href="{% url 'bookmarks:index' %}" class="menu-link">Active</a>
         </li>
         <li class="menu-item">
@@ -27,7 +27,7 @@
         </li>
       </ul>
     </div>
-    <a href="{% url 'bookmarks:settings.index' %}" class="btn btn-link">Settings</a>
+    <a href="{% url 'bookmarks:settings.index' %}" class="btn btn-link {% if request.path|starts_with:"/settings" %}active{% endif %}">Settings</a>
     <form class="d-inline" action="{% url 'logout' %}" method="post">
       {% csrf_token %}
       <button type="submit" class="btn btn-link">Logout</button>

--- a/bookmarks/templatetags/shared.py
+++ b/bookmarks/templatetags/shared.py
@@ -87,6 +87,11 @@ def hash_tag(tag_name):
     return "#" + tag_name
 
 
+@register.filter(name="starts_with")
+def starts_with(text, prefix):
+    return text.startswith(prefix)
+
+
 @register.filter(name="first_char")
 def first_char(text):
     return text[0]


### PR DESCRIPTION
## Changes

This is a fairly simple change that adds active states to the top-level nav menu items on large viewports. As a new user, the first time I clicked around, I expected to see that sort of feedback to give a sense of where I am in the app. 

I kept it to the "desktop" version of the nav menu only, as the "mobile" menu is structured a bit differently (the top-level "Bookmarks" item being grouped at the same hierarchy as the other Bookmarks entries), and I don't necessarily feel it needs the same feedback in that context. Happy to experiment with that though if you feel otherwise. 

In the same vein, I also tweaked the styles for hover states for the nav menu links.

## Screenshots

### Dark Mode

![nav-menu-active-items-dark](https://github.com/user-attachments/assets/fde7e8ff-26c4-40b1-9849-26da5e5ab6f7)

https://github.com/user-attachments/assets/8359c87c-d4c5-4d63-a284-ed48cb78be42

### Light Mode

![nav-menu-active-items-light](https://github.com/user-attachments/assets/e933f8e3-eb7b-4955-880f-306867491f55)

https://github.com/user-attachments/assets/ec1a5deb-9213-4b12-ab16-2a01ad776c82