### PR TITLE
Automatically compress uploads with gzip

### DIFF
--- a/bookmarks/services/assets.py
+++ b/bookmarks/services/assets.py
@@ -104,7 +104,6 @@ def upload_asset(bookmark: Bookmark, upload_file: UploadedFile):
             asset.gzip = True
             asset.file = f"{filename}.gz"
             asset.file_size = os.path.getsize(filepath)
-            asset.content_type = "text/html"  # to match how snapshots are handled
         else:
             with open(filepath, "wb") as f:
                 for chunk in upload_file.chunks():
@@ -113,7 +112,6 @@ def upload_asset(bookmark: Bookmark, upload_file: UploadedFile):
             asset.file_size = upload_file.size
             if upload_file.content_type == "application/gzip":
                 asset.gzip = True
-                asset.content_type = "text/html"  # to match how snapshots are handled
         asset.save()
 
         asset.bookmark.date_modified = timezone.now()

--- a/bookmarks/services/assets.py
+++ b/bookmarks/services/assets.py
@@ -94,24 +94,28 @@ def upload_asset(bookmark: Bookmark, upload_file: UploadedFile):
             gzip=False,
         )
         name, extension = os.path.splitext(upload_file.name)
-        filename = _generate_asset_filename(asset, name, extension.lstrip("."))
-        filepath = os.path.join(settings.LD_ASSET_FOLDER, filename)
+
+        # automatically gzip the file if it is not already gzipped
         if upload_file.content_type != "application/gzip":
-            filepath += ".gz"
+            filename = _generate_asset_filename(
+                asset, name, extension.lstrip(".") + ".gz"
+            )
+            filepath = os.path.join(settings.LD_ASSET_FOLDER, filename)
             with gzip.open(filepath, "wb", compresslevel=9) as f:
                 for chunk in upload_file.chunks():
                     f.write(chunk)
             asset.gzip = True
-            asset.file = f"{filename}.gz"
+            asset.file = filename
             asset.file_size = os.path.getsize(filepath)
         else:
+            filename = _generate_asset_filename(asset, name, extension.lstrip("."))
+            filepath = os.path.join(settings.LD_ASSET_FOLDER, filename)
             with open(filepath, "wb") as f:
                 for chunk in upload_file.chunks():
                     f.write(chunk)
             asset.file = filename
             asset.file_size = upload_file.size
-            if upload_file.content_type == "application/gzip":
-                asset.gzip = True
+
         asset.save()
 
         asset.bookmark.date_modified = timezone.now()

--- a/bookmarks/services/assets.py
+++ b/bookmarks/services/assets.py
@@ -103,7 +103,6 @@ def upload_asset(bookmark: Bookmark, upload_file: UploadedFile):
                     f.write(chunk)
             asset.gzip = True
             asset.file = f"{filename}.gz"
-            asset.display_name = asset.file
             asset.file_size = os.path.getsize(filepath)
             asset.content_type = "text/html"  # to match how snapshots are handled
         else:

--- a/bookmarks/services/assets.py
+++ b/bookmarks/services/assets.py
@@ -96,7 +96,7 @@ def upload_asset(bookmark: Bookmark, upload_file: UploadedFile):
         name, extension = os.path.splitext(upload_file.name)
         filename = _generate_asset_filename(asset, name, extension.lstrip("."))
         filepath = os.path.join(settings.LD_ASSET_FOLDER, filename)
-        if upload_file.content_type == "text/html":
+        if upload_file.content_type != "application/gzip":
             filepath += ".gz"
             with gzip.open(filepath, "wb", compresslevel=9) as f:
                 for chunk in upload_file.chunks():

--- a/bookmarks/tests/helpers.py
+++ b/bookmarks/tests/helpers.py
@@ -209,8 +209,17 @@ class BookmarkFactoryMixin:
 
     def read_asset_file(self, asset: BookmarkAsset):
         filepath = os.path.join(settings.LD_ASSET_FOLDER, asset.file)
-        with open(filepath, "rb") as f:
-            return f.read()
+
+        if asset.gzip:
+            with gzip.open(filepath, "rb") as f:
+                return f.read()
+        else:
+            with open(filepath, "rb") as f:
+                return f.read()
+
+    def get_asset_filesize(self, asset: BookmarkAsset):
+        filepath = os.path.join(settings.LD_ASSET_FOLDER, asset.file)
+        return os.path.getsize(filepath) if os.path.exists(filepath) else 0
 
     def has_asset_file(self, asset: BookmarkAsset):
         filepath = os.path.join(settings.LD_ASSET_FOLDER, asset.file)

--- a/bookmarks/tests/test_assets_service.py
+++ b/bookmarks/tests/test_assets_service.py
@@ -207,11 +207,10 @@ class AssetServiceTestCase(TestCase, BookmarkFactoryMixin):
 
         # verify file name
         self.assertTrue(saved_file_name.startswith("upload_"))
-        self.assertTrue(saved_file_name.endswith("_test_file.txt"))
+        self.assertTrue(saved_file_name.endswith("_test_file.txt.gz"))
 
         # file should contain the correct content
