### PR TITLE
Push Docker images to GHCR in addition to Docker Hub

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,6 +19,13 @@ jobs:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -34,6 +41,8 @@ jobs:
           tags: |
             sissbruecker/linkding:latest
             sissbruecker/linkding:${{ env.VERSION }}
+            ghcr.io/sissbruecker/linkding:latest
+            ghcr.io/sissbruecker/linkding:${{ env.VERSION }}
           target: linkding
           push: true
 
@@ -46,6 +55,8 @@ jobs:
           tags: |
             sissbruecker/linkding:latest-alpine
             sissbruecker/linkding:${{ env.VERSION }}-alpine
+            ghcr.io/sissbruecker/linkding:latest-alpine
+            ghcr.io/sissbruecker/linkding:${{ env.VERSION }}-alpine
           target: linkding
           push: true
 
@@ -58,6 +69,8 @@ jobs:
           tags: |
             sissbruecker/linkding:latest-plus
             sissbruecker/linkding:${{ env.VERSION }}-plus
+            ghcr.io/sissbruecker/linkding:latest-plus
+            ghcr.io/sissbruecker/linkding:${{ env.VERSION }}-plus
           target: linkding-plus
           push: true
 
@@ -70,5 +83,7 @@ jobs:
           tags: |
             sissbruecker/linkding:latest-plus-alpine
             sissbruecker/linkding:${{ env.VERSION }}-plus-alpine
+            ghcr.io/sissbruecker/linkding:latest-plus-alpine
+            ghcr.io/sissbruecker/linkding:${{ env.VERSION }}-plus-alpine
           target: linkding-plus
           push: true


### PR DESCRIPTION
### Description:
This PR updates the GitHub Actions workflow to push Docker images to **GitHub Container Registry (GHCR)** alongside **Docker Hub**.

### Changes Made:
- Added a Login to GHCR step using `${{ github.token }}`.
- Updated all Docker build steps to include GHCR tags (`ghcr.io/sissbruecker/linkding`).

### Why This Change?
- Provides an additional registry for hosting images.
- GHCR offers better integration with GitHub (e.g., private repos, organization access).
- Docker Hub usage limits:
  - Starting April 1, 2025, unauthenticated users will be limited to 10 pulls/hour, and free authenticated users to 100 pulls/hour.
  - Users with Pro, Team, or Business subscriptions will have unlimited pulls with fair use.
  - Providing an alternative registry ensures users can still access images without hitting rate limits.

### Testing & Verification:
- Workflow should successfully authenticate with both registries and push images.
- Verify that images appear in [GHCR](https://github.com/sissbruecker?tab=packages).

Fixes #939.