### PR TITLE
Fix error when filtering bookmark assets in the admin UI

### DIFF
--- a/bookmarks/admin.py
+++ b/bookmarks/admin.py
@@ -214,7 +214,7 @@ class AdminBookmarkAsset(admin.ModelAdmin):
 
     list_display = ("custom_display_name", "date_created", "status")
     search_fields = (
-        "custom_display_name",
+        "display_name",
         "file",
     )
     list_filter = ("status",)


### PR DESCRIPTION
Executing any search on `/admin/bookmarks/bookmarkasset/` results in a HTTP 500:

```
django.core.exceptions.FieldError: Cannot resolve keyword 'custom_display_name' into field. Choices are: asset_type, bookmark, bookmark_id, content_type, date_created, display_name, file, file_size, gzip, id, latest_snapshot, status
```

It seems that calculated display names are not supported as search fields. This PR changes the search field back to `display_name` to make searching work again. Unfortunately, this means that searching for a synthetic display name like `Bookmark Asset #42` is not supported.