### PR TITLE
Implement search for user in public shared feed

### DIFF
--- a/bookmarks/feeds.py
+++ b/bookmarks/feeds.py
@@ -112,10 +112,15 @@ class PublicSharedBookmarksFeed(BaseBookmarksFeed):
     description = "All public shared bookmarks"
 
     def get_object(self, request):
+        self.current_request = request
         return super().get_object(request, None)
 
     def get_query_set(self, feed_token: FeedToken, search: BookmarkSearch):
-        return queries.query_shared_bookmarks(None, UserProfile(), search, True)
+        qs = queries.query_shared_bookmarks(None, UserProfile(), search, True)
+        username = self.current_request.GET.get("user")
+        if username:
+            qs = qs.filter(owner__username__iexact=username)
+        return qs
 
     def link(self, context: FeedContext):
         return reverse("linkding:feeds.public_shared")


### PR DESCRIPTION
I like the shared bookmarks of a user (seen in Shaarli) very much, so I built the search into linkding.

Calling the shared feed URL without filter returns all shared bookmarks of the instance, but the call now also supports `?user=name` to filter shared bookmarks by user.

I'm not sure if this should also be mentioned in the integrations page, but for now, I'm fine knowing it's possible.

Regards,
Christoph