### PR TITLE
[fixes #1194] add to LD_CSRF_TRUSTED_ORIGIN

### DIFF
--- a/bookmarks/settings/dev.py
+++ b/bookmarks/settings/dev.py
@@ -20,7 +20,7 @@ INTERNAL_IPS = [
 ]
 
 # Allow access through ngrok
-CSRF_TRUSTED_ORIGINS = ["https://*.ngrok-free.app"]
+CSRF_TRUSTED_ORIGINS.append("https://*.ngrok-free.app")
 
 STATICFILES_DIRS = [
     # Resolve theme files from style source folder


### PR DESCRIPTION
add ngrok domains to LD_CSRF_TRUSTED_ORIGIN in dev mode to avoid discarding a setting in the serve command
