### PR TITLE
Add exclusion of Tags and Terms to Search

### DIFF
--- a/bookmarks/frontend/components/SearchAutoComplete.svelte
+++ b/bookmarks/frontend/components/SearchAutoComplete.svelte
@@ -102,6 +102,17 @@
           tagName: tag.name
         }))
     }
+    else if (currentWord && currentWord.length > 2 && currentWord[0] === '-' && currentWord[1] === '#') {
+      const searchTag = currentWord.substring(2, currentWord.length)
+      tagSuggestions = (tags || []).filter(tag => tag.name.toLowerCase().indexOf(searchTag.toLowerCase()) === 0)
+        .slice(0, 5)
+        .map(tag => ({
+          type: 'tag',
+          index: nextIndex(),
+          label: `-#${tag.name}`,
+          tagName: tag.name
+        }))
+    } 
 
     // Recent search suggestions
     const recentSearches = searchHistory.getRecentSearches(value, 5).map(value => ({
@@ -172,7 +183,9 @@
     if (suggestion.type === 'tag') {
       const bounds = getCurrentWordBounds(input);
       const inputValue = input.value;
-      input.value = inputValue.substring(0, bounds.start) + `#${suggestion.tagName} ` + inputValue.substring(bounds.end);
+      console.log(inputValue)
+      console.log(bounds)
+      input.value = inputValue.substring(0, bounds.start) + `${suggestion.label} ` + inputValue.substring(bounds.end);
       close()
     }
   }

--- a/bookmarks/queries.py
+++ b/bookmarks/queries.py
@@ -220,7 +220,7 @@ def parse_query_string(query_string):
             search_terms.append(word)
 
     tag_names = unique(tag_names, str.lower)
-
+    tag_names_negative = unique(tag_names_negative, str.lower)
 
     return {
         "search_terms": search_terms,

--- a/bookmarks/styles/bookmark-page.css
+++ b/bookmarks/styles/bookmark-page.css
@@ -392,6 +392,15 @@ li[ld-bookmark-item] {
     }
   }
 
+  & .selected-negative-tags {
+    margin-bottom: var(--unit-4);
+
+    & a,
+    & a:visited:hover {
+      color: var(--error-color);
+    }
+  }
+
   & .unselected-tags {
     & a,
     & a:visited:hover {

--- a/bookmarks/templates/bookmarks/index.html
+++ b/bookmarks/templates/bookmarks/index.html
@@ -37,6 +37,14 @@
       <section aria-labelledby="tags-heading">
         <div class="section-header">
           <h2 id="tags-heading">Tags</h2>
+          <a href="?{% get_tag_cloud_negative_search_toggle_url %}" data-is-tag-item>
+            {% get_tag_cloud_negative_search_state as negative_state %}
+            {% if negative_state == 1 %}
+              <span>Negative</span>
+            {% else %}
+              <span>Positive</span>
+            {% endif %}
+          </a>
         </div>
         <div id="tag-cloud-container">
           {% include 'bookmarks/tag_cloud.html' %}

--- a/bookmarks/templates/bookmarks/index.html
+++ b/bookmarks/templates/bookmarks/index.html
@@ -37,12 +37,12 @@
       <section aria-labelledby="tags-heading">
         <div class="section-header">
           <h2 id="tags-heading">Tags</h2>
-          <a href="?{% get_tag_cloud_negative_search_toggle_url %}" data-is-tag-item>
+          <a href="?{% get_tag_cloud_negative_search_toggle_url %}" data-is-tag-item class="btn">
             {% get_tag_cloud_negative_search_state as negative_state %}
             {% if negative_state == 1 %}
-              <span>Negative</span>
+              Negative
             {% else %}
-              <span>Positive</span>
+              Positive
             {% endif %}
           </a>
         </div>

--- a/bookmarks/templates/bookmarks/tag_cloud.html
+++ b/bookmarks/templates/bookmarks/tag_cloud.html
@@ -14,7 +14,7 @@
     {% if tag_cloud.has_selected_negative_tags %}
       <p class="selected-negative-tags">
         {% for tag in tag_cloud.selected_negative_tags %}
-          <a href="?{% remove_tag_from_query tag %}"
+          <a href="?{% remove_tag_from_query tag True %}"
              class="text-bold mr-2">
             <span>!{{ tag }}</span>
           </a>

--- a/bookmarks/templates/bookmarks/tag_cloud.html
+++ b/bookmarks/templates/bookmarks/tag_cloud.html
@@ -27,14 +27,14 @@
           {% for tag in group.tags %}
             {# Highlight first char of first tag in group #}
             {% if forloop.counter == 1 %}
-              <a href="?{% add_tag_to_query tag.name %}"
+              <a href="?{% add_tag_to_query tag.name negative_state %}"
                  class="mr-2" data-is-tag-item>
                 <span
                     class="highlight-char">{{ tag.name|first_char }}</span><span>{{ tag.name|remaining_chars:1 }}</span>
               </a>
             {% else %}
               {# Render remaining tags normally #}
-              <a href="?{% add_tag_to_query tag.name %}"
+              <a href="?{% add_tag_to_query tag.name negative_state %}"
                  class="mr-2" data-is-tag-item>
                 <span>{{ tag.name }}</span>
               </a>

--- a/bookmarks/templates/bookmarks/tag_cloud.html
+++ b/bookmarks/templates/bookmarks/tag_cloud.html
@@ -4,9 +4,9 @@
     {% if tag_cloud.has_selected_tags %}
       <p class="selected-tags">
         {% for tag in tag_cloud.selected_tags %}
-          <a href="?{% remove_tag_from_query tag %}"
+          <a href="?{% remove_tag_from_query tag.name %}"
              class="text-bold mr-2">
-            <span>-{{ tag }}</span>
+            <span>-{{ tag.name }}</span>
           </a>
         {% endfor %}
       </p>
@@ -14,9 +14,9 @@
     {% if tag_cloud.has_selected_negative_tags %}
       <p class="selected-negative-tags">
         {% for tag in tag_cloud.selected_negative_tags %}
-          <a href="?{% remove_tag_from_query tag True %}"
+          <a href="?{% remove_tag_from_query tag.name True %}"
              class="text-bold mr-2">
-            <span>!{{ tag }}</span>
+            <span>!{{ tag.name }}</span>
           </a>
         {% endfor %}
       </p>

--- a/bookmarks/templates/bookmarks/tag_cloud.html
+++ b/bookmarks/templates/bookmarks/tag_cloud.html
@@ -11,6 +11,16 @@
         {% endfor %}
       </p>
     {% endif %}
+    {% if tag_cloud.has_selected_negative_tags %}
+      <p class="selected-negative-tags">
+        {% for tag in tag_cloud.selected_negative_tags %}
+          <a href="?{% remove_tag_from_query tag %}"
+             class="text-bold mr-2">
+            <span>!{{ tag }}</span>
+          </a>
+        {% endfor %}
+      </p>
+    {% endif %}
     <div class="unselected-tags">
       {% for group in tag_cloud.groups %}
         <p class="group">

--- a/bookmarks/templates/bookmarks/tag_cloud.html
+++ b/bookmarks/templates/bookmarks/tag_cloud.html
@@ -4,9 +4,9 @@
     {% if tag_cloud.has_selected_tags %}
       <p class="selected-tags">
         {% for tag in tag_cloud.selected_tags %}
-          <a href="?{% remove_tag_from_query tag.name %}"
+          <a href="?{% remove_tag_from_query tag %}"
              class="text-bold mr-2">
-            <span>-{{ tag.name }}</span>
+            <span>-{{ tag }}</span>
           </a>
         {% endfor %}
       </p>

--- a/bookmarks/templatetags/shared.py
+++ b/bookmarks/templatetags/shared.py
@@ -11,6 +11,30 @@ from bookmarks.models import UserProfile
 
 register = template.Library()
 
+@register.simple_tag(takes_context=True)
+def get_tag_cloud_negative_search_toggle_url(context):
+    params = context.request.GET.copy()
+
+    # Append to or create query string
+    query_string = params.get("n", "0")
+
+    if query_string == "1":
+        query_string = "0"
+    else:  
+        query_string = "1"
+
+    params.setlist("n", [query_string])
+
+    params.pop("details", None)
+    params.pop("page", None)
+
+    return params.urlencode()
+
+@register.simple_tag(takes_context=True)
+def get_tag_cloud_negative_search_state(context):
+    params = context.request.GET.copy()
+
+    return params.get("n", "0") == "1"
 
 @register.simple_tag(takes_context=True)
 def update_query_string(context, **kwargs):
@@ -24,12 +48,15 @@ def update_query_string(context, **kwargs):
 
 
 @register.simple_tag(takes_context=True)
-def add_tag_to_query(context, tag_name: str):
+def add_tag_to_query(context, tag_name: str, tag_negative: bool = False):
     params = context.request.GET.copy()
 
     # Append to or create query string
     query_string = params.get("q", "")
-    query_string = (query_string + " #" + tag_name).strip()
+    if tag_negative:
+        query_string = (query_string + " -#" + tag_name).strip()
+    else:
+        query_string = (query_string + " #" + tag_name).strip()
     params.setlist("q", [query_string])
 
     # Remove details ID and page number

--- a/bookmarks/templatetags/shared.py
+++ b/bookmarks/templatetags/shared.py
@@ -40,14 +40,18 @@ def add_tag_to_query(context, tag_name: str):
 
 
 @register.simple_tag(takes_context=True)
-def remove_tag_from_query(context, tag_name: str):
+def remove_tag_from_query(context, tag_name: str, tag_negative: bool = False):
     params = context.request.GET.copy()
     if params.__contains__("q"):
         # Split query string into parts
         query_string = params.__getitem__("q")
         query_parts = query_string.split()
+        #Switch for negtive Tag
         # Remove tag with hash
-        tag_name_with_hash = "#" + tag_name
+        if tag_negative:
+            tag_name_with_hash = "-#" + tag_name
+        else:
+            tag_name_with_hash = "#" + tag_name
         query_parts = [
             part
             for part in query_parts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linkding",
-  "version": "1.36.0",
+  "version": "1.40.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linkding",
-      "version": "1.36.0",
+      "version": "1.40.0",
       "license": "MIT",
       "dependencies": {
         "@hotwired/turbo": "^8.0.6",


### PR DESCRIPTION
Adding a "-" before tag or term in the search means that bookmarks containing it will not be in the search results.
Tag cloud has a button to allow to choose  whether a clicked tag should be in the search results or excluded.