### PR TITLE
Fix permission errors when building docker container

### DIFF
--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -79,6 +79,7 @@ ENV UWSGI_MAX_FD=4096
 EXPOSE 9090
 # Allow running containers as an an arbitrary user in the root group, to support deployment scenarios like OpenShift, Podman
 RUN chmod g+w . && \
+    chmod -R a+rX . && \
     chmod +x ./bootstrap.sh
 
 HEALTHCHECK --interval=30s --retries=3 --timeout=1s \

--- a/docker/default.Dockerfile
+++ b/docker/default.Dockerfile
@@ -77,6 +77,7 @@ ENV UWSGI_MAX_FD=4096
 EXPOSE 9090
 # Allow running containers as an an arbitrary user in the root group, to support deployment scenarios like OpenShift, Podman
 RUN chmod g+w . && \
+    chmod -R a+rX . && \
     chmod +x ./bootstrap.sh
 
 HEALTHCHECK --interval=30s --retries=3 --timeout=1s \

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -14,6 +14,7 @@ uid = www-data
 gid = www-data
 buffer-size = 8192
 die-on-term = true
+need-app = true
 
 if-env = LD_CONTEXT_PATH
 static-map = /%(_)static=static


### PR DESCRIPTION
When I tried to build the docker container locally, it failed to start because my default umask is more restrictive. As a result the python source files that got copied into the container ended up with `-rw-------` permissions and were not readable by the `uwsgi` user.

Also add `need-app=true` to `uwsgi.ini` for easier debugging when things don't work. Because of the permission errors inside the container, `uwsgi` was unable to load `bookmarks.wsgi` but it continued starting up anyways. Adding `need-app=true` causes `uwsgi` to fail and exit if it can't load the WSGI app for some reason. This makes it much easier to catch startup errors.