### PR TITLE
Add sort by modification date option

### DIFF
--- a/bookmarks/forms.py
+++ b/bookmarks/forms.py
@@ -249,6 +249,8 @@ class BookmarkSearchForm(forms.Form):
     SORT_CHOICES = [
         (BookmarkSearch.SORT_ADDED_ASC, "Added ↑"),
         (BookmarkSearch.SORT_ADDED_DESC, "Added ↓"),
+        (BookmarkSearch.SORT_MODIFIED_ASC, "Modified ↑"),
+        (BookmarkSearch.SORT_MODIFIED_DESC, "Modified ↓"),
         (BookmarkSearch.SORT_TITLE_ASC, "Title ↑"),
         (BookmarkSearch.SORT_TITLE_DESC, "Title ↓"),
     ]

--- a/bookmarks/models.py
+++ b/bookmarks/models.py
@@ -224,6 +224,8 @@ class BookmarkBundle(models.Model):
 class BookmarkSearch:
     SORT_ADDED_ASC = "added_asc"
     SORT_ADDED_DESC = "added_desc"
+    SORT_MODIFIED_ASC = "modified_asc"
+    SORT_MODIFIED_DESC = "modified_desc"
     SORT_TITLE_ASC = "title_asc"
     SORT_TITLE_DESC = "title_desc"
 

