### PR TITLE
Allow configuring session duration

### DIFF
--- a/bookmarks/settings/base.py
+++ b/bookmarks/settings/base.py
@@ -334,3 +334,6 @@ LD_SNAPSHOT_PDF_MAX_SIZE = int(os.getenv("LD_SNAPSHOT_PDF_MAX_SIZE", 15728640)) 
 # it turns out to be useful in the future.
 LD_MONOLITH_PATH = os.getenv("LD_MONOLITH_PATH", "monolith")
 LD_MONOLITH_OPTIONS = os.getenv("LD_MONOLITH_OPTIONS", "-a -v -s")
+
+# Allow override of the session cookie length, provided in seconds.
+SESSION_COOKIE_AGE = int(os.getenv("LD_SESSION_COOKIE_AGE", 1209600))  # 2 weeks

--- a/bookmarks/settings/base.py
+++ b/bookmarks/settings/base.py
@@ -180,6 +180,9 @@ HUEY = {
     },
 }
 
+# Allow override of the session cookie length, provided in seconds.
+SESSION_COOKIE_AGE = int(os.getenv("LD_SESSION_COOKIE_AGE", 1209600))  # 2 weeks
+
 # Disable login form if configured
 LD_DISABLE_LOGIN_FORM = os.getenv("LD_DISABLE_LOGIN_FORM", False) in (
     True,
@@ -334,6 +337,3 @@ LD_SNAPSHOT_PDF_MAX_SIZE = int(os.getenv("LD_SNAPSHOT_PDF_MAX_SIZE", 15728640)) 
 # it turns out to be useful in the future.
 LD_MONOLITH_PATH = os.getenv("LD_MONOLITH_PATH", "monolith")
 LD_MONOLITH_OPTIONS = os.getenv("LD_MONOLITH_OPTIONS", "-a -v -s")
-
-# Allow override of the session cookie length, provided in seconds.
-SESSION_COOKIE_AGE = int(os.getenv("LD_SESSION_COOKIE_AGE", 1209600))  # 2 weeks

--- a/docs/src/content/docs/options.md
+++ b/docs/src/content/docs/options.md
@@ -317,3 +317,9 @@ Example: `LD_SINGLEFILE_OPTIONS=--user-agent="Mozilla/5.0 (Macintosh; Intel Mac 
 Values: `true` or `false` | Default =  `false`
 
 Set uWSGI [disable-logging](https://uwsgi-docs.readthedocs.io/en/latest/Options.html#disable-logging) parameter to disable request logs, except for requests with a client (4xx) or server (5xx) error response.
+
+### `LD_SESSION_COOKIE_AGE`
+
+Values: `Integer` | Default = 1209600
+
+Set the length of the session cookie, in seconds. This value determines how long a browser will stay logged in to the web interface. Default value is 2 weeks.

--- a/docs/src/content/docs/options.md
+++ b/docs/src/content/docs/options.md
@@ -199,6 +199,12 @@ Disables the login form on the login page.
 This is useful when you want to enforce authentication through OIDC only.
 When enabled, users will not be able to log in using their username and password, and only the "Login with OIDC" button will be shown on the login page.
 
+### `LD_SESSION_COOKIE_AGE`
+
+Values: `Integer` as seconds | Default = `1209600`
+
+Set the lifetime of the session cookie, in seconds. This value determines how long a browser will stay logged in to the web interface. The default value is 2 weeks.
+
 ### `LD_CSRF_TRUSTED_ORIGINS`
 
 Values: `String` | Default = None
@@ -317,9 +323,3 @@ Example: `LD_SINGLEFILE_OPTIONS=--user-agent="Mozilla/5.0 (Macintosh; Intel Mac 
 Values: `true` or `false` | Default =  `false`
 
 Set uWSGI [disable-logging](https://uwsgi-docs.readthedocs.io/en/latest/Options.html#disable-logging) parameter to disable request logs, except for requests with a client (4xx) or server (5xx) error response.
-
-### `LD_SESSION_COOKIE_AGE`
-
-Values: `Integer` | Default = 1209600
-
-Set the length of the session cookie, in seconds. This value determines how long a browser will stay logged in to the web interface. Default value is 2 weeks.


### PR DESCRIPTION
Allows overriding [`SESSION_COOKIE_AGE`](https://docs.djangoproject.com/en/6.0/ref/settings/#session-cookie-age) via an environment variable, to support setting a longer session expiry when hosting in docker. The provided default value is the current Django default.

resolves #1226