### PR TITLE
Fix crash on file upload with non-ASCII filename

### DIFF
--- a/bookmarks/services/assets.py
+++ b/bookmarks/services/assets.py
@@ -244,7 +244,7 @@ def _generate_asset_filename(
     asset: BookmarkAsset, filename: str, extension: str
 ) -> str:
     def sanitize_char(char):
-        if char.isalnum() or char in ("-", "_", "."):
+        if char.isascii() and (char.isalnum() or char in ("-", "_", ".")):
             return char
         else:
             return "_"

--- a/bookmarks/tests/test_assets_service.py
+++ b/bookmarks/tests/test_assets_service.py
@@ -407,6 +407,21 @@ class AssetServiceTestCase(TestCase, BookmarkFactoryMixin):
         bookmark.refresh_from_db()
         self.assertGreater(bookmark.date_modified, initial_modified)
 
+    def test_upload_asset_with_non_ascii_filename(self):
+        bookmark = self.setup_bookmark()
+        file_content = b"test content"
+        upload_file = SimpleUploadedFile(
+            "explodér.html", file_content, content_type="text/html"
+        )
+
+        asset = assets.upload_asset(bookmark, upload_file)
+
+        saved_file_name = self.get_saved_snapshot_file()
+        self.assertTrue(saved_file_name.startswith("upload_"))
+        self.assertTrue(saved_file_name.endswith("_explod_r.html.gz"))
+        self.assertEqual(self.read_asset_file(asset), file_content)
+        self.assertEqual(asset.display_name, "explodér.html")
+
     @disable_logging
     def test_upload_asset_truncates_asset_file_name(self):
         # Create a bookmark with a very long URL


### PR DESCRIPTION
Fixes #1348

**Problem**

Uploading a file with non-ASCII characters in its name (e.g. `explodér.html`) crashes with `UnicodeEncodeError` when `gzip.open()` tries to create the compressed file on systems where the filesystem encoding is ASCII — the default in many Docker containers.

The root cause is in `_generate_asset_filename`'s `sanitize_char`: it uses `char.isalnum()` which returns `True` for accented letters like `é` (`'é'.isalnum() → True`), so they pass through into the filesystem path. When Python then tries to open that path on an ASCII-encoded filesystem, it fails:

```
UnicodeEncodeError: 'ascii' codec can't encode character '\xe9' in position 73
```

**Fix**

Add `char.isascii()` as a guard so only ASCII alphanumeric characters (plus `-`, `_`, `.`) survive into the filename. Non-ASCII characters are replaced with `_`, same as spaces and other special characters already are. The original filename is still preserved in `display_name` for the UI.

**Tests**

Added a regression test that uploads a file named `explodér.html` and verifies:
- the asset file is created successfully (no crash)
- the sanitized filename replaces `é` with `_`
- the file content round-trips correctly through gzip
- `display_name` still shows the original filename

All 24 tests in `test_assets_service.py` pass.