### PR TITLE
Fix uBlock Chromium release selection

### DIFF
--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -88,13 +88,14 @@ CMD ["./bootstrap.sh"]
 FROM node:22-alpine AS ublock-build
 WORKDIR /etc/linkding
 # Install necessary tools
-# Download and unzip the latest uBlock Origin Lite release
+# Download and unzip the latest uBlock Origin Lite release with a Chromium asset
 # Patch manifest to enable annoyances by default
 RUN apk add --no-cache curl jq unzip && \
-    TAG=$(curl -sL https://api.github.com/repos/uBlockOrigin/uBOL-home/releases/latest | jq -r '.tag_name') && \
-    DOWNLOAD_URL=https://github.com/uBlockOrigin/uBOL-home/releases/download/$TAG/uBOLite_$TAG.chromium.zip && \
+    DOWNLOAD_URL=$(curl -fsSL "https://api.github.com/repos/uBlockOrigin/uBOL-home/releases?per_page=20" | \
+        jq -r 'first(.[] | .assets[] | select(.name | endswith(".chromium.zip")) | .browser_download_url) // empty') && \
+    test -n "$DOWNLOAD_URL" && \
     echo "Downloading $DOWNLOAD_URL" && \
-    curl -L -o uBOLite.zip $DOWNLOAD_URL && \
+    curl -fL -o uBOLite.zip "$DOWNLOAD_URL" && \
     unzip uBOLite.zip -d uBOLite.chromium.mv3 && \
     rm uBOLite.zip && \
     jq '.declarative_net_request.rule_resources |= map(if .id == "annoyances-overlays" or .id == "annoyances-cookies" or .id == "annoyances-social" or .id == "annoyances-widgets" or .id == "annoyances-others" then .enabled = true else . end)' \

--- a/docker/default.Dockerfile
+++ b/docker/default.Dockerfile
@@ -83,13 +83,14 @@ CMD ["./bootstrap.sh"]
 FROM node:22-alpine AS ublock-build
 WORKDIR /etc/linkding
 # Install necessary tools
-# Download and unzip the latest uBlock Origin Lite release
+# Download and unzip the latest uBlock Origin Lite release with a Chromium asset
 # Patch manifest to enable annoyances by default
 RUN apk add --no-cache curl jq unzip && \
-    TAG=$(curl -sL https://api.github.com/repos/uBlockOrigin/uBOL-home/releases/latest | jq -r '.tag_name') && \
-    DOWNLOAD_URL=https://github.com/uBlockOrigin/uBOL-home/releases/download/$TAG/uBOLite_$TAG.chromium.zip && \
+    DOWNLOAD_URL=$(curl -fsSL "https://api.github.com/repos/uBlockOrigin/uBOL-home/releases?per_page=20" | \
+        jq -r 'first(.[] | .assets[] | select(.name | endswith(".chromium.zip")) | .browser_download_url) // empty') && \
+    test -n "$DOWNLOAD_URL" && \
     echo "Downloading $DOWNLOAD_URL" && \
-    curl -L -o uBOLite.zip $DOWNLOAD_URL && \
+    curl -fL -o uBOLite.zip "$DOWNLOAD_URL" && \
     unzip uBOLite.zip -d uBOLite.chromium.mv3 && \
     rm uBOLite.zip && \
     jq '.declarative_net_request.rule_resources |= map(if .id == "annoyances-overlays" or .id == "annoyances-cookies" or .id == "annoyances-social" or .id == "annoyances-widgets" or .id == "annoyances-others" then .enabled = true else . end)' \

--- a/scripts/setup-ublock.sh
+++ b/scripts/setup-ublock.sh
@@ -1,10 +1,11 @@
 rm -rf uBOLite.chromium.mv3
 
-# Download uBlock Origin Lite
-TAG=$(curl -sL https://api.github.com/repos/uBlockOrigin/uBOL-home/releases/latest | jq -r '.tag_name')
-DOWNLOAD_URL=https://github.com/uBlockOrigin/uBOL-home/releases/download/$TAG/uBOLite_$TAG.chromium.zip
+# Download the latest uBlock Origin Lite release with a Chromium asset
+DOWNLOAD_URL=$(curl -fsSL "https://api.github.com/repos/uBlockOrigin/uBOL-home/releases?per_page=20" | \
+  jq -r 'first(.[] | .assets[] | select(.name | endswith(".chromium.zip")) | .browser_download_url) // empty')
+test -n "$DOWNLOAD_URL" || exit 1
 echo "Downloading $DOWNLOAD_URL"
-curl -L -o uBOLite.zip $DOWNLOAD_URL
+curl -fL -o uBOLite.zip "$DOWNLOAD_URL"
 unzip uBOLite.zip -d uBOLite.chromium.mv3
 rm uBOLite.zip
 


### PR DESCRIPTION
## Summary

- select the newest uBlock Origin Lite release that actually contains a Chromium ZIP
- use the asset's API-provided download URL instead of constructing one from the latest tag
- fail clearly when the API returns no compatible asset
- apply the same logic to both Docker variants and the local setup script

Closes #1368

## Validation

- `docker build --target ublock-build -f docker/default.Dockerfile .`
- live GitHub release selector returned a valid Chromium asset
- `sh -n scripts/setup-ublock.sh`
- `git diff --check`