### PR TITLE
Add CORS support

### DIFF
--- a/bookmarks/settings/base.py
+++ b/bookmarks/settings/base.py
@@ -33,6 +33,7 @@ ALLOWED_HOSTS = ["*"]
 
 INSTALLED_APPS = [
     "bookmarks.apps.BookmarksConfig",
+    "corsheaders",
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
@@ -225,6 +226,40 @@ if LD_ENABLE_AUTH_PROXY:
 trusted_origins = os.getenv("LD_CSRF_TRUSTED_ORIGINS", "")
 if trusted_origins:
     CSRF_TRUSTED_ORIGINS = trusted_origins.split(",")
+
+# CORS
+# https://pypi.org/project/django-cors-headers/
+cors_enabled = False
+cors_origins = os.getenv("LD_CORS_ALLOWED_ORIGINS", "")
+if cors_origins:
+    CORS_ALLOWED_ORIGINS = cors_origins.split(",")
+    cors_enabled = True
+
+cores_regex = os.getenv("LD_CORS_ALLOWED_REGEX", "")
+if cores_regex:
+    CORS_ALLOWED_ORIGIN_REGEXES = [cores_regex]
+    cors_enabled = True
+
+cors_all = os.getenv("LD_CORS_ALLOW_ALL", False) in (True, "True", "true", "1")
+if cors_all:
+    CORS_ALLOW_ALL_ORIGINS = True
+    cors_enabled = True
+
+if cors_enabled:
+    MIDDLEWARE.insert(0, "corsheaders.middleware.CorsMiddleware")
+    CORS_ALLOW_CREDENTIALS = os.getenv("LD_CORS_ALLOW_CREDENTIALS", False) in (True, "True", "true", "1")
+    CORS_URLS_REGEX = os.getenv("LD_CORS_URLS_REGEX", r"^/api/.*$")
+    cors_methods = os.getenv("LD_CORS_ALLOWED_METHODS", "")
+    if cors_methods:
+        CORS_ALLOW_METHODS = cors_methods.split(",")
+    CORS_ALLOW_HEADERS = os.getenv("LD_CORS_ALLOWED_HEADERS", "authorization,content-type").split(",")
+    cors_expose_headers = os.getenv("LD_CORS_EXPOSE_HEADERS", "")
+    if cors_expose_headers:
+        CORS_EXPOSE_HEADERS = cors_expose_headers.split(",")
+    cors_preflight_max_age = os.getenv("LD_CORS_PREFLIGHT_MAX_AGE")
+    if cors_preflight_max_age:
+        CORS_PREFLIGHT_MAX_AGE = int(cors_preflight_max_age)
+    CORS_ALLOW_PRIVATE_NETWORK = os.getenv("LD_CORS_ALLOW_PRIVATE_NETWORK", False) in (True, "True", "true", "1")
 
 # Database
 # https://docs.djangoproject.com/en/2.2/ref/settings/#databases

--- a/docs/src/content/docs/options.md
+++ b/docs/src/content/docs/options.md
@@ -179,6 +179,26 @@ identity_providers:
 
 </details>
 
+### `LD_CORS_*`
+
+If CORS support is needed, it can be enabled by setting one of three options:
+
+- `LD_CORS_ALLOWED_ORIGINS` - A comma-separated list of allowed Origins
+- `LD_CORS_ALLOWED_REGEX` - A regular expression that is matched to decide if the requested Origin is allowed. This setting roughly corresponds to `CORS_ALLOWED_ORIGIN_REGEXES` except that it only allows a single regular expression
+- `LD_CORS_ALLOW_ALL` - When set to `True`, all Origins are allowed
+
+Full details of how CORS headers are handled is available inside the [django-cors-headers](https://pypi.org/project/django-cors-headers/) documentation. Each environment variable corresponds to the corresponding django-cors-headers variable, but without the `LD_` prefix, except where noted.
+
+Once CORS is enabled, a number of other options are available, but most users should not need to modify them:
+
+- `LD_CORS_ALLOW_CREDENTIALS` - If `True`, cookies will be allowed to be included in cross-site HTTP requests
+- `LD_CORS_URLS_REGEX` - Regex which restricts the URL’s for which the CORS headers will be sent. The default is "`^/api/.*$`" 
+- `LD_CORS_ALLOWED_METHODS` - A list of HTTP verbs that are allowed for the actual request
+- `LD_CORS_ALLOWED_HEADERS` - Comma-separated list of "non-standard" HTTP headers to allow from the browser. Defaults to "`authorization,content-type`"
+- `LD_CORS_EXPOSE_HEADERS` - he list of extra HTTP headers to expose to the browser, in addition to the default safelisted headers
+- `LD_CORS_PREFLIGHT_MAX_AGE` - The number of seconds the browser can cache the preflight response
+- `LD_CORS_ALLOW_PRIVATE_NETWORK` - If `True`, allow requests from sites on "public" IP to this server on a "private" IP
+
 ### `LD_CSRF_TRUSTED_ORIGINS`
 
 Values: `String` | Default = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "bleach>=6.1.0",
     "bleach-allowlist>=1.0.3",
     "django>=5.2.3",
+    "django-cors-headers==4.9.0",
     "django-registration>=3.4",
     "django-widget-tweaks>=1.5.0",
     "djangorestframework>=3.15.2",

--- a/uv.lock
+++ b/uv.lock
@@ -260,6 +260,19 @@ wheels = [
 ]
 
 [[package]]
+name = "django-cors-headers"
+version = "4.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "django" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/39/55822b15b7ec87410f34cd16ce04065ff390e50f9e29f31d6d116fc80456/django_cors_headers-4.9.0.tar.gz", hash = "sha256:fe5d7cb59fdc2c8c646ce84b727ac2bca8912a247e6e68e1fb507372178e59e8", size = 21458, upload-time = "2025-09-18T10:40:52.326Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/d8/19ed1e47badf477d17fb177c1c19b5a21da0fd2d9f093f23be3fb86c5fab/django_cors_headers-4.9.0-py3-none-any.whl", hash = "sha256:15c7f20727f90044dcee2216a9fd7303741a864865f0c3657e28b7056f61b449", size = 12809, upload-time = "2025-09-18T10:40:50.843Z" },
+]
+
+[[package]]
 name = "django-debug-toolbar"
 version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -384,6 +397,7 @@ dependencies = [
     { name = "bleach" },
     { name = "bleach-allowlist" },
     { name = "django" },
+    { name = "django-cors-headers" },
     { name = "django-registration" },
     { name = "django-widget-tweaks" },
     { name = "djangorestframework" },
@@ -418,6 +432,7 @@ requires-dist = [
     { name = "bleach", specifier = ">=6.1.0" },
     { name = "bleach-allowlist", specifier = ">=1.0.3" },
     { name = "django", specifier = ">=5.2.3" },
+    { name = "django-cors-headers", specifier = "==4.9.0" },
     { name = "django-registration", specifier = ">=3.4" },
     { name = "django-widget-tweaks", specifier = ">=1.5.0" },
     { name = "djangorestframework", specifier = ">=3.15.2" },


### PR DESCRIPTION
Add CORS support to linkding. This is useful if you are running an alternate web-based frontend. By default, all CORS support is disabled, but once one of the documented environment variables are set, an additional Django middleware ([django-cors-headers](https://pypi.org/project/django-cors-headers/)) is added and configured appropriately.

This change:
- adds a new dependency `django-cors-headers` (which adds no additional net-new transitive dependencies)
- adds a number of new configuration parameters/environment variables
- documents the settings on the Options page

