### PR TITLE
Add option to import description as notes

### DIFF
--- a/bookmarks/services/importer.py
+++ b/bookmarks/services/importer.py
@@ -23,6 +23,7 @@ class ImportResult:
 @dataclass
 class ImportOptions:
     map_private_flag: bool = False
+    description_as_notes: bool = False
 
 
 class TagCache:
@@ -239,7 +240,10 @@ def _copy_bookmark_data(
     if netscape_bookmark.title:
         bookmark.title = netscape_bookmark.title
     if netscape_bookmark.description:
-        bookmark.description = netscape_bookmark.description
+        if options.description_as_notes:
+            bookmark.notes = netscape_bookmark.description
+        else:
+            bookmark.description = netscape_bookmark.description
     if netscape_bookmark.notes:
         bookmark.notes = netscape_bookmark.notes
     if options.map_private_flag and not netscape_bookmark.private:

--- a/bookmarks/templates/settings/general.html
+++ b/bookmarks/templates/settings/general.html
@@ -342,6 +342,16 @@ reddit.com/r/Music music reddit</pre>
           </div>
         </div>
         <div class="form-group">
+          <label for="import_description_as_notes" class="form-checkbox">
+            <input type="checkbox" id="import_description_as_notes" name="description_as_notes">
+            <i class="form-icon"></i> Import description as notes
+          </label>
+          <div class="form-input-hint">
+            Enabling this option will store the imported bookmarks' descriptions in the notes field instead of the
+            description field.
+          </div>
+        </div>
+        <div class="form-group">
           <div class="input-group width-75 width-md-100">
             <input class="form-input" type="file" name="import_file">
             <input type="submit" class="input-group-btn btn btn-primary" value="Upload">

--- a/bookmarks/tests/test_settings_import_view.py
+++ b/bookmarks/tests/test_settings_import_view.py
@@ -133,3 +133,30 @@ class SettingsImportViewTestCase(TestCase, BookmarkFactoryMixin):
             self.assertEqual(Bookmark.objects.all()[0].shared, True)
             self.assertEqual(Bookmark.objects.all()[1].shared, True)
             self.assertEqual(Bookmark.objects.all()[2].shared, True)
+
+    def test_should_respect_description_as_notes_option(self):
+        with open(
+            "bookmarks/tests/resources/simple_valid_import_file.html"
+        ) as import_file:
+            self.client.post(
+                reverse("linkding:settings.import"),
+                {"import_file": import_file},
+                follow=True,
+            )
+
+            self.assertEqual(Bookmark.objects.all()[0].description, "test description 1")
+            self.assertEqual(Bookmark.objects.all()[0].notes, "")
+
+        Bookmark.objects.all().delete()
+
+        with open(
+            "bookmarks/tests/resources/simple_valid_import_file.html"
+        ) as import_file:
+            self.client.post(
+                reverse("linkding:settings.import"),
+                {"import_file": import_file, "description_as_notes": "on"},
+                follow=True,
+            )
+
+            self.assertEqual(Bookmark.objects.all()[0].description, "")
+            self.assertEqual(Bookmark.objects.all()[0].notes, "test description 1")

--- a/bookmarks/views/settings.py
+++ b/bookmarks/views/settings.py
@@ -199,7 +199,8 @@ def integrations(request):
 def bookmark_import(request: HttpRequest):
     import_file = request.FILES.get("import_file")
     import_options = importer.ImportOptions(
-        map_private_flag=request.POST.get("map_private_flag") == "on"
+        map_private_flag=request.POST.get("map_private_flag") == "on",
+        description_as_notes=request.POST.get("description_as_notes") == "on"
     )
 
     if import_file is None:


### PR DESCRIPTION
Adds a second import option to import a bookmark’s description as notes:

![](https://github.com/user-attachments/assets/9d40d55f-68fe-4c59-9923-fb2603008df3)

This makes it easier to import bookmarks exported by other services such as Pinboard or Raindrop.io which store the user’s notes in the description field (as the Netscape file format doesn’t provide a dedicated notes field).