### PR TITLE
Make init command initialize data dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 init:
 	uv sync
+	[ -d data ] || mkdir data data/assets data/favicons data/previews
 	uv run manage.py migrate
 	npm install
 


### PR DESCRIPTION
When the project dir is checked out for the first time for a dev environment, the sqlite command fails with

    sqlite3.OperationalError: unable to open database file

which comes from the fact that the data dir does not yet exists, I have added a line to Makefile to create it

