### PR TITLE
Make date_added and date_modified optionally writable fields for the POST /api/bookmarks/ API

### DIFF
--- a/bookmarks/api/serializers.py
+++ b/bookmarks/api/serializers.py
@@ -53,8 +53,6 @@ class BookmarkSerializer(serializers.ModelSerializer):
             "favicon_url",
             "preview_image_url",
             "tag_names",
-            "date_added",
-            "date_modified",
             "website_title",
             "website_description",
         ]
@@ -69,6 +67,9 @@ class BookmarkSerializer(serializers.ModelSerializer):
     # Add dummy website title and description fields for backwards compatibility but keep them empty
     website_title = EmtpyField()
     website_description = EmtpyField()
+    # these are optional
+    date_added = serializers.DateTimeField(required=False)
+    date_modified = serializers.DateTimeField(required=False)
 
     def get_favicon_url(self, obj: Bookmark):
         if not obj.favicon_file:
@@ -111,6 +112,17 @@ class BookmarkSerializer(serializers.ModelSerializer):
         # title and description to be populated automatically when left empty
         if not disable_scraping:
             bookmarks.enhance_with_website_metadata(saved_bookmark)
+
+        # override default timestamps, if specified
+        added = 'date_added' in validated_data
+        modified = 'date_modified' in validated_data
+        if added or modified:
+            if added:
+                saved_bookmark.date_added = validated_data['date_added']
+            if modified:
+                saved_bookmark.date_modified = validated_data['date_modified']
+            saved_bookmark.save()
+
         return saved_bookmark
 
     def update(self, instance: Bookmark, validated_data):


### PR DESCRIPTION
As discussed at https://github.com/sissbruecker/linkding/issues/940, syncing bookmarks between platforms is a good use case where it makes sense to be able to POST a bookmark via the API with a specified date_added and/or date_modified timestamp set.  This PR makes them optional parameters on that API.

This resolves https://github.com/sissbruecker/linkding/issues/940 .