### PR TITLE
Clarify auto tagging behavior in API docs

### DIFF
--- a/docs/src/content/docs/api.md
+++ b/docs/src/content/docs/api.md
@@ -167,10 +167,13 @@ PATCH /api/bookmarks/<id>/
 ```
 
 Updates a bookmark.
-When using `POST`, at least all required fields must be provided (currently only `url`).
+When using `PUT`, at least all required fields must be provided (currently only `url`).
 When using `PATCH`, only the fields that should be updated need to be provided.
 Regardless which method is used, any field that is not provided is not modified.
 Tags are simply assigned using their names.
+
+Note that [auto tagging](/auto-tagging) rules are applied on every update: tags from
+matching rules are merged into `tag_names`, even if the request does not include that field.
 
 If the provided URL is already bookmarked this returns an error.
 

--- a/docs/src/content/docs/auto-tagging.md
+++ b/docs/src/content/docs/auto-tagging.md
@@ -48,7 +48,7 @@ Consider the following auto tagging rule:
 reddit.com/r/Music music reddit
 ```
 
-When adding or editing a bookmark for a URL like `https://www.reddit.com/r/Music/comments/...`, the auto tagging mechanism will:
+When adding a bookmark for a URL like `https://www.reddit.com/r/Music/comments/...`, the auto tagging mechanism will:
 
 1. Parse the URL to extract the hostname (`www.reddit.com`), path (`/r/Music/comments/...`), and query string (none).
 2. Match the hostname against the pattern. The domain `reddit.com` matches. Since the rule does not specify a subdomain,

--- a/docs/src/content/docs/auto-tagging.md
+++ b/docs/src/content/docs/auto-tagging.md
@@ -48,7 +48,7 @@ Consider the following auto tagging rule:
 reddit.com/r/Music music reddit
 ```
 
-When adding a bookmark for a URL like `https://www.reddit.com/r/Music/comments/...`, the auto tagging mechanism will:
+When adding or editing a bookmark for a URL like `https://www.reddit.com/r/Music/comments/...`, the auto tagging mechanism will:
 
 1. Parse the URL to extract the hostname (`www.reddit.com`), path (`/r/Music/comments/...`), and query string (none).
 2. Match the hostname against the pattern. The domain `reddit.com` matches. Since the rule does not specify a subdomain,


### PR DESCRIPTION
When auto tagging rules are configured, tags from matching rules are merged into `tag_names` on every update, **including** partial updates that do not touch url or `tag_names`. Fixes a typo in the same section : `PUT` instead of `POST`.

Auto-tagging documentation : updates the example.
