### PR TITLE
Fix: Prevent layout issues caused by long bookmark title in detail view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -196,3 +196,6 @@ typings/
 /chromium-profile
 # direnv
 /.direnv
+
+.DS_Store
+PROJECT.md

--- a/bookmarks/styles/bookmark-details.css
+++ b/bookmarks/styles/bookmark-details.css
@@ -94,3 +94,9 @@
   flex-direction: column;
   gap: var(--unit-6);
 }
+
+.bookmark-title {
+  word-break: break-all;
+  overflow-wrap: break-word;
+  white-space: normal;
+}

--- a/bookmarks/templates/bookmarks/details/modal.html
+++ b/bookmarks/templates/bookmarks/details/modal.html
@@ -3,7 +3,7 @@
   <div class="modal-overlay"></div>
   <div class="modal-container" role="dialog" aria-modal="true">
     <div class="modal-header">
-      <h2>{{ details.bookmark.resolved_title }}</h2>
+      <h2 class="bookmark-title">{{ details.bookmark.resolved_title|slice:":150" }}{% if details.bookmark.resolved_title|length > 150 %}...{% endif %}</h2>
       <button class="close" aria-label="Close dialog">
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="2"
              stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">


### PR DESCRIPTION
This PR fixes layout issues on the bookmark detail (view) page caused by excessively long titles.
## Problem
1. **Overlong Titles**:
When a bookmark is created via the RESTful API, if the parsed title exceeds 512 characters, it is not limited, causing the detail view to break the layout.
(See attached image 1)
2. **URL as Title**:
When a URL is used as the title, it does not wrap, resulting in layout overflow.
(See attached image 2)
## Solution:
1. Limit the maximum length of bookmark titles displayed in the detail view.
2. Ensure that long titles and URLs will wrap appropriately to prevent layout overflow.
## Screenshots:
- Problem:
Image 1: ![image](https://github.com/user-attachments/assets/ef6e987c-6609-499f-bb4a-07abb7439d0c)
Image 2: ![image](https://github.com/user-attachments/assets/2b23c72b-2b5e-4940-8937-4206e38f3f05)

- Fixed:
![image](https://github.com/user-attachments/assets/73fe1a56-45e7-4718-bccd-224b86dca2ff)
![image](https://github.com/user-attachments/assets/c96cd64a-83d7-4bbc-be85-943f96fa5c67)
