### PR TITLE
Date-based hierarchical asset dir

### DIFF
--- a/bookmarks/services/assets.py
+++ b/bookmarks/services/assets.py
@@ -164,8 +164,15 @@ def _generate_asset_filename(
         else:
             return "_"
 
+    year = asset.date_created.strftime("%Y")
+    month = asset.date_created.strftime("%m")
     formatted_datetime = asset.date_created.strftime("%Y-%m-%d_%H%M%S")
     sanitized_filename = "".join(sanitize_char(char) for char in filename)
+
+    # Make sure directories exist
+    dir = os.path.join(settings.LD_ASSET_FOLDER, f"{year}/{month}")
+    if not os.path.exists(dir):
+        os.makedirs(dir)
 
     # Calculate the length of fixed parts of the final filename
     non_filename_length = len(f"{asset.asset_type}_{formatted_datetime}_.{extension}")
@@ -174,4 +181,4 @@ def _generate_asset_filename(
     # Truncate the filename if necessary
     sanitized_filename = sanitized_filename[:max_filename_length]
 
-    return f"{asset.asset_type}_{formatted_datetime}_{sanitized_filename}.{extension}"
+    return f"{year}/{month}/{asset.asset_type}_{formatted_datetime}_{sanitized_filename}.{extension}"

--- a/bookmarks/tests/test_assets_service.py
+++ b/bookmarks/tests/test_assets_service.py
@@ -33,11 +33,13 @@ class AssetServiceTestCase(TestCase, BookmarkFactoryMixin):
     def tearDown(self) -> None:
         self.mock_singlefile_create_snapshot_patcher.stop()
 
-    def get_saved_snapshot_file(self):
+    def get_saved_snapshot_file(
+        self, year=timezone.now().strftime("%Y"), month=timezone.now().strftime("%m")
+    ):
         # look up first file in the asset folder
-        files = os.listdir(self.assets_dir)
+        files = os.listdir(os.path.join(self.assets_dir, year, month))
         if files:
-            return files[0]
+            return os.path.join(year, month, files[0])
 
     def test_create_snapshot_asset(self):
         bookmark = self.setup_bookmark()
@@ -70,9 +72,13 @@ class AssetServiceTestCase(TestCase, BookmarkFactoryMixin):
         assets.create_snapshot(asset)
 
         expected_temp_filename = "snapshot_2023-08-11_214511_https___example.com.tmp"
-        expected_temp_filepath = os.path.join(self.assets_dir, expected_temp_filename)
+        expected_temp_filepath = os.path.join(
+            self.assets_dir, "2023", "08", expected_temp_filename
+        )
         expected_filename = "snapshot_2023-08-11_214511_https___example.com.html.gz"
-        expected_filepath = os.path.join(self.assets_dir, expected_filename)
+        expected_filepath = os.path.join(
+            self.assets_dir, "2023", "08", expected_filename
+        )
 
         # should call singlefile.create_snapshot with the correct arguments
         self.mock_singlefile_create_snapshot.assert_called_once_with(
@@ -93,7 +99,7 @@ class AssetServiceTestCase(TestCase, BookmarkFactoryMixin):
         # should update asset status and file
         asset.refresh_from_db()
         self.assertEqual(asset.status, BookmarkAsset.STATUS_COMPLETE)
-        self.assertEqual(asset.file, expected_filename)
+        self.assertEqual(asset.file, os.path.join("2023", "08", expected_filename))
         self.assertTrue(asset.gzip)
 
         # should update bookmark modified date
@@ -123,8 +129,10 @@ class AssetServiceTestCase(TestCase, BookmarkFactoryMixin):
 
         saved_file = self.get_saved_snapshot_file()
 
-        self.assertEqual(192, len(saved_file))
-        self.assertTrue(saved_file.startswith("snapshot_"))
+        self.assertEqual(200, len(saved_file))
+        year = timezone.now().strftime("%Y")
+        month = timezone.now().strftime("%m")
+        self.assertTrue(saved_file.startswith(f"{year}/{month}/snapshot_"))
         self.assertTrue(saved_file.endswith("aaaa.html.gz"))
 
     def test_upload_snapshot(self):
@@ -141,7 +149,9 @@ class AssetServiceTestCase(TestCase, BookmarkFactoryMixin):
         self.assertIsNotNone(saved_file_name)
 
         # verify file name
-        self.assertTrue(saved_file_name.startswith("snapshot_"))
+        year = timezone.now().strftime("%Y")
+        month = timezone.now().strftime("%m")
+        self.assertTrue(saved_file_name.startswith(f"{year}/{month}/snapshot_"))
         self.assertTrue(saved_file_name.endswith("_https___example.com.html.gz"))
 
         # gzip file should contain the correct content
@@ -184,8 +194,10 @@ class AssetServiceTestCase(TestCase, BookmarkFactoryMixin):
 
         saved_file = self.get_saved_snapshot_file()
 
-        self.assertEqual(192, len(saved_file))
-        self.assertTrue(saved_file.startswith("snapshot_"))
+        self.assertEqual(200, len(saved_file))
+        year = timezone.now().strftime("%Y")
+        month = timezone.now().strftime("%m")
+        self.assertTrue(saved_file.startswith(f"{year}/{month}/snapshot_"))
         self.assertTrue(saved_file.endswith("aaaa.html.gz"))
 
     @disable_logging
@@ -206,7 +218,9 @@ class AssetServiceTestCase(TestCase, BookmarkFactoryMixin):
         self.assertIsNotNone(upload_file)
 
         # verify file name
-        self.assertTrue(saved_file_name.startswith("upload_"))
+        year = timezone.now().strftime("%Y")
+        month = timezone.now().strftime("%m")
+        self.assertTrue(saved_file_name.startswith(f"{year}/{month}/upload_"))
         self.assertTrue(saved_file_name.endswith("_test_file.txt.gz"))
 
         # file should contain the correct content
@@ -245,7 +259,9 @@ class AssetServiceTestCase(TestCase, BookmarkFactoryMixin):
         self.assertIsNotNone(upload_file)
 
         # verify file name
-        self.assertTrue(saved_file_name.startswith("upload_"))
+        year = timezone.now().strftime("%Y")
+        month = timezone.now().strftime("%m")
+        self.assertTrue(saved_file_name.startswith(f"{year}/{month}/upload_"))
         self.assertTrue(saved_file_name.endswith("_test_file.html.gz"))
 
         # file should contain the correct content
@@ -281,8 +297,10 @@ class AssetServiceTestCase(TestCase, BookmarkFactoryMixin):
 
         saved_file = self.get_saved_snapshot_file()
 
-        self.assertEqual(192, len(saved_file))
-        self.assertTrue(saved_file.startswith("upload_"))
+        self.assertEqual(200, len(saved_file))
+        year = timezone.now().strftime("%Y")
+        month = timezone.now().strftime("%m")
+        self.assertTrue(saved_file.startswith(f"{year}/{month}/upload_"))
         self.assertTrue(saved_file.endswith("aaaa.txt.gz"))
 
     @disable_logging

--- a/bookmarks/tests/test_settings_export_view.py
+++ b/bookmarks/tests/test_settings_export_view.py
@@ -79,10 +79,12 @@ class SettingsExportViewTestCase(TestCase, BookmarkFactoryMixin):
 
     def test_filename_includes_date_and_time(self):
         self.setup_bookmark()
-        
+
         # Mock timezone.now to return a fixed datetime for predictable filename
-        fixed_time = datetime.datetime(2023, 5, 15, 14, 30, 45, tzinfo=datetime.timezone.utc)
-        
+        fixed_time = datetime.datetime(
+            2023, 5, 15, 14, 30, 45, tzinfo=datetime.timezone.utc
+        )
+
         with patch("bookmarks.views.settings.timezone.now", return_value=fixed_time):
             response = self.client.get(reverse("linkding:settings.export"), follow=True)
 


### PR DESCRIPTION
I have over 50,000 bookmarks and storing that many in a single asset directory and storing that many asset files in a single directory doesn't seem ideal.  This PR adds to `_generate_asset_filename()` the feature where it add `{year}/{month}` to the front of the filename and creates the directory/directories if they don't exist.  In all of my testing it's backward compatible... it leaves any existing assets as-is and just starts putting new assets into the "hierarchical" structure.  The tests have been updated as well.

Thank you