### PR TITLE
Redirect supervisord output to stdout in docker

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -29,6 +29,8 @@ chown -R www-data: /etc/linkding/data
 
 # Start background task processor using supervisord, unless explicitly disabled
 if [ "$LD_DISABLE_BACKGROUND_TASKS" != "True" ]; then
+  # when running under Docker send the logs to stdout so that Docker can collect them
+  sed -i -e 's/logfile=.*/logfile=\/dev\/stdout/; s/logfile_maxbytes=.*/logfile_maxbytes=0/' supervisord.conf
   supervisord -c supervisord.conf
 fi
 

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,6 +1,8 @@
 [supervisord]
 user=root
 loglevel=info
+logfile=supervisord.log
+logfile_maxbytes=50MB
 
 [program:jobs]
 user=www-data


### PR DESCRIPTION
When running services in docker it's usually most convenient to use docker's built-in log management that collects logs from container stdout. Having logs go to log files inside the container is much more cumbersome to work with.

Fixes #1123