-        with open(os.path.join(self.assets_dir, saved_file_name), "rb") as file:
-            self.assertEqual(file.read(), file_content)
+        self.assertEqual(self.read_asset_file(asset), file_content)
 
         # should create asset
         self.assertIsNotNone(asset.id)
@@ -221,8 +220,8 @@ class AssetServiceTestCase(TestCase, BookmarkFactoryMixin):
         self.assertEqual(asset.display_name, upload_file.name)
         self.assertEqual(asset.status, BookmarkAsset.STATUS_COMPLETE)
         self.assertEqual(asset.file, saved_file_name)
-        self.assertEqual(asset.file_size, len(file_content))
-        self.assertFalse(asset.gzip)
+        self.assertEqual(asset.file_size, self.get_asset_filesize(asset))
+        self.assertTrue(asset.gzip)
 
         # should update bookmark modified date
         bookmark.refresh_from_db()
@@ -250,60 +249,18 @@ class AssetServiceTestCase(TestCase, BookmarkFactoryMixin):
         self.assertTrue(saved_file_name.endswith("_test_file.html.gz"))
 
         # file should contain the correct content
-        with open(os.path.join(self.assets_dir, saved_file_name), "rb") as file:
-            self.assertEqual(file.read(), file_content)
+        self.assertEqual(self.read_asset_file(asset), file_content)
 
         # should create asset
         self.assertIsNotNone(asset.id)
         self.assertEqual(asset.bookmark, bookmark)
         self.assertEqual(asset.asset_type, BookmarkAsset.TYPE_UPLOAD)
-        self.assertEqual(asset.content_type, "text/html")  # to match snapshot handling
+        self.assertEqual(asset.content_type, "application/gzip")
         self.assertEqual(asset.display_name, upload_file.name)
         self.assertEqual(asset.status, BookmarkAsset.STATUS_COMPLETE)
         self.assertEqual(asset.file, saved_file_name)
         self.assertEqual(asset.file_size, len(file_content))
-        self.assertTrue(asset.gzip)
-
-        # should update bookmark modified date
-        bookmark.refresh_from_db()
-        self.assertGreater(bookmark.date_modified, initial_modified)
-
-    @disable_logging
-    def test_upload_html_asset(self):
-        initial_modified = timezone.datetime(
-            2025, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc
-        )
-        bookmark = self.setup_bookmark(modified=initial_modified)
-        file_content = b"<html>test content</html>"
-        upload_file = SimpleUploadedFile(
-            "test_file.html", file_content, content_type="text/html"
-        )
-
-        asset = assets.upload_asset(bookmark, upload_file)
-
-        # should create file in asset folder
-        saved_file_name = self.get_saved_snapshot_file()
-        self.assertIsNotNone(upload_file)
-
-        # verify file name
-        self.assertTrue(saved_file_name.startswith("upload_"))
-        self.assertTrue(saved_file_name.endswith("_test_file.html.gz"))
-
-        # file should contain the correct content
-        with open(os.path.join(self.assets_dir, saved_file_name), "rb") as file:
-            self.assertEqual(gzip.decompress(file.read()), file_content)
-
-        # should create asset
-        self.assertIsNotNone(asset.id)
-        self.assertEqual(asset.bookmark, bookmark)
-        self.assertEqual(asset.asset_type, BookmarkAsset.TYPE_UPLOAD)
-        self.assertEqual(asset.content_type, "text/html")  # to match snapshot handling
-        self.assertTrue(asset.display_name.startswith("upload_"))
-        self.assertTrue(asset.display_name.endswith("_test_file.html.gz"))
-        self.assertEqual(asset.status, BookmarkAsset.STATUS_COMPLETE)
-        self.assertEqual(asset.file, saved_file_name)
-        self.assertNotEqual(asset.file_size, len(file_content))
-        self.assertTrue(asset.gzip)
+        self.assertFalse(asset.gzip)
 
         # should update bookmark modified date
         bookmark.refresh_from_db()
@@ -326,7 +283,7 @@ class AssetServiceTestCase(TestCase, BookmarkFactoryMixin):
 
         self.assertEqual(192, len(saved_file))
         self.assertTrue(saved_file.startswith("upload_"))
-        self.assertTrue(saved_file.endswith("aaaa.txt"))
+        self.assertTrue(saved_file.endswith("aaaa.txt.gz"))
 
     @disable_logging
     def test_upload_asset_failure(self):

--- a/bookmarks/tests/test_bookmark_assets_api.py
+++ b/bookmarks/tests/test_bookmark_assets_api.py
@@ -253,8 +253,8 @@ class BookmarkAssetsApiTestCase(LinkdingApiTestCase, BookmarkFactoryMixin):
         self.assertEqual(asset.display_name, file_name)
         self.assertEqual(asset.asset_type, BookmarkAsset.TYPE_UPLOAD)
         self.assertEqual(asset.content_type, "text/plain")
-        self.assertEqual(asset.file_size, len(file_content))
-        self.assertFalse(asset.gzip)
+        self.assertEqual(asset.file_size, self.get_asset_filesize(asset))
+        self.assertTrue(asset.gzip)
 
         content = self.read_asset_file(asset)
         self.assertEqual(content, file_content)


### PR DESCRIPTION
This adds the feature where files that are uploaded get gzip compressed to save space (and so they are similar to saved SingleFile snapshots).  
