### PR TITLE
Linkify plain URLs in notes

### DIFF
--- a/bookmarks/templatetags/shared.py
+++ b/bookmarks/templatetags/shared.py
@@ -142,5 +142,6 @@ def render_markdown(context, markdown_text):
 
     as_html = renderer.convert(markdown_text)
     sanitized_html = bleach.clean(as_html, markdown_tags, markdown_attrs)
+    linkified_html = bleach.linkify(sanitized_html)
 
-    return mark_safe(sanitized_html)
+    return mark_safe(linkified_html)

--- a/bookmarks/tests/test_bookmarks_list_template.py
+++ b/bookmarks/tests/test_bookmarks_list_template.py
@@ -885,12 +885,18 @@ class BookmarkListTemplateTest(TestCase, BookmarkFactoryMixin, HtmlTestMixin):
         self.assertNotes(html, note_html, 1)
 
     def test_note_renders_markdown_with_linkify(self):
-        self.setup_bookmark(notes='Example: https://example.com')
+        # Should linkify plain URL
+        self.setup_bookmark(notes="Example: https://example.com")
         html = self.render_template()
 
-        note_html = (
-            '<p>Example: <a href="https://example.com" rel="nofollow">https://example.com</a></p>'
-        )
+        note_html = '<p>Example: <a href="https://example.com" rel="nofollow">https://example.com</a></p>'
+        self.assertNotes(html, note_html, 1)
+
+        # Should not linkify URL in markdown link
+        self.setup_bookmark(notes="[https://example.com](https://example.com)")
+        html = self.render_template()
+
+        note_html = '<p><a href="https://example.com" rel="nofollow">https://example.com</a></p>'
         self.assertNotes(html, note_html, 1)
 
     def test_note_cleans_html(self):

--- a/bookmarks/tests/test_bookmarks_list_template.py
+++ b/bookmarks/tests/test_bookmarks_list_template.py
@@ -884,6 +884,15 @@ class BookmarkListTemplateTest(TestCase, BookmarkFactoryMixin, HtmlTestMixin):
         )
         self.assertNotes(html, note_html, 1)
 
+    def test_note_renders_markdown_with_linkify(self):
+        self.setup_bookmark(notes='Example: https://example.com')
+        html = self.render_template()
+
+        note_html = (
+            '<p>Example: <a href="https://example.com" rel="nofollow">https://example.com</a></p>'
+        )
+        self.assertNotes(html, note_html, 1)
+
     def test_note_cleans_html(self):
         self.setup_bookmark(notes='<script>alert("test")</script>')
         self.setup_bookmark(


### PR DESCRIPTION
Linkifies plain URLs in notes so one does not need to use Markdown syntax to be able to click on links.

At first, I considered using a Python-Markdown extension with Django’s `Urlizer`, but since we already use Bleach, it’s probably easiest to just use it for linkifying as well.

Closes #743.