### PR TITLE
Add bundles explanation for new users

### DIFF
--- a/bookmarks/templates/bundles/index.html
+++ b/bookmarks/templates/bundles/index.html
@@ -52,7 +52,7 @@
     {% else %}
       <div class="empty">
         <p class="empty-title h5">You have no bundles yet</p>
-        <p class="empty-subtitle">Create your first bundle to get started</p>
+        <p class="empty-subtitle">Bundles are filtering presets with keywords and tags, create your first bundle to get started</p>
       </div>
     {% endif %}
   </main>


### PR DESCRIPTION
Change default bundle screen message to include explanation for new users from:
<img width="1006" height="293" alt="image" src="https://github.com/user-attachments/assets/a16a5be3-355c-4b59-86e3-09310aed666e" />

to:
<img width="1005" height="297" alt="image" src="https://github.com/user-attachments/assets/56111305-ee2a-4ed7-9726-693738b2edf9" />


I've had to look up issue #659 on github to find out what 'bundles' are for after having updated.  
It may be obvious for existing users, but having seen this for the first time, it doesn't clearly communicate it's purpose:   
<img width="1021" height="760" alt="image" src="https://github.com/user-attachments/assets/58dfac66-0a0c-413a-a3be-c132336de45b" />

Trying a feature out just to find out what it doesn't isn't a good user experience.  
Thanks for your consideration.