### PR TITLE
Escape tag names in HTML export

### DIFF
--- a/bookmarks/services/exporter.py
+++ b/bookmarks/services/exporter.py
@@ -35,7 +35,7 @@ def append_bookmark(doc: BookmarkDocument, bookmark: Bookmark):
     tag_names = bookmark.tag_names
     if bookmark.is_archived:
         tag_names.append("linkding:bookmarks.archived")
-    tags = ",".join(tag_names)
+    tags = ",".join(html.escape(tag) for tag in tag_names)
     toread = "1" if bookmark.unread else "0"
     private = "0" if bookmark.shared else "1"
     added = int(bookmark.date_added.timestamp())

--- a/bookmarks/tests/test_exporter.py
+++ b/bookmarks/tests/test_exporter.py
@@ -96,6 +96,7 @@ class ExporterTestCase(TestCase, BookmarkFactoryMixin):
             title="<style>: The Style Information element",
             description="The <style> HTML element contains style information for a document, or part of a document.",
             notes="Interesting notes about the <style> HTML element.",
+            tags=[self.setup_tag(name='"'), self.setup_tag(name="&")],
         )
         html = exporter.export_netscape_html([bookmark])
 
@@ -105,6 +106,7 @@ class ExporterTestCase(TestCase, BookmarkFactoryMixin):
             html,
         )
         self.assertIn("Interesting notes about the &lt;style&gt; HTML element.", html)
+        self.assertIn('TAGS="&quot;,&amp;"', html)
 
     def test_handle_empty_values(self):
         bookmark = self.setup_bookmark()


### PR DESCRIPTION
Fixes #1377.