### PR TITLE
Docs - note for nginx users on bookmark importing

### DIFF
--- a/docs/src/content/docs/installation.md
+++ b/docs/src/content/docs/installation.md
@@ -142,6 +142,7 @@ location /linkding {
 }
 ```
 
+It's also wise to raise the default `client_body_buffer_size` up from 16k if you plan on importing large bookmark backups, if only temporarily.
 </details>
 
 Instead of configuring header forwarding in your proxy, you can also configure the URL from which you want to access your linkding instance with the  [`LD_CSRF_TRUSTED_ORIGINS` option](/options#ld_csrf_trusted_origins).


### PR DESCRIPTION
without altering the client_body_buffer_size, uploads would be restricted to around 40-50 bookmarks per file, since the default body is only 16k on 64-bit machines.