### PR TITLE
docs: add link to bookmarklet section

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The name comes from:
 - Automatically archive websites, either as local HTML file or on Internet Archive
 - Import and export bookmarks in Netscape HTML format
 - Installable as a Progressive Web App (PWA)
-- Extensions for [Firefox](https://addons.mozilla.org/firefox/addon/linkding-extension/) and [Chrome](https://chrome.google.com/webstore/detail/linkding-extension/beakmhbijpdhipnjhnclmhgjlddhidpe), as well as a bookmarklet
+- Extensions for [Firefox](https://addons.mozilla.org/firefox/addon/linkding-extension/) and [Chrome](https://chrome.google.com/webstore/detail/linkding-extension/beakmhbijpdhipnjhnclmhgjlddhidpe), as well as a [bookmarklet](https://linkding.link/how-to/#using-the-bookmarklet-on-androidchrome)
 - SSO support via OIDC or authentication proxies
 - REST API for developing 3rd party apps
 - Admin panel for user self-service and raw data access


### PR DESCRIPTION
Hi, this PR add a link in README to the bookmarklet page. This will help new users with the initial setup for Linkding.

![Screenshot of README with red rectangle around "bookmarklet" text](https://github.com/user-attachments/assets/596fe77e-de86-4e29-917a-0a2cb9a357a5)
