### PR TITLE
add option to disable form login

### DIFF
--- a/bookmarks/templates/registration/login.html
+++ b/bookmarks/templates/registration/login.html
@@ -15,6 +15,7 @@
           <p class="form-input-hint">Your username and password didn't match. Please try again.</p>
         </div>
       {% endif %}
+      {% if not disable_form_login %}
       <div class="form-group">
         <label class="form-label" for="{{ form.username.id_for_label }}">Username</label>
         {{ form.username|add_class:'form-input'|attr:'placeholder: ' }}
@@ -23,13 +24,18 @@
         <label class="form-label" for="{{ form.password.id_for_label }}">Password</label>
         {{ form.password|add_class:'form-input'|attr:'placeholder: ' }}
       </div>
+      {% endif %}
 
       <br/>
       <div class="d-flex justify-between">
+        {% if not disable_form_login %}
         <input type="submit" value="Login" class="btn btn-primary btn-wide"/>
         <input type="hidden" name="next" value="{{ next }}"/>
         {% if enable_oidc %}
           <a class="btn btn-link" href="{% url 'oidc_authentication_init' %}">Login with OIDC</a>
+        {% endif %}
+        {% else %}
+          <a class="btn btn-primary btn-wide" href="{% url 'oidc_authentication_init' %}">Login with OIDC</a>
         {% endif %}
         {% if allow_registration %}
           <a href="{% url 'django_registration_register' %}" class="btn btn-link">Register</a>

--- a/bookmarks/tests/test_login_view.py
+++ b/bookmarks/tests/test_login_view.py
@@ -39,3 +39,18 @@ class LoginViewTestCase(TestCase, BookmarkFactoryMixin, HtmlTestMixin):
         oidc_login_link = soup.find("a", string="Login with OIDC")
 
         self.assertIsNotNone(oidc_login_link)
+
+    @override_settings(LD_DISABLE_FORM_LOGIN=True)
+    def test_should_not_show_login_form_fields(self):
+        response = self.client.get("/login/")
+
+        self.assertNotContains(response, '<input type="text" name="username" autofocus="" autocapitalize="none" autocomplete="username" maxlength="150" placeholder=" " class="form-input" required="" id="id_username">', html=True)
+        self.assertNotContains(response, '<input type="password" name="password" autocomplete="current-password" placeholder=" " class="form-input" required="" id="id_password">', html=True)
+        self.assertNotContains(response, '<input type="submit" value="Login" class="btn btn-primary btn-wide">', html=True)
+        
+    def test_default_should_show_login_form_fields(self):
+        response = self.client.get("/login/")
+
+        self.assertInHTML('<input type="text" name="username" autofocus="" autocapitalize="none" autocomplete="username" maxlength="150" placeholder=" " class="form-input" required="" id="id_username">', response.content.decode())
+        self.assertInHTML('<input type="password" name="password" autocomplete="current-password" placeholder=" " class="form-input" required="" id="id_password">', response.content.decode())
+        self.assertInHTML('<input type="submit" value="Login" class="btn btn-primary btn-wide">', response.content.decode())

--- a/docs/src/content/docs/options.md
+++ b/docs/src/content/docs/options.md
@@ -99,6 +99,14 @@ For example, for Authelia, which passes the `Remote-User` HTTP header, the `LD_A
 By default, the logout redirects to the login URL, which means the user will be automatically authenticated again.
 Instead, you might want to configure the logout URL of the auth proxy here.
 
+### `LD_DISABLE_FORM_LOGIN`
+
+Values: `True`, `False` | Default = `False`
+
+Disables form authentication hiding the username and password field on `/login` page.
+
+Use with `LD_ENABLE_OIDC` or `LD_ENABLE_AUTH_PROXY`.
+
 ### `LD_ENABLE_OIDC`
 
 Values: `True`, `False` | Default = `False`

--- a/siteroot/settings/base.py
+++ b/siteroot/settings/base.py
@@ -177,6 +177,7 @@ HUEY = {
     },
 }
 
+LD_DISABLE_FORM_LOGIN = os.getenv("LD_DISABLE_FORM_LOGIN", False) in (True, "True", "1")
 
 # Enable OICD support if configured
 LD_ENABLE_OIDC = os.getenv("LD_ENABLE_OIDC", False) in (True, "True", "1")

--- a/siteroot/urls.py
+++ b/siteroot/urls.py
@@ -32,6 +32,7 @@ class LinkdingLoginView(auth_views.LoginView):
 
         context["allow_registration"] = settings.ALLOW_REGISTRATION
         context["enable_oidc"] = settings.LD_ENABLE_OIDC
+        context["disable_form_login"] = settings.LD_DISABLE_FORM_LOGIN
         return context
 
     def form_invalid(self, form):


### PR DESCRIPTION
Fixes #730 

Add an option to disable login form, this hides the username and password fields and Login button, 
i also changed the `Login with OIDC` button css classes to make it a little better when form is disabled
which gives a for like this :
![image](https://github.com/user-attachments/assets/828a30f3-7f97-456e-84ab-ea6d8dceb388)


i'm not sure about the frontend part , it could probably be improved.

- Added test to validate that by default fiels are still present
- Added test to validate that fields are not present when option is true
