### PR TITLE
Allow pre-filling tags in new bookmark form

### DIFF
--- a/bookmarks/forms.py
+++ b/bookmarks/forms.py
@@ -41,6 +41,7 @@ class BookmarkForm(forms.ModelForm):
                 "title": request.GET.get("title"),
                 "description": request.GET.get("description"),
                 "notes": request.GET.get("notes"),
+                "tag_string": request.GET.get("tag_string"),
                 "auto_close": "auto_close" in request.GET,
                 "unread": request.user_profile.default_mark_unread,
             }

--- a/bookmarks/forms.py
+++ b/bookmarks/forms.py
@@ -41,7 +41,7 @@ class BookmarkForm(forms.ModelForm):
                 "title": request.GET.get("title"),
                 "description": request.GET.get("description"),
                 "notes": request.GET.get("notes"),
-                "tag_string": request.GET.get("tag_string"),
+                "tag_string": request.GET.get("tags"),
                 "auto_close": "auto_close" in request.GET,
                 "unread": request.user_profile.default_mark_unread,
             }

--- a/bookmarks/tests/test_bookmark_new_view.py
+++ b/bookmarks/tests/test_bookmark_new_view.py
@@ -110,6 +110,19 @@ class BookmarkNewViewTestCase(TestCase, BookmarkFactoryMixin):
             html,
         )
 
+    def test_should_prefill_tags_from_url_parameter(self):
+        response = self.client.get(
+            reverse("linkding:bookmarks.new") + "?tags=tag1%20tag2%20tag3"
+        )
+        html = response.content.decode()
+
+        self.assertInHTML(
+            '<input type="text" name="tag_string" value="tag1 tag2 tag3" '
+            'class="form-input" autocomplete="off" autocapitalize="off" '
+            'id="id_tag_string">',
+            html,
+        )
+
     def test_should_prefill_notes_from_url_parameter(self):
         response = self.client.get(
             reverse("linkding:bookmarks.new")


### PR DESCRIPTION
Hi there 👋 

I'm moving from another comparable system to linkding and realized that I can't set the bookmarks in custom bookmark snippets. This PR reads `tag_string` from the GET requests, allowing to pre-fill tags.

Hope that is ok to add it like I've done in the PR. Let me know if there's also some documentation that needs to be amended.

/dasrecht