### PR TITLE
Add Trafilatura archiver as lightweight alternative to SingleFile for HTML snapshots

### DIFF
--- a/bookmarks/services/assets.py
+++ b/bookmarks/services/assets.py
@@ -26,8 +26,37 @@ def create_snapshot_asset(bookmark: Bookmark) -> BookmarkAsset:
         content_type=BookmarkAsset.CONTENT_TYPE_HTML,
         display_name=f"HTML snapshot from {timestamp}",
         status=BookmarkAsset.STATUS_PENDING,
-    )
+    )    
     return asset
+
+
+def _try_trafilatura_snapshot(url: str, filepath: str) -> bool:
+    """Try to create snapshot using Trafilatura. Returns True on success."""
+    try:
+        import trafilatura
+        logger.info(f"Creating snapshot with Trafilatura for {url}")
+        trafilatura_extractor.create_snapshot(url, filepath)
+        return True
+    except ImportError:
+        logger.warning("Trafilatura not available")
+        return False
+    except Exception as e:
+        logger.warning(f"Trafilatura failed for {url}: {e}")
+        return False
+
+
+def _try_singlefile_snapshot(url: str, filepath: str) -> bool:
+    """Try to create snapshot using SingleFile. Returns True on success."""
+    try:
+        logger.info(f"Creating snapshot with SingleFile for {url}")
+        singlefile.create_snapshot(url, filepath)
+        return True
+    except FileNotFoundError:
+        logger.warning("SingleFile CLI not available")
+        return False
+    except Exception as e:
+        logger.warning(f"SingleFile failed for {url}: {e}")
+        return False
 
 
 def create_snapshot(asset: BookmarkAsset):
@@ -36,15 +65,26 @@ def create_snapshot(asset: BookmarkAsset):
         temp_filename = _generate_asset_filename(asset, asset.bookmark.url, "tmp")
         temp_filepath = os.path.join(settings.LD_ASSET_FOLDER, temp_filename)
         
-        # Choose archiver based on configuration
+        # Choose archiver based on configuration with fallback logic
         archiver_type = getattr(settings, 'LD_ARCHIVER_TYPE', 'singlefile').lower()
         
+        # Try preferred archiver first, then fallback
+        success = False
+        
         if archiver_type == 'trafilatura':
-            logger.info(f"Creating snapshot with Trafilatura for {asset.bookmark.url}")
-            trafilatura_extractor.create_snapshot(asset.bookmark.url, temp_filepath)
+            success = _try_trafilatura_snapshot(asset.bookmark.url, temp_filepath)
+            if not success:
+                logger.warning(f"Trafilatura failed for {asset.bookmark.url}")
         else:
-            logger.info(f"Creating snapshot with SingleFile for {asset.bookmark.url}")
-            singlefile.create_snapshot(asset.bookmark.url, temp_filepath)
+            # Default to SingleFile (backward compatibility)
+            success = _try_singlefile_snapshot(asset.bookmark.url, temp_filepath)
+            if not success and archiver_type != 'singlefile':
+                # If explicitly configured SingleFile fails, try Trafilatura
+                logger.warning(f"SingleFile failed for {asset.bookmark.url}, trying Trafilatura fallback")
+                success = _try_trafilatura_snapshot(asset.bookmark.url, temp_filepath)
+        
+            if not success:
+                raise Exception("Both Trafilatura and SingleFile failed to create snapshot")
 
         # Store as gzip in asset folder
         filename = _generate_asset_filename(asset, asset.bookmark.url, "html.gz")

