### PR TITLE
Use filename when downloading asset through UI

### DIFF
--- a/bookmarks/api/routes.py
+++ b/bookmarks/api/routes.py
@@ -199,13 +199,10 @@ class BookmarkAssetViewSet(
                 if asset.gzip
                 else open(file_path, "rb")
             )
-            file_name = (
-                f"{asset.display_name}.html"
-                if asset.asset_type == BookmarkAsset.TYPE_SNAPSHOT
-                else asset.display_name
-            )
             response = StreamingHttpResponse(file_stream, content_type=content_type)
-            response["Content-Disposition"] = f'attachment; filename="{file_name}"'
+            response["Content-Disposition"] = (
+                f'attachment; filename="{asset.download_name}"'
+            )
             return response
         except FileNotFoundError:
             raise Http404("Asset file does not exist")

--- a/bookmarks/models.py
+++ b/bookmarks/models.py
@@ -133,6 +133,14 @@ class BookmarkAsset(models.Model):
     status = models.CharField(max_length=64, blank=False, null=False)
     gzip = models.BooleanField(default=False, null=False)
 
+    @property
+    def download_name(self):
+        return (
+            f"{self.display_name}.html"
+            if self.asset_type == BookmarkAsset.TYPE_SNAPSHOT
+            else self.display_name
+        )
+
     def save(self, *args, **kwargs):
         if self.file:
             try:

--- a/bookmarks/views/assets.py
+++ b/bookmarks/views/assets.py
@@ -31,7 +31,9 @@ def view(request, asset_id: int):
     asset = access.asset_read(request, asset_id)
     content = _get_asset_content(asset)
 
-    return HttpResponse(content, content_type=asset.content_type)
+    response = HttpResponse(content, content_type=asset.content_type)
+    response["Content-Disposition"] = f'inline; filename="{asset.download_name}"'
+    return response
 
 
 def read(request, asset_id: int):


### PR DESCRIPTION
Currently, the asset view response carries no information about the name of the asset. This is fine for viewing HTML snapshots in the browser, but downloading the asset defaults to a file name consisting of just the asset id (with no extension). This is especially cumbersome if the browser doesn't support displaying the file type itself - the browser might attempt to download the file directly without prompting for a file name, and the user will have to manually rename the file afterwards.

The asset download route in the API already handles this by using the display name of the asset in the Content-Disposition header. This PR reuses the same logic in the assets view, but with an "inline" disposition type so the browser will still attempt to display the file instead of downloading it. If the browser/user attempts to save the file to disk, the downloaded file now uses the display name by default.