### PR TITLE
Support deleting tags through the API

### DIFF
--- a/bookmarks/api/routes.py
+++ b/bookmarks/api/routes.py
@@ -251,6 +251,7 @@ class TagViewSet(
     mixins.ListModelMixin,
     mixins.RetrieveModelMixin,
     mixins.CreateModelMixin,
+    mixins.DestroyModelMixin,
 ):
     request: HttpRequest
     serializer_class = TagSerializer

--- a/bookmarks/tests/test_tags_api.py
+++ b/bookmarks/tests/test_tags_api.py
@@ -1,0 +1,41 @@
+from django.urls import reverse
+from rest_framework import status
+
+from bookmarks.models import Bookmark, Tag
+from bookmarks.tests.helpers import BookmarkFactoryMixin, LinkdingApiTestCase
+
+
+class TagsApiTestCase(LinkdingApiTestCase, BookmarkFactoryMixin):
+    def test_delete_tag(self):
+        self.authenticate()
+
+        tag = self.setup_tag()
+
+        url = reverse("linkding:tag-detail", kwargs={"pk": tag.id})
+        self.delete(url, expected_status_code=status.HTTP_204_NO_CONTENT)
+
+        self.assertFalse(Tag.objects.filter(id=tag.id).exists())
+
+    def test_delete_tag_keeps_tagged_bookmarks(self):
+        self.authenticate()
+
+        tag = self.setup_tag()
+        bookmark = self.setup_bookmark(tags=[tag])
+
+        url = reverse("linkding:tag-detail", kwargs={"pk": tag.id})
+        self.delete(url, expected_status_code=status.HTTP_204_NO_CONTENT)
+
+        self.assertFalse(Tag.objects.filter(id=tag.id).exists())
+        self.assertTrue(Bookmark.objects.filter(id=bookmark.id).exists())
+        self.assertEqual(bookmark.tags.count(), 0)
+
+    def test_can_not_delete_tag_of_other_user(self):
+        self.authenticate()
+
+        other_user = self.setup_user()
+        tag = self.setup_tag(user=other_user)
+
+        url = reverse("linkding:tag-detail", kwargs={"pk": tag.id})
+        self.delete(url, expected_status_code=status.HTTP_404_NOT_FOUND)
+
+        self.assertTrue(Tag.objects.filter(id=tag.id).exists())

--- a/docs/src/content/docs/api.md
+++ b/docs/src/content/docs/api.md
@@ -359,6 +359,14 @@ Example payload:
 }
 ```
 
+**Delete**
+
+```
+DELETE /api/tags/<id>/
+```
+
+Deletes a tag by ID.
+
 ### Bundles
 
 **List**


### PR DESCRIPTION
The tags API supports list, retrieve, and create but not delete, so a tag can currently only be removed through the web UI. This adds `DELETE /api/tags/<id>/` by giving `TagViewSet` the `DestroyModelMixin` that `BookmarkViewSet` already has.

Deletion is scoped to the requesting user through the existing `get_queryset`, so a user can only delete their own tags — a tag owned by another user returns 404. Deleting a tag unassigns it from any bookmarks and leaves the bookmarks intact, matching the web UI's tag delete.

Includes tests for delete, delete of a tag that's applied to a bookmark, and the cross-user 404, plus an entry in the API reference.

---

_Drafted with Claude Code, reviewed by me before opening._
