### PR TITLE
Allow sandboxed scripts when viewing assets

### DIFF
--- a/bookmarks/tests/test_bookmark_asset_view.py
+++ b/bookmarks/tests/test_bookmark_asset_view.py
@@ -151,7 +151,7 @@ class BookmarkAssetViewTestCase(TestCase, BookmarkFactoryMixin):
             response["Content-Disposition"],
             f'inline; filename="{asset.display_name}.html"',
         )
-        self.assertEqual(response["Content-Security-Policy"], "sandbox")
+        self.assertEqual(response["Content-Security-Policy"], "sandbox allow-scripts")
 
     def test_uploaded_file_download_headers(self):
         bookmark = self.setup_bookmark()
@@ -163,4 +163,4 @@ class BookmarkAssetViewTestCase(TestCase, BookmarkFactoryMixin):
             response["Content-Disposition"],
             f'inline; filename="{asset.display_name}"',
         )
-        self.assertEqual(response["Content-Security-Policy"], "sandbox")
+        self.assertEqual(response["Content-Security-Policy"], "sandbox allow-scripts")

--- a/bookmarks/views/assets.py
+++ b/bookmarks/views/assets.py
@@ -33,7 +33,7 @@ def view(request, asset_id: int):
 
     response = HttpResponse(content, content_type=asset.content_type)
     response["Content-Disposition"] = f'inline; filename="{asset.download_name}"'
-    response["Content-Security-Policy"] = "sandbox"
+    response["Content-Security-Policy"] = "sandbox allow-scripts"
     return response
 
 


### PR DESCRIPTION
Fixes https://github.com/sissbruecker/linkding/issues/1250