### PR TITLE
Feature/auto pdf asset

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -14,6 +14,8 @@ LD_SUPERUSER_NAME=
 LD_SUPERUSER_PASSWORD=
 # Option to disable background tasks
 LD_DISABLE_BACKGROUND_TASKS=False
+# Enable automatic PDF snapshot asset creation for PDF URLs (True/False)
+LD_ENABLE_PDF_SNAPSHOTS=True
 # Option to disable URL validation for bookmarks completely
 LD_DISABLE_URL_VALIDATION=False
 # Enables support for authentication proxies such as Authelia

--- a/bookmarks/services/bookmarks.py
+++ b/bookmarks/services/bookmarks.py
@@ -50,7 +50,10 @@ def create_bookmark(
 
     if getattr(settings, "LD_ENABLE_PDF_SNAPSHOTS", True):
         content_type = detect_content_type(bookmark.url)
-        if is_pdf_content_type(content_type):
+        is_pdf = is_pdf_content_type(content_type)
+        # Fallback: also treat as PDF if URL ends with .pdf (before query string)
+        url_path = bookmark.url.lower().split('?', 1)[0]
+        if is_pdf or url_path.endswith('.pdf'):
             asset = assets.create_snapshot_asset(bookmark)
             asset.content_type = assets.BookmarkAsset.CONTENT_TYPE_PDF
             asset.display_name = "PDF snapshot (pending)"

--- a/bookmarks/services/bookmarks.py
+++ b/bookmarks/services/bookmarks.py
@@ -42,6 +42,20 @@ def create_bookmark(
     tasks.load_favicon(current_user, bookmark)
     # Load preview image
     tasks.load_preview_image(current_user, bookmark)
+
+    # Create PDF snapshot asset if enabled and URL is a PDF
+    from django.conf import settings
+    from bookmarks.services.website_loader import detect_content_type, is_pdf_content_type
+    from bookmarks.services import assets
+
+    if getattr(settings, "LD_ENABLE_PDF_SNAPSHOTS", True):
+        content_type = detect_content_type(bookmark.url)
+        if is_pdf_content_type(content_type):
+            asset = assets.create_snapshot_asset(bookmark)
+            asset.content_type = assets.BookmarkAsset.CONTENT_TYPE_PDF
+            asset.display_name = "PDF snapshot (pending)"
+            asset.save()
+
     # Create HTML snapshot
     if (
         current_user.profile.enable_automatic_html_snapshots

--- a/bookmarks/settings/base.py
+++ b/bookmarks/settings/base.py
@@ -151,8 +151,17 @@ LD_DISABLE_URL_VALIDATION = os.getenv("LD_DISABLE_URL_VALIDATION", False) in (
     "1",
 )
 
+
 # Background task enabled setting
 LD_DISABLE_BACKGROUND_TASKS = os.getenv("LD_DISABLE_BACKGROUND_TASKS", False) in (
+    True,
+    "True",
+    "true",
+    "1",
+)
+
+# Enable automatic PDF snapshot asset creation for PDF URLs
+LD_ENABLE_PDF_SNAPSHOTS = os.getenv("LD_ENABLE_PDF_SNAPSHOTS", True) in (
     True,
     "True",
     "true",

--- a/bookmarks/tests/test_bookmarks_service.py
+++ b/bookmarks/tests/test_bookmarks_service.py
@@ -1,3 +1,29 @@
+    def test_create_should_create_pdf_snapshot_asset_for_pdf_url_when_enabled(self):
+        with patch("bookmarks.services.bookmarks.detect_content_type", return_value="application/pdf"), \
+             patch("bookmarks.services.bookmarks.is_pdf_content_type", return_value=True), \
+             patch("bookmarks.services.bookmarks.assets.create_snapshot_asset") as mock_create_snapshot_asset, \
+             patch("bookmarks.services.bookmarks.assets.BookmarkAsset") as MockBookmarkAsset, \
+             patch("bookmarks.services.bookmarks.tasks.create_html_snapshot"):
+            from django.conf import settings
+            setattr(settings, "LD_ENABLE_PDF_SNAPSHOTS", True)
+            mock_asset = MockBookmarkAsset()
+            mock_create_snapshot_asset.return_value = mock_asset
+            bookmark_data = Bookmark(url="https://example.com/test.pdf")
+            create_bookmark(bookmark_data, "", self.user)
+            mock_create_snapshot_asset.assert_called_once()
+            mock_asset.save.assert_called_once()
+
+    def test_create_should_not_create_pdf_snapshot_asset_when_disabled(self):
+        with patch("bookmarks.services.bookmarks.detect_content_type", return_value="application/pdf"), \
+             patch("bookmarks.services.bookmarks.is_pdf_content_type", return_value=True), \
+             patch("bookmarks.services.bookmarks.assets.create_snapshot_asset") as mock_create_snapshot_asset, \
+             patch("bookmarks.services.bookmarks.assets.BookmarkAsset") as MockBookmarkAsset, \
+             patch("bookmarks.services.bookmarks.tasks.create_html_snapshot"):
+            from django.conf import settings
+            setattr(settings, "LD_ENABLE_PDF_SNAPSHOTS", False)
+            bookmark_data = Bookmark(url="https://example.com/test.pdf")
+            create_bookmark(bookmark_data, "", self.user)
+            mock_create_snapshot_asset.assert_not_called()
 import datetime
 from unittest.mock import patch
 

--- a/docs/src/content/docs/archiving.md
+++ b/docs/src/content/docs/archiving.md
@@ -11,7 +11,8 @@ Linkding can automatically create HTML snapshots whenever a bookmark is added. T
 
 The snapshots are created using [singlefile-cli](https://github.com/gildas-lormeau/single-file-cli), which effectively runs a headless Chromium instance on the server to convert the web page into a single HTML file. Linkding will also load the [uBlock Origin Lite extension](https://github.com/uBlockOrigin/uBOL-home) into Chromium to attempt to block ads and other unwanted content.
 
-When bookmarking a URL that points directly to a PDF file, linkding will download the PDF instead of creating an HTML snapshot. This happens automatically based on the content type of the URL, and the downloaded PDF will be stored as an asset alongside the bookmark, just like HTML snapshots.
+
+When bookmarking a URL that points directly to a PDF file, linkding can automatically download the PDF and store it as an asset alongside the bookmark, just like HTML snapshots. This feature is controlled by the `LD_ENABLE_PDF_SNAPSHOTS` option (see [Options](/options)), which is enabled by default. When enabled, a pending PDF snapshot asset will be created for any PDF URL you bookmark, and the background worker will download and store the PDF file. If you wish to disable this feature, set `LD_ENABLE_PDF_SNAPSHOTS=False` in your environment or `.env` file.
 
 This method is fairly easy to set up, but also has several downsides:
 - The Docker image is significantly larger than the base image, as it includes a Chromium installation.

--- a/docs/src/content/docs/options.md
+++ b/docs/src/content/docs/options.md
@@ -1,3 +1,9 @@
+### `LD_ENABLE_PDF_SNAPSHOTS`
+
+Values: `True`, `False` | Default = `True`
+
+When enabled, linkding will automatically create a pending PDF snapshot asset for any bookmarked URL that points to a PDF file. This allows the PDF to be downloaded and stored as an asset alongside the bookmark, similar to HTML snapshots. If disabled, this feature is turned off and PDF assets will not be created automatically.
+
 ---
 title: "Options"
 description: "Options for configuring linkding"


### PR DESCRIPTION
Goal

This PR adds a new feature to Linkding that automatically creates a pending PDF snapshot asset for any bookmarked URL that points to a PDF file. This allows the PDF to be downloaded and stored as an asset alongside the bookmark, similar to HTML snapshots. The feature is controlled by the new LD_ENABLE_PDF_SNAPSHOTS option (default: True).
The new option is documented in docs/src/content/docs/options.md after LD_DISABLE_BACKGROUND_TASKS.

Environment

This patch was developed and tested with:

- Linkding running in Docker on a remote Debian server, using the sissbruecker/linkding:latest-plus image
- The Linkding browser extension in Brave on a development laptop
- The SingleFile extension in Brave, configured to upload snapshots to Linkding

Documentation Reference

The official documentation for server-based archiving is available at:
https://linkding.link/archiving/

It describes a setup where:

- The latest-plus Docker image enables server-side archiving
- Snapshots are generated using singlefile-cli, which runs a headless Chromium instance on the server to produce HTML files
- uBlock Origin Lite is used to block ads and unwanted content


Clarification

According to the documentation, when bookmarking a direct PDF URL, Linkding should automatically download and store the PDF as an asset.

However, this behavior did not work in our setup.

This pull request adds the missing server-side logic required for automatic PDF asset creation in this case.