### PR TITLE
Fix pagination links to use relative URLs

### DIFF
--- a/bookmarks/templatetags/pagination.py
+++ b/bookmarks/templatetags/pagination.py
@@ -14,7 +14,7 @@ register = template.Library()
 )
 def pagination(context, page: Page):
     request = context["request"]
-    base_url = request.build_absolute_uri(request.path)
+    base_url = request.path
 
     # remove page number and details from query parameters
     query_params = request.GET.copy()

--- a/bookmarks/tests/test_pagination_tag.py
+++ b/bookmarks/tests/test_pagination_tag.py
@@ -32,7 +32,7 @@ class PaginationTagTest(TestCase, BookmarkFactoryMixin):
         )
 
     def assertPrevLink(self, html: str, page_number: int, href: str = None):
-        href = href if href else "http://testserver/test?page={0}".format(page_number)
+        href = href if href else "/test?page={0}".format(page_number)
         self.assertInHTML(
             """
             <li class="page-item">
@@ -55,7 +55,7 @@ class PaginationTagTest(TestCase, BookmarkFactoryMixin):
         )
 
     def assertNextLink(self, html: str, page_number: int, href: str = None):
-        href = href if href else "http://testserver/test?page={0}".format(page_number)
+        href = href if href else "/test?page={0}".format(page_number)
         self.assertInHTML(
             """
             <li class="page-item">
@@ -76,7 +76,7 @@ class PaginationTagTest(TestCase, BookmarkFactoryMixin):
         href: str = None,
     ):
         active_class = "active" if active else ""
-        href = href if href else "http://testserver/test?page={0}".format(page_number)
+        href = href if href else "/test?page={0}".format(page_number)
         self.assertInHTML(
             """
             <li class="page-item {1}">
@@ -167,35 +167,35 @@ class PaginationTagTest(TestCase, BookmarkFactoryMixin):
         self.assertPrevLink(
             rendered_template,
             1,
-            href="http://testserver/test?q=cake&sort=title_asc&page=1",
+            href="/test?q=cake&sort=title_asc&page=1",
         )
         self.assertPageLink(
             rendered_template,
             1,
             False,
-            href="http://testserver/test?q=cake&sort=title_asc&page=1",
+            href="/test?q=cake&sort=title_asc&page=1",
         )
         self.assertPageLink(
             rendered_template,
             2,
             True,
-            href="http://testserver/test?q=cake&sort=title_asc&page=2",
+            href="/test?q=cake&sort=title_asc&page=2",
         )
         self.assertNextLink(
             rendered_template,
             3,
-            href="http://testserver/test?q=cake&sort=title_asc&page=3",
+            href="/test?q=cake&sort=title_asc&page=3",
         )
 
     def test_removes_details_parameter(self):
         rendered_template = self.render_template(
             100, 10, 2, url="/test?details=1&page=2"
         )
-        self.assertPrevLink(rendered_template, 1, href="http://testserver/test?page=1")
+        self.assertPrevLink(rendered_template, 1, href="/test?page=1")
         self.assertPageLink(
-            rendered_template, 1, False, href="http://testserver/test?page=1"
+            rendered_template, 1, False, href="/test?page=1"
         )
         self.assertPageLink(
-            rendered_template, 2, True, href="http://testserver/test?page=2"
+            rendered_template, 2, True, href="/test?page=2"
         )
-        self.assertNextLink(rendered_template, 3, href="http://testserver/test?page=3")
+        self.assertNextLink(rendered_template, 3, href="/test?page=3")


### PR DESCRIPTION
When I run the application in docker container and access it behind reverse proxy, I see all pagination links point to "localhost:8000" . 
This change fixes the absolute paths to relative (without host and port).