### PR TITLE
feat(ui): Display username in navigation menu  (issue #1106)

### DIFF
--- a/bookmarks/templates/bookmarks/nav_menu.html
+++ b/bookmarks/templates/bookmarks/nav_menu.html
@@ -2,6 +2,9 @@
 {% htmlmin %}
   {# Basic menu list #}
   <div class="hide-md">
+      {% if user.is_authenticated %}
+          <span class="btn btn-link mr-2">Hello, {{ user.username }}!</span>
+      {% endif %}
     <a href="{% url 'linkding:bookmarks.new' %}" class="btn btn-primary mr-2">Add bookmark</a>
     <div ld-dropdown class="dropdown">
       <button class="btn btn-link dropdown-toggle" tabindex="0">


### PR DESCRIPTION
Addresses issue #1106: "When a user logs in, can a username appear here? Because I have several usernames,"

This PR implements the requested feature from issue #1106 to display the currently logged-in user's username in the navigation menu. This enhancement improves usability for users with multiple accounts by providing a clear indication of the active session.

![Screenshot 2025-06-24 192641](https://github.com/user-attachments/assets/a4e3968c-a87b-434f-a3ee-d968d5cf0360)

Fixes #1106