--- a/bookmarks/services/trafilatura_extractor.py
+++ b/bookmarks/services/trafilatura_extractor.py
@@ -1,0 +1,336 @@
+import logging
+import os
+import requests
+from urllib.parse import urljoin, urlparse
+import base64
+import gzip
+import trafilatura
+from bs4 import BeautifulSoup
+from django.conf import settings
+from django.utils import timezone
+
+logger = logging.getLogger(__name__)
+
+
+class TrafilaturaError(Exception):
+    pass
+
+
+def create_snapshot(url: str, filepath: str):
+    """
+    Lightweight alternative to SingleFile using Trafilatura for content extraction.
+    Maintains same signature for API compatibility.
+    
+    Args:
+        url: The URL to archive
+        filepath: The output file path (will be .html or .html.gz)
+    """
+    try:
+        extractor = TrafilaturaContentExtractor()
+        html_content = extractor.extract_and_create_html(url)
+        
+        # Create directory if it doesn't exist
+        os.makedirs(os.path.dirname(filepath), exist_ok=True)
+        
+        # Write to file (uncompressed first, as assets.py will handle gzip compression)
+        with open(filepath, 'w', encoding='utf-8') as f:
+            f.write(html_content)
+            
+        logger.info(f"Created Trafilatura snapshot: {filepath} ({len(html_content)} bytes)")
+        
+    except Exception as e:
+        logger.error(f"Failed to create Trafilatura snapshot for {url}: {e}")
+        raise TrafilaturaError(f"Failed to create snapshot: {e}")
+
+
+class TrafilaturaContentExtractor:
+    def __init__(self):
+        self.session = requests.Session()
+        self.session.headers.update({
+            'User-Agent': getattr(settings, 'LD_TRAFILATURA_USER_AGENT', 
+                'Mozilla/5.0 (compatible; linkding archiver)'),
+            'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+            'Accept-Language': 'en-US,en;q=0.5',
+            'Accept-Encoding': 'gzip, deflate',
+            'Connection': 'keep-alive',
+        })
+        
+        # Configure session timeout
+        self.timeout = getattr(settings, 'LD_TRAFILATURA_TIMEOUT_SEC', 30)
+        
+        # Image embedding settings
+        self.embed_images = getattr(settings, 'LD_TRAFILATURA_EMBED_IMAGES', True)
+        self.max_image_size = getattr(settings, 'LD_TRAFILATURA_MAX_IMAGE_SIZE', 1024 * 1024)  # 1MB
+        
+    def extract_and_create_html(self, url: str) -> str:
+        """Extract content and create a complete HTML file"""
+        try:
+            # Download page content
+            logger.info(f"Downloading content from {url}")
+            downloaded = trafilatura.fetch_url(url, config=self._get_trafilatura_config())
+            
+            if not downloaded:
+                raise TrafilaturaError("Failed to download page content")
+            
+            # Extract main content
+            content = trafilatura.extract(
+                downloaded,
+                include_images=True,
+                include_links=True,
+                include_tables=True,
+                include_formatting=True,
+                output_format='html',
+                favor_precision=True,
+                with_metadata=True
+            )
+            
+            if not content:
+                raise TrafilaturaError("Failed to extract readable content from page")
+            
+            # Extract metadata
+            metadata = trafilatura.extract_metadata(downloaded)
+            
+            # Process and embed images if enabled
+            if self.embed_images:
+                content = self._embed_images_in_content(content, url)
+            
+            # Create final HTML
+            html_output = self._create_complete_html(content, metadata, url)
+            
+            return html_output
+            
+        except requests.RequestException as e:
+            raise TrafilaturaError(f"Network error: {e}")
+        except Exception as e:
+            raise TrafilaturaError(f"Content extraction error: {e}")
+    
+    def _get_trafilatura_config(self):
+        """Get Trafilatura configuration"""
+        config = trafilatura.settings.use_config()
+        config.set("DEFAULT", "EXTRACTION_TIMEOUT", str(self.timeout))
+        return config
+    
+    def _embed_images_in_content(self, content: str, base_url: str) -> str:
+        """Download and embed images as base64 data URLs"""
+        try:
+            soup = BeautifulSoup(content, 'html.parser')
+            
+            for img in soup.find_all('img'):
+                src = img.get('src')
+                if not src:
+                    continue
+                
+                # Skip if already a data URL
+                if src.startswith('data:'):
+                    continue
+                
+                try:
+                    # Resolve relative URLs
+                    img_url = urljoin(base_url, src)
+                    
+                    # Download image with size limit
+                    response = self.session.get(
+                        img_url, 
+                        timeout=10, 
+                        stream=True,
+                        headers={'Referer': base_url}
+                    )
+                    
+                    if response.status_code == 200:
+                        # Check content length
+                        content_length = response.headers.get('content-length')
+                        if content_length and int(content_length) > self.max_image_size:
+                            logger.debug(f"Skipping large image: {img_url} ({content_length} bytes)")
+                            continue
+                        
+                        # Download with size limit
+                        image_data = b''
+                        downloaded_size = 0
+                        
+                        for chunk in response.iter_content(chunk_size=8192):
+                            downloaded_size += len(chunk)
+                            if downloaded_size > self.max_image_size:
+                                logger.debug(f"Image too large, skipping: {img_url}")
+                                break
+                            image_data += chunk
+                        else:
+                            # Successfully downloaded within size limit
+                            content_type = response.headers.get('content-type', 'image/jpeg')
+                            if content_type.startswith('image/'):
+                                img_data_b64 = base64.b64encode(image_data).decode()
+                                img['src'] = f"data:{content_type};base64,{img_data_b64}"
+                                logger.debug(f"Embedded image: {img_url} ({len(image_data)} bytes)")
+                
+                except Exception as e:
+                    logger.debug(f"Failed to embed image {img_url}: {e}")
+                    # Keep original src on failure
+                    pass
+            
+            return str(soup)
+            
+        except Exception as e:
+            logger.warning(f"Failed to embed images: {e}")
+            return content
+    
+    def _create_complete_html(self, content: str, metadata, original_url: str) -> str:
+        """Create a complete HTML document"""
+        
+        # Extract metadata safely
+        title = getattr(metadata, 'title', None) or "Archived Page"
+        author = getattr(metadata, 'author', None) or ""
+        date = getattr(metadata, 'date', None) or ""
+        site_name = getattr(metadata, 'sitename', None) or ""
+        description = getattr(metadata, 'description', None) or ""
+        
+        # Current timestamp
+        archived_at = timezone.now().strftime("%Y-%m-%d %H:%M:%S UTC")
+        
+        # Create clean HTML document
+        html_template = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{self._escape_html(title)}</title>
+    <meta name="description" content="{self._escape_html(description)}">
+    <meta name="author" content="{self._escape_html(author)}">
+    <meta name="archived-from" content="{self._escape_html(original_url)}">
+    <meta name="archived-at" content="{archived_at}">
+    <meta name="archived-with" content="linkding-trafilatura">
+    <style>
+        body {{
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            line-height: 1.6;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            color: #333;
+            background: #fff;
+        }}
+        
+        .archive-header {{
+            background: #f8f9fa;
+            border: 1px solid #e9ecef;
+            border-radius: 6px;
+            padding: 16px;
+            margin-bottom: 24px;
+            font-size: 14px;
+            color: #6c757d;
+        }}
+        
+        .archive-header h2 {{
+            margin: 0 0 8px 0;
+            font-size: 16px;
+            color: #495057;
+        }}
+        
+        .archive-header a {{
+            color: #007bff;
+            text-decoration: none;
+            word-break: break-all;
+        }}
+        
+        .archive-header a:hover {{
+            text-decoration: underline;
+        }}
+        
+        .content h1, .content h2, .content h3, .content h4, .content h5, .content h6 {{
+            color: #212529;
+            margin-top: 24px;
+            margin-bottom: 16px;
+        }}
+        
+        .content h1 {{
+            font-size: 2em;
+            border-bottom: 1px solid #eaecef;
+            padding-bottom: 8px;
+        }}
+        
+        .content img {{
+            max-width: 100%;
+            height: auto;
+            border-radius: 4px;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+            margin: 16px 0;
+        }}
+        
+        .content blockquote {{
+            border-left: 4px solid #dfe2e5;
+            margin: 16px 0;
+            padding: 0 16px;
+            color: #6a737d;
+        }}
+        
+        .content code {{
+            background: #f6f8fa;
+            border-radius: 3px;
+            font-size: 85%;
+            margin: 0;
+            padding: 2px 4px;
+        }}
+        
+        .content pre {{
+            background: #f6f8fa;
+            border-radius: 6px;
+            font-size: 85%;
+            line-height: 1.45;
+            overflow: auto;
+            padding: 16px;
+        }}
+        
+        .content table {{
+            border-collapse: collapse;
+            margin: 16px 0;
+            width: 100%;
+        }}
+        
+        .content th, .content td {{
+            border: 1px solid #dfe2e5;
+            padding: 8px 12px;
+            text-align: left;
+        }}
+        
+        .content th {{
+            background: #f6f8fa;
+            font-weight: 600;
+        }}
+        
+        .content a {{
+            color: #0366d6;
+            text-decoration: none;
+        }}
+        
+        .content a:hover {{
+            text-decoration: underline;
+        }}
+    </style>
+</head>
+<body>
+    <div class="archive-header">
+        <h2>📄 Archived Content</h2>
+        <div><strong>Original URL:</strong> <a href="{self._escape_html(original_url)}" target="_blank" rel="noopener">{self._escape_html(original_url)}</a></div>
+        {f'<div><strong>Site:</strong> {self._escape_html(site_name)}</div>' if site_name else ''}
+        {f'<div><strong>Author:</strong> {self._escape_html(author)}</div>' if author else ''}
+        {f'<div><strong>Published:</strong> {self._escape_html(str(date))}</div>' if date else ''}
+        <div><strong>Archived:</strong> {archived_at}</div>
+        <div><strong>Archived with:</strong> linkding + Trafilatura</div>
+    </div>
+    
+    <main class="content">
+        {content}
+    </main>
+</body>
+</html>"""
+        
+        return html_template
+    
+    def _escape_html(self, text: str) -> str:
+        """Escape HTML entities in text"""
+        if not text:
+            return ""
+        return (str(text)
+                .replace('&', '&amp;')
+                .replace('<', '&lt;')
+                .replace('>', '&gt;')
+                .replace('"', '&quot;')
+                .replace("'", '&#x27;'))

--- a/bookmarks/settings/base.py
+++ b/bookmarks/settings/base.py
@@ -320,6 +320,18 @@ LD_SINGLEFILE_UBLOCK_OPTIONS = os.getenv(
 LD_SINGLEFILE_OPTIONS = os.getenv("LD_SINGLEFILE_OPTIONS", "")
 LD_SINGLEFILE_TIMEOUT_SEC = float(os.getenv("LD_SINGLEFILE_TIMEOUT_SEC", 120))
 
+# Trafilatura settings for lightweight content extraction
+LD_ARCHIVER_TYPE = os.getenv("LD_ARCHIVER_TYPE", "singlefile")  # 'singlefile' or 'trafilatura'
+LD_TRAFILATURA_TIMEOUT_SEC = int(os.getenv("LD_TRAFILATURA_TIMEOUT_SEC", 30))
+LD_TRAFILATURA_EMBED_IMAGES = os.getenv("LD_TRAFILATURA_EMBED_IMAGES", True) in (
+    True,
+    "True", 
+    "true",
+    "1",
+)
+LD_TRAFILATURA_MAX_IMAGE_SIZE = int(os.getenv("LD_TRAFILATURA_MAX_IMAGE_SIZE", 1048576))  # 1MB
+LD_TRAFILATURA_USER_AGENT = os.getenv("LD_TRAFILATURA_USER_AGENT", "Mozilla/5.0 (compatible; linkding archiver)")
+
 # Monolith isn't used at the moment, as the local snapshot implementation
 # switched to single-file after the prototype. Keeping this around in case
 # it turns out to be useful in the future.

--- a/bookmarks/tests/test_assets_trafilatura_integration.py
+++ b/bookmarks/tests/test_assets_trafilatura_integration.py
@@ -1,0 +1,144 @@
+import os
+import tempfile
+import gzip
+from unittest import mock
+from django.test import TestCase, override_settings
+from bookmarks.tests.helpers import BookmarkFactoryMixin
+from bookmarks.services import assets
+from bookmarks.models import BookmarkAsset
+
+
+class AssetServiceTrafilaturaTestCase(TestCase, BookmarkFactoryMixin):
+    def setUp(self):
+        self.user = None  # Initialize user attribute for BookmarkFactoryMixin
+        self.setup_temp_assets_dir()  # Set up temporary assets directory for testing
+        self.bookmark = self.setup_bookmark()
+
+    @override_settings(LD_ARCHIVER_TYPE='trafilatura')
+    def test_create_snapshot_with_trafilatura(self):
+        """Test that assets service uses Trafilatura when configured"""
+        with mock.patch('bookmarks.services.trafilatura_extractor.create_snapshot') as mock_trafilatura, \
+             mock.patch('bookmarks.services.singlefile.create_snapshot') as mock_singlefile:
+            
+            # Create mock file for trafilatura with gzipped content
+            def create_mock_file(url, filepath):
+                # Ensure directory exists
+                os.makedirs(os.path.dirname(filepath), exist_ok=True)
+                html_content = f"<html><body><h1>Trafilatura Test</h1><p>URL: {url}</p></body></html>"
+                with gzip.open(filepath, 'wt', encoding='utf-8') as f:
+                    f.write(html_content)
+            
+            mock_trafilatura.side_effect = create_mock_file
+            
+            # Create snapshot asset
+            asset = assets.create_snapshot_asset(self.bookmark)
+            assets.create_snapshot(asset)
+            
+            # Verify Trafilatura was called, not SingleFile
+            mock_trafilatura.assert_called_once()
+            mock_singlefile.assert_not_called()
+            
+            # Verify asset was created successfully
+            asset.refresh_from_db()
+            self.assertEqual(asset.status, BookmarkAsset.STATUS_COMPLETE)
+            self.assertTrue(asset.file.endswith('.html.gz'))
+            self.assertTrue(asset.gzip)
+            
+            # Verify the bookmark's latest snapshot was updated
+            self.bookmark.refresh_from_db()
+            self.assertEqual(self.bookmark.latest_snapshot, asset)
+
+    @override_settings(LD_ARCHIVER_TYPE='singlefile')  
+    def test_create_snapshot_with_singlefile_default(self):
+        """Test that assets service uses SingleFile by default"""
+        with mock.patch('bookmarks.services.trafilatura_extractor.create_snapshot') as mock_trafilatura, \
+             mock.patch('bookmarks.services.singlefile.create_snapshot') as mock_singlefile:
+            
+            # Create mock file for singlefile
+            def create_mock_file(url, filepath):
+                # Ensure directory exists
+                os.makedirs(os.path.dirname(filepath), exist_ok=True)
+                with open(filepath, 'w') as f:
+                    f.write(f"<html><body><h1>SingleFile Test</h1><p>URL: {url}</p></body></html>")
+            
+            mock_singlefile.side_effect = create_mock_file
+            
+            # Create snapshot asset
+            asset = assets.create_snapshot_asset(self.bookmark)
+            assets.create_snapshot(asset)
+            
+            # Verify SingleFile was called, not Trafilatura
+            mock_singlefile.assert_called_once()
+            mock_trafilatura.assert_not_called()
+            
+            # Verify asset was created successfully
+            asset.refresh_from_db()
+            self.assertEqual(asset.status, BookmarkAsset.STATUS_COMPLETE)
+
+    @override_settings(LD_ARCHIVER_TYPE='trafilatura')
+    def test_trafilatura_compression_format(self):
+        """Test that Trafilatura output is properly compressed as gzip"""
+        with mock.patch('bookmarks.services.trafilatura_extractor.create_snapshot') as mock_trafilatura:
+            
+            # Create mock HTML content
+            test_content = """<!DOCTYPE html>
+<html>
+<head><title>Test Page</title></head>
+<body>
+    <div class="archive-header">
+        <h2>📄 Archived Content</h2>
+        <div><strong>Original URL:</strong> <a href="https://example.com">https://example.com</a></div>
+    </div>
+    <main class="content">
+        <h1>Test Article</h1>
+        <p>This is test content from Trafilatura.</p>
+    </main>
+</body>
+</html>"""
+            
+            def create_mock_file(url, filepath):
+                # Ensure directory exists
+                os.makedirs(os.path.dirname(filepath), exist_ok=True)
+                with open(filepath, 'w', encoding='utf-8') as f:
+                    f.write(test_content)
+            
+            mock_trafilatura.side_effect = create_mock_file
+            
+            # Create snapshot asset
+            asset = assets.create_snapshot_asset(self.bookmark)
+            assets.create_snapshot(asset)
+            
+            # Verify the file was created and is gzipped
+            asset.refresh_from_db()
+            self.assertEqual(asset.status, BookmarkAsset.STATUS_COMPLETE)
+            self.assertTrue(asset.gzip)
+            
+            # Verify we can read the gzipped content from the asset file
+            if self.has_asset_file(asset):
+                content = self.read_asset_file(asset)
+                content_str = gzip.decompress(content).decode('utf-8')
+                self.assertIn("Test Article", content_str)
+                self.assertIn("Archived Content", content_str)
+                self.assertIn("Trafilatura", content_str)
+
+    @override_settings(LD_ARCHIVER_TYPE='invalid_archiver')
+    def test_invalid_archiver_falls_back_to_singlefile(self):
+        """Test that invalid archiver type falls back to SingleFile"""
+        with mock.patch('bookmarks.services.trafilatura_extractor.create_snapshot') as mock_trafilatura, \
+             mock.patch('bookmarks.services.singlefile.create_snapshot') as mock_singlefile:
+            
+            def create_mock_file(url, filepath):
+                # Ensure directory exists
+                os.makedirs(os.path.dirname(filepath), exist_ok=True)
+                with open(filepath, 'w') as f:
+                    f.write(f"<html><body><h1>Fallback Test</h1></body></html>")
+            
+            mock_singlefile.side_effect = create_mock_file
+            
+            # Create snapshot asset
+            asset = assets.create_snapshot_asset(self.bookmark)
+            assets.create_snapshot(asset)
+            
+            # Should fall back to SingleFile for invalid archiver type
+            mock_singlefile.assert_called_once()
+            mock_trafilatura.assert_not_called()

--- a/bookmarks/tests/test_trafilatura_service.py
+++ b/bookmarks/tests/test_trafilatura_service.py
@@ -1,0 +1,161 @@
+import os
+import tempfile
+import gzip
+from unittest import mock
+from django.test import TestCase, override_settings
+from bookmarks.services import trafilatura_extractor
+
+
+class TrafilaturaExtractorTestCase(TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.temp_html_filepath = os.path.join(self.temp_dir, "test.html")
+
+    def tearDown(self):
+        # Clean up temp files
+        if os.path.exists(self.temp_html_filepath):
+            os.remove(self.temp_html_filepath)
+        os.rmdir(self.temp_dir)
+
+    def create_test_file(self):
+        """Create a test HTML file"""
+        content = """<!DOCTYPE html>
+<html>
+<head><title>Test Page</title></head>
+<body>
+    <h1>Test Content</h1>
+    <p>This is test content.</p>
+    <img src="/test.jpg" alt="Test image">
+</body>
+</html>"""
+        with open(self.temp_html_filepath, "w") as f:
+            f.write(content)
+
+    def test_create_snapshot_success(self):
+        """Test successful snapshot creation with trafilatura"""
+        # Mock trafilatura functions
+        mock_downloaded_content = """
+        <!DOCTYPE html>
+        <html>
+        <head><title>Test Page</title></head>
+        <body>
+            <article>
+                <h1>Test Article</h1>
+                <p>This is the main content of the article.</p>
+                <img src="https://example.com/image.jpg" alt="Test image">
+            </article>
+        </body>
+        </html>
+        """
+        
+        mock_extracted_content = """
+        <h1>Test Article</h1>
+        <p>This is the main content of the article.</p>
+        <img src="https://example.com/image.jpg" alt="Test image">
+        """
+
+        with mock.patch('trafilatura.fetch_url', return_value=mock_downloaded_content), \
+             mock.patch('trafilatura.extract', return_value=mock_extracted_content), \
+             mock.patch('trafilatura.extract_metadata') as mock_metadata, \
+             mock.patch('requests.Session.get') as mock_get:
+            
+            # Mock metadata
+            mock_meta = mock.Mock()
+            mock_meta.title = "Test Article"
+            mock_meta.author = "Test Author"
+            mock_meta.date = "2024-01-01"
+            mock_meta.sitename = "Test Site"
+            mock_meta.description = "Test description"
+            mock_metadata.return_value = mock_meta
+            
+            # Mock image download (simulate failure to test fallback)
+            mock_response = mock.Mock()
+            mock_response.status_code = 404
+            mock_get.return_value = mock_response
+            
+            # Test the function
+            trafilatura_extractor.create_snapshot("https://example.com/test", self.temp_html_filepath)
+            
+            # Check if file was created
+            self.assertTrue(os.path.exists(self.temp_html_filepath))
+            
+            # Check file content
+            with open(self.temp_html_filepath, 'r') as f:
+                content = f.read()
+                self.assertIn("Test Article", content)
+                self.assertIn("Archived Content", content)
+                self.assertIn("https://example.com/test", content)
+                self.assertIn("linkding + Trafilatura", content)
+
+    def test_create_snapshot_with_image_embedding(self):
+        """Test snapshot creation with successful image embedding"""
+        mock_downloaded_content = """
+        <html><body><p>Test content</p><img src="test.jpg" alt="Test"></body></html>
+        """
+        
+        mock_extracted_content = """
+        <p>Test content</p><img src="test.jpg" alt="Test">
+        """
+
+        # Mock successful image download
+        mock_image_data = b'fake_image_data'
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+        mock_response.headers = {'content-type': 'image/jpeg', 'content-length': '100'}
+        mock_response.iter_content.return_value = [mock_image_data]
+
+        with mock.patch('trafilatura.fetch_url', return_value=mock_downloaded_content), \
+             mock.patch('trafilatura.extract', return_value=mock_extracted_content), \
+             mock.patch('trafilatura.extract_metadata', return_value=mock.Mock(title="Test")), \
+             mock.patch('requests.Session.get', return_value=mock_response):
+            
+            trafilatura_extractor.create_snapshot("https://example.com/test", self.temp_html_filepath)
+            
+            # Check if file was created and contains base64 image
+            self.assertTrue(os.path.exists(self.temp_html_filepath))
+            
+            with open(self.temp_html_filepath, 'r') as f:
+                content = f.read()
+                self.assertIn("data:image/jpeg;base64,", content)
+
+    def test_create_snapshot_failure(self):
+        """Test snapshot creation failure handling"""
+        with mock.patch('trafilatura.fetch_url', return_value=None):
+            with self.assertRaises(trafilatura_extractor.TrafilaturaError):
+                trafilatura_extractor.create_snapshot("https://example.com/test", self.temp_html_filepath)
+
+    @override_settings(LD_TRAFILATURA_EMBED_IMAGES=False)
+    def test_create_snapshot_without_image_embedding(self):
+        """Test snapshot creation with image embedding disabled"""
+        mock_downloaded_content = "<html><body><p>Test</p></body></html>"
+        mock_extracted_content = "<p>Test</p>"
+
+        with mock.patch('trafilatura.fetch_url', return_value=mock_downloaded_content), \
+             mock.patch('trafilatura.extract', return_value=mock_extracted_content), \
+             mock.patch('trafilatura.extract_metadata', return_value=mock.Mock(title="Test")):
+            
+            trafilatura_extractor.create_snapshot("https://example.com/test", self.temp_html_filepath)
+            
+            self.assertTrue(os.path.exists(self.temp_html_filepath))
+
+    @override_settings(LD_TRAFILATURA_TIMEOUT_SEC=5)
+    def test_custom_timeout_setting(self):
+        """Test that custom timeout setting is respected"""
+        extractor = trafilatura_extractor.TrafilaturaContentExtractor()
+        self.assertEqual(extractor.timeout, 5)
+
+    def test_html_escaping(self):
+        """Test HTML escaping in metadata"""
+        extractor = trafilatura_extractor.TrafilaturaContentExtractor()
+        
+        # Test various HTML entities
+        test_cases = [
+            ("Simple text", "Simple text"),
+            ("Text with <tags>", "Text with &lt;tags&gt;"),
+            ('Text with "quotes"', 'Text with &quot;quotes&quot;'),
+            ("Text with 'apostrophes'", "Text with &#x27;apostrophes&#x27;"),
+            ("Text with & ampersands", "Text with &amp; ampersands"),
+        ]
+        
+        for input_text, expected_output in test_cases:
+            self.assertEqual(extractor._escape_html(input_text), expected_output)

--- a/bookmarks/views/contexts.py
+++ b/bookmarks/views/contexts.py
@@ -19,6 +19,7 @@ from bookmarks.models import (
     Tag,
 )
 from bookmarks.services.wayback import generate_fallback_webarchive_url
+from bookmarks.services.tasks import is_html_snapshot_feature_active
 from bookmarks.type_defs import HttpRequest
 from bookmarks.views import access
 
@@ -400,15 +401,14 @@ class BookmarkDetailsContext:
         self.edit_return_url = request_context.details(bookmark.id)
         self.action_url = request_context.action(add={"details": bookmark.id})
         self.delete_url = request_context.action()
-        self.close_url = request_context.index()
-
+        self.close_url = request_context.index()        
         self.bookmark = bookmark
         self.profile = request.user_profile
         self.is_editable = bookmark.owner == user
         self.sharing_enabled = user_profile.enable_sharing
         self.preview_image_enabled = user_profile.enable_preview_images
         self.show_link_icons = user_profile.enable_favicons and bookmark.favicon_file
-        self.snapshots_enabled = settings.LD_ENABLE_SNAPSHOTS
+        self.snapshots_enabled = is_html_snapshot_feature_active()
         self.uploads_enabled = not settings.LD_DISABLE_ASSET_UPLOAD
 
         self.web_archive_snapshot_url = bookmark.web_archive_snapshot_url

--- a/docs/src/content/docs/options.md
+++ b/docs/src/content/docs/options.md
@@ -284,6 +284,38 @@ See `single-file --help` for complete list of arguments, or browse source: https
 
 Example: `LD_SINGLEFILE_OPTIONS=--user-agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:124.0) Gecko/20100101 Firefox/124.0"`
 
+### `LD_ARCHIVER_TYPE`
+
+Values: `singlefile` or `trafilatura` | Default = `singlefile`
+
+Choose the archiver to use for creating HTML snapshots. 
+- `singlefile`: Uses SingleFile CLI for complete page capture with full browser rendering (high memory usage)
+- `trafilatura`: Uses Trafilatura for lightweight content extraction (low memory usage, faster processing)
+
+### `LD_TRAFILATURA_TIMEOUT_SEC`
+
+Values: `Integer` | Default = 30
+
+When using Trafilatura archiver, control the timeout for downloading and processing content, in `seconds`.
+
+### `LD_TRAFILATURA_EMBED_IMAGES`
+
+Values: `true` or `false` | Default = `true`
+
+When using Trafilatura archiver, control whether images should be downloaded and embedded as base64 data URLs in the archived HTML.
+
+### `LD_TRAFILATURA_MAX_IMAGE_SIZE`
+
+Values: `Integer` | Default = 1048576
+
+When using Trafilatura archiver with image embedding enabled, set the maximum size in bytes for images to embed. Images larger than this will be skipped.
+
+### `LD_TRAFILATURA_USER_AGENT`
+
+Values: `String` | Default = "Mozilla/5.0 (compatible; linkding archiver)"
+
+When using Trafilatura archiver, set the User-Agent string used for HTTP requests.
+
 ### `LD_DISABLE_REQUEST_LOGS`
 
 Values: `true` or `false` | Default =  `false`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linkding",
-  "version": "1.36.0",
+  "version": "1.40.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linkding",
-      "version": "1.36.0",
+      "version": "1.40.0",
       "license": "MIT",
       "dependencies": {
         "@hotwired/turbo": "^8.0.6",

--- a/requirements.in
+++ b/requirements.in
@@ -12,5 +12,6 @@ psycopg2-binary
 python-dateutil
 requests
 supervisor
+trafilatura
 uWSGI
 waybackpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,8 @@
 #
 asgiref==3.8.1
     # via django
+babel==2.17.0
+    # via courlan
 beautifulsoup4==4.12.3
     # via -r requirements.in
 bleach==6.1.0
@@ -13,20 +15,29 @@ bleach==6.1.0
 bleach-allowlist==1.0.3
     # via -r requirements.in
 certifi==2024.8.30
-    # via requests
+    # via
+    #   requests
+    #   trafilatura
 cffi==1.17.1
     # via cryptography
 charset-normalizer==3.3.2
-    # via requests
+    # via
+    #   htmldate
+    #   requests
+    #   trafilatura
 click==8.1.7
     # via waybackpy
 confusable-homoglyphs==3.3.1
     # via django-registration
+courlan==1.3.2
+    # via trafilatura
 cryptography==43.0.1
     # via
     #   josepy
     #   mozilla-django-oidc
     #   pyopenssl
+dateparser==1.2.1
+    # via htmldate
 django==5.1.9
     # via
     #   -r requirements.in
@@ -39,12 +50,24 @@ django-widget-tweaks==1.5.0
     # via -r requirements.in
 djangorestframework==3.15.2
     # via -r requirements.in
+htmldate==1.9.1
+    # via trafilatura
 huey==2.5.1
     # via -r requirements.in
 idna==3.10
     # via requests
 josepy==1.14.0
     # via mozilla-django-oidc
+justext==3.0.2
+    # via trafilatura
+lxml[html-clean]==5.4.0
+    # via
+    #   htmldate
+    #   justext
+    #   lxml-html-clean
+    #   trafilatura
+lxml-html-clean==0.4.2
+    # via lxml
 markdown==3.7
     # via -r requirements.in
 mozilla-django-oidc==4.0.1
@@ -56,7 +79,14 @@ pycparser==2.22
 pyopenssl==24.2.1
     # via josepy
 python-dateutil==2.9.0.post0
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   dateparser
+    #   htmldate
+pytz==2025.2
+    # via dateparser
+regex==2024.11.6
+    # via dateparser
 requests==2.32.3
     # via
     #   -r requirements.in
@@ -72,9 +102,18 @@ sqlparse==0.5.1
     # via django
 supervisor==4.2.5
     # via -r requirements.in
+tld==0.13.1
+    # via courlan
+trafilatura==1.12.2
+    # via -r requirements.in
+tzlocal==5.3.1
+    # via dateparser
 urllib3==2.2.3
     # via
+    #   courlan
+    #   htmldate
     #   requests
+    #   trafilatura
     #   waybackpy
 uwsgi==2.0.28
     # via -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ certifi==2024.8.30
     #   trafilatura
 cffi==1.17.1
     # via cryptography
-charset-normalizer==3.3.2
+charset-normalizer==3.4.2
     # via
     #   htmldate
     #   requests
@@ -50,7 +50,7 @@ django-widget-tweaks==1.5.0
     # via -r requirements.in
 djangorestframework==3.15.2
     # via -r requirements.in
-htmldate==1.9.1
+htmldate==1.9.3
     # via trafilatura
 huey==2.5.1
     # via -r requirements.in
@@ -104,7 +104,7 @@ supervisor==4.2.5
     # via -r requirements.in
 tld==0.13.1
     # via courlan
-trafilatura==1.12.2
+trafilatura==2.0.0
     # via -r requirements.in
 tzlocal==5.3.1
     # via dateparser


### PR DESCRIPTION
### Summary
SingleFile have issues working on machines with restricted memory (1Gb) and handling complex pages with a lot of embedded media. This PR introduces Trafilatura as a lightweight alternative archiver for creating HTML snapshots, providing a pure Python solution that doesn't require browser dependencies like Chromium.

You may check this build from:
[docker pull domage/linkding:test](https://hub.docker.com/repository/docker/domage/linkding/general)

WARNING: Despite the fact that the image _should_ work without any problems with existing installations, remember that **this is a test build, so make a copy of your data before you deploy, or deploy in a separate instance.** 

### Key Features
- Lightweight archiver: Pure Python implementation using Trafilatura library
- Image embedding: Automatically embeds images as base64 data URLs with configurable size limits
- Video handling (very basic): Converts _some_ video embeds to clickable links for better accessibility (not perfect, but handles some cases)
- Backward compatibility: Maintains full compatibility with existing SingleFile installations
- Memory efficient: Significantly lower resource usage compared to browser-based solutions (works well on 1Gb Mem instances)

### New Components
- trafilatura_extractor.py: Core extraction engine with content processing
- Enhanced assets.py: Archiver selection logic with fallback mechanism
- Updated contexts.py: UI integration for snapshot button visibility in base image

New environment variables for Trafilatura configuration:
```
LD_ARCHIVER_TYPE=trafilatura|singlefile  # Choose archiver (default: singlefile)
LD_TRAFILATURA_TIMEOUT_SEC=30           # Request timeout
LD_TRAFILATURA_EMBED_IMAGES=True        # Embed images as base64
LD_TRAFILATURA_MAX_IMAGE_SIZE=1048576   # Max image size (1MB)
LD_TRAFILATURA_USER_AGENT=linkding/1.0  # Custom user agent
```

### Backward Compatibility
- No breaking changes: Existing installations continue using SingleFile by default
- Seamless migration: Switch archivers via environment variable
- Same output format: Both archivers produce compatible .html.gz files

Test run:
```
----------------------------------------------------------------------
Ran 814 tests in 176.715s

OK
Destroying test database for alias 'default' ('file:memorydb_default?mode=memory&cache=shared')...

```