--- a/bookmarks/queries.py
+++ b/bookmarks/queries.py
@@ -296,6 +296,10 @@ def _base_bookmarks_query(
             query_set = query_set.order_by(order_field)
         elif search.sort == BookmarkSearch.SORT_TITLE_DESC:
             query_set = query_set.order_by(order_field).reverse()
+    elif search.sort == BookmarkSearch.SORT_MODIFIED_ASC:
+        query_set = query_set.order_by("date_modified")
+    elif search.sort == BookmarkSearch.SORT_MODIFIED_DESC:
+        query_set = query_set.order_by("-date_modified")
     elif search.sort == BookmarkSearch.SORT_ADDED_ASC:
         query_set = query_set.order_by("date_added")
     else:

--- a/bookmarks/queries.py
+++ b/bookmarks/queries.py
@@ -296,12 +296,12 @@ def _base_bookmarks_query(
             query_set = query_set.order_by(order_field)
         elif search.sort == BookmarkSearch.SORT_TITLE_DESC:
             query_set = query_set.order_by(order_field).reverse()
+    elif search.sort == BookmarkSearch.SORT_ADDED_ASC:
+        query_set = query_set.order_by("date_added")
     elif search.sort == BookmarkSearch.SORT_MODIFIED_ASC:
         query_set = query_set.order_by("date_modified")
     elif search.sort == BookmarkSearch.SORT_MODIFIED_DESC:
         query_set = query_set.order_by("-date_modified")
-    elif search.sort == BookmarkSearch.SORT_ADDED_ASC:
-        query_set = query_set.order_by("date_added")
     else:
         # Sort by date added, descending by default
         query_set = query_set.order_by("-date_added")

--- a/bookmarks/tests/test_queries.py
+++ b/bookmarks/tests/test_queries.py
@@ -1164,6 +1164,68 @@ class QueriesBasicTestCase(TestCase, BookmarkFactoryMixin):
         query = queries.query_bookmarks(self.user, self.profile, search)
         self.assertEqual(list(query), sorted_bookmarks)
 
+    def test_sort_by_date_modified_asc(self):
+        search = BookmarkSearch(sort=BookmarkSearch.SORT_MODIFIED_ASC)
+
+        bookmarks = [
+            self.setup_bookmark(
+                modified=timezone.datetime(2020, 1, 1, tzinfo=datetime.UTC)
+            ),
+            self.setup_bookmark(
+                modified=timezone.datetime(2021, 2, 1, tzinfo=datetime.UTC)
+            ),
+            self.setup_bookmark(
+                modified=timezone.datetime(2022, 3, 1, tzinfo=datetime.UTC)
+            ),
+            self.setup_bookmark(
+                modified=timezone.datetime(2023, 4, 1, tzinfo=datetime.UTC)
+            ),
+            self.setup_bookmark(
+                modified=timezone.datetime(2022, 5, 1, tzinfo=datetime.UTC)
+            ),
+            self.setup_bookmark(
+                modified=timezone.datetime(2021, 6, 1, tzinfo=datetime.UTC)
+            ),
+            self.setup_bookmark(
+                modified=timezone.datetime(2020, 7, 1, tzinfo=datetime.UTC)
+            ),
+        ]
+        sorted_bookmarks = sorted(bookmarks, key=lambda b: b.date_modified)
+
+        query = queries.query_bookmarks(self.user, self.profile, search)
+        self.assertEqual(list(query), sorted_bookmarks)
+
+    def test_sort_by_date_modified_desc(self):
+        search = BookmarkSearch(sort=BookmarkSearch.SORT_MODIFIED_DESC)
+
+        bookmarks = [
+            self.setup_bookmark(
+                modified=timezone.datetime(2020, 1, 1, tzinfo=datetime.UTC)
+            ),
+            self.setup_bookmark(
+                modified=timezone.datetime(2021, 2, 1, tzinfo=datetime.UTC)
+            ),
+            self.setup_bookmark(
+                modified=timezone.datetime(2022, 3, 1, tzinfo=datetime.UTC)
+            ),
+            self.setup_bookmark(
+                modified=timezone.datetime(2023, 4, 1, tzinfo=datetime.UTC)
+            ),
+            self.setup_bookmark(
+                modified=timezone.datetime(2022, 5, 1, tzinfo=datetime.UTC)
+            ),
+            self.setup_bookmark(
+                modified=timezone.datetime(2021, 6, 1, tzinfo=datetime.UTC)
+            ),
+            self.setup_bookmark(
+                modified=timezone.datetime(2020, 7, 1, tzinfo=datetime.UTC)
+            ),
+        ]
+        sorted_bookmarks = sorted(bookmarks, key=lambda b: b.date_modified, reverse=True)
+
+        query = queries.query_bookmarks(self.user, self.profile, search)
+        self.assertEqual(list(query), sorted_bookmarks)
+
     def setup_title_sort_data(self):
         # lots of combinations to test effective title logic
         bookmarks = [

--- a/bookmarks/tests/test_queries.py
+++ b/bookmarks/tests/test_queries.py
@@ -1169,7 +1169,13 @@ class QueriesBasicTestCase(TestCase, BookmarkFactoryMixin):
 
         bookmarks = [
             self.setup_bookmark(
-                modified=timezone.datetime(2020, 1, 1, tzinfo=datetime.UTC)
+                modified=timezone.datetime(2022, 5, 1, tzinfo=datetime.UTC)
+            ),
+            self.setup_bookmark(
+                modified=timezone.datetime(2020, 7, 1, tzinfo=datetime.UTC)
+            ),
+            self.setup_bookmark(
+                modified=timezone.datetime(2023, 4, 1, tzinfo=datetime.UTC)
             ),
             self.setup_bookmark(
                 modified=timezone.datetime(2021, 2, 1, tzinfo=datetime.UTC)
@@ -1178,16 +1184,10 @@ class QueriesBasicTestCase(TestCase, BookmarkFactoryMixin):
                 modified=timezone.datetime(2022, 3, 1, tzinfo=datetime.UTC)
             ),
             self.setup_bookmark(
-                modified=timezone.datetime(2023, 4, 1, tzinfo=datetime.UTC)
-            ),
-            self.setup_bookmark(
-                modified=timezone.datetime(2022, 5, 1, tzinfo=datetime.UTC)
+                modified=timezone.datetime(2020, 1, 1, tzinfo=datetime.UTC)
             ),
             self.setup_bookmark(
                 modified=timezone.datetime(2021, 6, 1, tzinfo=datetime.UTC)
-            ),
-            self.setup_bookmark(
-                modified=timezone.datetime(2020, 7, 1, tzinfo=datetime.UTC)
             ),
         ]
         sorted_bookmarks = sorted(bookmarks, key=lambda b: b.date_modified)
@@ -1200,28 +1200,30 @@ class QueriesBasicTestCase(TestCase, BookmarkFactoryMixin):
 
         bookmarks = [
             self.setup_bookmark(
-                modified=timezone.datetime(2020, 1, 1, tzinfo=datetime.UTC)
-            ),
-            self.setup_bookmark(
-                modified=timezone.datetime(2021, 2, 1, tzinfo=datetime.UTC)
-            ),
-            self.setup_bookmark(
-                modified=timezone.datetime(2022, 3, 1, tzinfo=datetime.UTC)
+                modified=timezone.datetime(2021, 6, 1, tzinfo=datetime.UTC)
             ),
             self.setup_bookmark(
                 modified=timezone.datetime(2023, 4, 1, tzinfo=datetime.UTC)
             ),
             self.setup_bookmark(
-                modified=timezone.datetime(2022, 5, 1, tzinfo=datetime.UTC)
+                modified=timezone.datetime(2020, 1, 1, tzinfo=datetime.UTC)
             ),
             self.setup_bookmark(
-                modified=timezone.datetime(2021, 6, 1, tzinfo=datetime.UTC)
+                modified=timezone.datetime(2022, 3, 1, tzinfo=datetime.UTC)
+            ),
+            self.setup_bookmark(
+                modified=timezone.datetime(2021, 2, 1, tzinfo=datetime.UTC)
             ),
             self.setup_bookmark(
                 modified=timezone.datetime(2020, 7, 1, tzinfo=datetime.UTC)
             ),
+            self.setup_bookmark(
+                modified=timezone.datetime(2022, 5, 1, tzinfo=datetime.UTC)
+            ),
         ]
-        sorted_bookmarks = sorted(bookmarks, key=lambda b: b.date_modified, reverse=True)
+        sorted_bookmarks = sorted(
+            bookmarks, key=lambda b: b.date_modified, reverse=True
+        )
 
         query = queries.query_bookmarks(self.user, self.profile, search)
         self.assertEqual(list(query), sorted_bookmarks)


### PR DESCRIPTION
Adds two new sort options to bookmark search: sort by modification date
ascending and descending.

Changes:
- Add SORT_MODIFIED_ASC and SORT_MODIFIED_DESC constants to BookmarkSearch
- Add sort logic in _base_bookmarks_query for the new options
- Add Modified ↑ / Modified ↓ choices to BookmarkSearchForm
- Add tests for new sort options

Closes https://github.com/sissbruecker/linkding/issues/1346
