### PR TITLE
Add default robots.txt to block crawlers

### DIFF
--- a/bookmarks/static/robots.txt
+++ b/bookmarks/static/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -4,6 +4,7 @@ env = DJANGO_SETTINGS_MODULE=siteroot.settings.prod
 static-map = /static=static
 static-map = /static=data/favicons
 static-map = /static=data/previews
+static-map = /robots.txt=static/robots.txt
 processes = 2
 threads = 2
 pidfile = /tmp/linkding.pid
@@ -18,6 +19,7 @@ if-env = LD_CONTEXT_PATH
 static-map = /%(_)static=static
 static-map = /%(_)static=data/favicons
 static-map = /%(_)static=data/previews
+static-map = /%(_)robots.txt=static/robots.txt
 endif =
 
 if-env = LD_REQUEST_TIMEOUT


### PR DESCRIPTION
Adds a default robots.txt that instructs crawlers to not index the application. To customize this, a custom robots.txt could be mounted into the Docker container at `/etc/linkding/static/robots.txt`.

Closes https://github.com/sissbruecker/linkding/issues/956