### PR TITLE
Add Pocket migration to to community page

### DIFF
--- a/docs/src/content/docs/community.md
+++ b/docs/src/content/docs/community.md
@@ -29,6 +29,6 @@ This section lists community projects around using linkding, in alphabetical ord
 - [linktiles](https://github.com/haondt/linktiles) A web app that displays your links as tiles in a configurable mosaic. By [haondt](https://github.com/haondt)
 - [Open all links bookmarklet](https://gist.github.com/ukcuddlyguy/336dd7339e6d35fc64a75ccfc9323c66) A browser bookmarklet to open all links on the current Linkding page in new tabs. By [ukcuddlyguy](https://github.com/ukcuddlyguy)
 - [Pinkt](https://github.com/fibelatti/pinboard-kotlin) An Android client for linkding. By [fibelatti](https://github.com/fibelatti)
+- [Pocket2Linkding](https://github.com/hkclark/Pocket2Linkding/) A tool to migrate from Mozilla Pocket to lingding. Preserves the date the link was added to pocket and any tags.
 - [Postman collection](https://gist.github.com/gingerbeardman/f0b42502f3bc9344e92ce63afd4360d3) a group of saved request templates for API testing. By [gingerbeardman](https://github.com/gingerbeardman)
 - [serchding](https://github.com/ldwgchen/serchding) Full-text search for linkding. By [ldwgchen](https://github.com/ldwgchen)
-- [Pocket2Linkding](https://github.com/hkclark/Pocket2Linkding/) A tool to migrate from Mozilla Pocket to lingding.  Preserves the date the link was added to pocket and any tags.

--- a/docs/src/content/docs/community.md
+++ b/docs/src/content/docs/community.md
@@ -31,3 +31,4 @@ This section lists community projects around using linkding, in alphabetical ord
 - [Pinkt](https://github.com/fibelatti/pinboard-kotlin) An Android client for linkding. By [fibelatti](https://github.com/fibelatti)
 - [Postman collection](https://gist.github.com/gingerbeardman/f0b42502f3bc9344e92ce63afd4360d3) a group of saved request templates for API testing. By [gingerbeardman](https://github.com/gingerbeardman)
 - [serchding](https://github.com/ldwgchen/serchding) Full-text search for linkding. By [ldwgchen](https://github.com/ldwgchen)
+- [Pocket2Linkding](https://github.com/hkclark/Pocket2Linkding/) A tool to migrate from Mozilla Pocket to lingding.  Preserves the date the link was added to pocket and any tags.


### PR DESCRIPTION
Updates the community page to include a link to [Pocket2Linkding](https://github.com/hkclark/Pocket2Linkding/).  With Mozilla Pocket shutting down on July 8, 2025 (the export service will be available through Oct 8, 2025), this could be a helpful tool for people looking to find a "home" after Pocket is dead.