### PR TITLE
Fix: Stored XSS via Reader View and SSRF via bookmark URL fetching

### DIFF
--- a/bookmarks/services/preview_image_loader.py
+++ b/bookmarks/services/preview_image_loader.py
@@ -34,6 +34,10 @@ def load_preview_image(url: str) -> str | None:
 
     image_url = metadata.preview_image
 
+    if not website_loader.is_safe_url(image_url):
+        logger.debug(f"Blocked request to internal IP for preview image: {image_url}")
+        return None
+
     logger.debug(f"Loading preview image: {image_url}")
     with requests.get(image_url, stream=True) as response:
         if response.status_code < 200 or response.status_code >= 300:

--- a/bookmarks/services/website_loader.py
+++ b/bookmarks/services/website_loader.py
@@ -1,7 +1,9 @@
+import ipaddress
 import logging
+import socket
 from dataclasses import dataclass
 from functools import lru_cache
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 
 import requests
 from bs4 import BeautifulSoup
@@ -9,6 +11,39 @@ from charset_normalizer import from_bytes
 from django.utils import timezone
 
 logger = logging.getLogger(__name__)
+
+# Private/internal IP ranges blocked for SSRF protection
+BLOCKED_NETWORKS = [
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("169.254.0.0/16"),
+    ipaddress.ip_network("0.0.0.0/32"),
+    ipaddress.ip_network("0.0.0.0/8"),  # "This" network
+    ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("fc00::/7"),  # Unique local addresses
+]
+
+
+def is_safe_url(url: str) -> bool:
+    """Check if URL hostname resolves to a safe (non-internal) IP address.
+
+    Returns False for private/internal IPs, True otherwise.
+    Used to prevent SSRF attacks when fetching bookmark URLs.
+    """
+    try:
+        hostname = urlparse(url).hostname
+        if not hostname:
+            return False
+        ip = ipaddress.ip_address(socket.gethostbyname(hostname))
+        for network in BLOCKED_NETWORKS:
+            if ip in network:
+                logger.warning(f"Blocked request to internal IP: {hostname} ({ip})")
+                return False
+        return True
+    except Exception:
+        return False
 
 
 @dataclass
@@ -94,6 +129,8 @@ MAX_CONTENT_LIMIT = 5000 * 1024
 
 
 def load_page(url: str):
+    if not is_safe_url(url):
+        raise ValueError(f"Request to internal/private IP is blocked: {url}")
     headers = fake_request_headers()
     size = 0
     content = None
@@ -143,6 +180,8 @@ def fake_request_headers():
 
 def detect_content_type(url: str, timeout: int = 10) -> str | None:
     """Make HEAD request to detect content type of URL. Returns None on failure."""
+    if not is_safe_url(url):
+        return None
     headers = fake_request_headers()
 
     try:

--- a/bookmarks/views/assets.py
+++ b/bookmarks/views/assets.py
@@ -47,10 +47,12 @@ def read(request, asset_id: int):
     content = _get_asset_content(asset)
     content = content.decode("utf-8")
 
-    return render(
+    response = render(
         request,
         "bookmarks/read.html",
         {
             "content": content,
         },
     )
+    response["Content-Security-Policy"] = "sandbox allow-scripts"
+    return response


### PR DESCRIPTION
## Summary

This PR fixes two security vulnerabilities:

### 1. Stored XSS via HTML Snapshot in Reader View (CVSS 9.6)
The  endpoint in  was rendering HTML content with the  template filter without a Content-Security-Policy header. This bypassed the CVE-2025-14202 sandbox fix that was applied to the  endpoint.

**Fix:** Added  header to the  endpoint response, matching the existing protection on the  endpoint.

### 2. SSRF via Unvalidated Bookmark URLs (CVSS 8.2)
The  and  services made HTTP requests to user-supplied bookmark URLs without validating the destination hostname. This allowed attackers to force the server to make requests to internal/private IP addresses.

**Fix:** Added  validation function that resolves the URL hostname and blocks requests to private/internal IP ranges:
- 127.0.0.0/8 (loopback)
- 10.0.0.0/8 (private)
- 172.16.0.0/12 (private)
- 192.168.0.0/16 (private)
- 169.254.0.0/16 (link-local)
- 0.0.0.0/8 ("this" network)
- ::1/128 (IPv6 loopback)
- fc00::/7 (IPv6 unique local)

The validation is applied to all three request sites:
-  - raises ValueError for blocked URLs
-  - returns None for blocked URLs
-  - returns None for blocked preview image URLs

### Files Changed
-  - Added CSP header to read() endpoint
-  - Added SSRF protection with is_safe_url()
-  - Added SSRF check for preview image URLs