### PR TITLE
fix upload issue when sending a wrong empty tag with spaces

### DIFF
--- a/bookmarks/models.py
+++ b/bookmarks/models.py
@@ -40,7 +40,7 @@ def parse_tag_string(tag_string: str, delimiter: str = ","):
         return []
     names = tag_string.strip().split(delimiter)
     # remove empty names, sanitize remaining names
-    names = [sanitize_tag_name(name) for name in names if name]
+    names = [sanitize_tag_name(name) for name in names if name.strip()]
     # remove duplicates
     names = unique(names, str.lower)
     names.sort(key=str.lower)

--- a/bookmarks/tests/test_tags_model.py
+++ b/bookmarks/tests/test_tags_model.py
@@ -40,6 +40,11 @@ class TagTestCase(TestCase):
         self.assertCountEqual(
             parse_tag_string("book,,movie,,,album"), ["album", "book", "movie"]
         )
+    
+    def test_parse_tag_string_handles_duplicate_separators_with_spaces(self):
+        self.assertCountEqual(
+            parse_tag_string("book, ,movie, , ,album"), ["album", "book", "movie"]
+        )
 
     def test_parse_tag_string_replaces_whitespace_within_names(self):
         self.assertCountEqual(


### PR DESCRIPTION
Notices a small issue when importing old bookmarks (exported from another tool). I had one entry that had a blank tag (see below between tensorflow and toread). There are spaces between separators, maybe this is an issue with the export of the other tool, but I suppose the import could be robust to this case.

<DT><A HREF="http://web.stanford.edu/class/cs20si/syllabus.html" LAST_VISIT="1489236019" ADD_DATE="1489236019" PRIVATE="1" TAGS="machinelearning ,tensorflow, ,toread">Stanford University: Tensorflow for Deep Learning Research</A>

This bookmarks file imported without error but then when running the app fails with  "string index out of range" in this location.

```
/home/pedro/git/my-fork-linkding/bookmarks/views/contexts.py, line 287, in _create_tag_groups_alphabetical
        group = None
        groups = []
        cjk_used = False
        cjk_group = TagGroup("Ideographic")
        # Group tags that start with a different character than the previous one
        for tag in sorted_tags:
            tag_char = tag.name[0].lower()
                            ^^^^^^^^^^^ …
            if CJK_RE.match(tag_char):
                cjk_used = True
                cjk_group.tags.append(tag)
            elif not group or group.char != tag_char:
                group = TagGroup(tag_char)
                groups.append(group)
```

I did run the tests on the proposed fix and tests passed ok.