### PR TITLE
Search on whole tags instead of start for tag autocomplete

### DIFF
--- a/bookmarks/frontend/components/TagAutocomplete.svelte
+++ b/bookmarks/frontend/components/TagAutocomplete.svelte
@@ -32,7 +32,7 @@
     const word = getCurrentWord(input);
 
     suggestions = word
-      ? tags.filter(tag => tag.name.toLowerCase().indexOf(word.toLowerCase()) === 0)
+      ? tags.filter(tag => tag.name.toLowerCase().includes(word.toLowerCase()))
       : [];
 
     if (word && suggestions.length > 0) {


### PR DESCRIPTION
I'm finding the current tag autocomplete a bit strict when searching. Assuming I have the following tags in database:

- `animal/python`
- `language/python`

Typing `python` in the input will show no suggestion. This is because the search matches from the start of the tag name. This patch changes the behaviour to search in the whole tag name, and not only at the start.

# Current behaviour

![image](https://github.com/user-attachments/assets/abbbbb22-c930-4f8d-a834-0668d60645ca)

# New behaviour

![image](https://github.com/user-attachments/assets/ba5c9b71-c48d-403e-a567-cb1ab5203db2)
