### PR TITLE
Document API bundle filter

### DIFF
--- a/docs/src/content/docs/api.md
+++ b/docs/src/content/docs/api.md
@@ -37,6 +37,7 @@ Parameters:
 - `offset` - Index from which to start returning results
 - `modified_since` - Filter results to only include bookmarks modified after the specified date (format: ISO 8601, e.g. "2025-01-01T00:00:00Z")
 - `added_since` - Filter results to only include bookmarks added after the specified date (format: ISO 8601, e.g. "2025-05-29T00:00:00Z")
+- `bundle` - Filter results by bundle id to only include bookmarks matched by a given bundle
 
 Example response:
 


### PR DESCRIPTION
It's possible to filter bookmarks in the API by providing a bundle id, but this is not mentioned in the docs.