### PR TITLE
Harden the Docker build and CI workflows

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -7,29 +7,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build latest
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: ./docker/default.Dockerfile
@@ -42,7 +42,7 @@ jobs:
           cache-to: type=registry,ref=ghcr.io/sissbruecker/linkding:buildcache,mode=max
 
       - name: Build latest-alpine
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: ./docker/alpine.Dockerfile
@@ -55,7 +55,7 @@ jobs:
           cache-to: type=registry,ref=ghcr.io/sissbruecker/linkding:buildcache-alpine,mode=max
 
       - name: Build latest-plus
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: ./docker/default.Dockerfile
@@ -68,7 +68,7 @@ jobs:
           cache-to: type=registry,ref=ghcr.io/sissbruecker/linkding:buildcache,mode=max
 
       - name: Build latest-plus-alpine
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: ./docker/alpine.Dockerfile

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -2,6 +2,11 @@ name: build-test
 
 on: workflow_dispatch
 
+permissions:
+  contents: read
+  # Pushing the images to ghcr.io uses the workflow token.
+  packages: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,6 +2,11 @@ name: build
 
 on: workflow_dispatch
 
+permissions:
+  contents: read
+  # Pushing the images to ghcr.io uses the workflow token.
+  packages: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,33 +7,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Read version from file
         id: get_version
         run: echo "VERSION=$(cat version.txt)" >> $GITHUB_ENV
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build latest
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: ./docker/default.Dockerfile
@@ -49,7 +49,7 @@ jobs:
           cache-to: type=registry,ref=ghcr.io/sissbruecker/linkding:buildcache,mode=max
 
       - name: Build latest-alpine
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: ./docker/alpine.Dockerfile
@@ -65,7 +65,7 @@ jobs:
           cache-to: type=registry,ref=ghcr.io/sissbruecker/linkding:buildcache-alpine,mode=max
 
       - name: Build latest-plus
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: ./docker/default.Dockerfile
@@ -81,7 +81,7 @@ jobs:
           cache-to: type=registry,ref=ghcr.io/sissbruecker/linkding:buildcache,mode=max
 
       - name: Build latest-plus-alpine
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: ./docker/alpine.Dockerfile

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,15 +11,15 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.13"
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
           cache: 'npm'
@@ -35,15 +35,15 @@ jobs:
     name: E2E Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.13"
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
           cache: 'npm'
@@ -62,7 +62,7 @@ jobs:
         run: uv run pytest bookmarks/tests_e2e -n auto -o "python_files=e2e_test_*.py"
       - name: Upload screenshots
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: e2e-screenshots
           path: test-results/screenshots

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,6 +6,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   unit_tests:
     name: Unit Tests


### PR DESCRIPTION
Two small commits, nothing about how the builds run changes.

**Pin the actions by commit SHA.** The build workflows log into Docker Hub and ghcr.io and push the release images. Every action they use was referenced by a version tag, and a tag is a movable pointer, whoever controls the action repository can point it at different code and the next dispatched build runs it with the registry credentials in scope. The tj-actions/changed-files incident (CVE-2025-30066) rewrote tags exactly this way to leak CI secrets. A commit SHA cannot be moved. Each pin keeps the version as a trailing comment so it can be checked against the action's releases page, and versions stay exactly where they were. If you ever enable Dependabot or Renovate for github-actions, both understand this format and keep the pins updated.

**Declare token permissions.** The two Docker build workflows keep `packages: write` for the ghcr.io push and everything else drops to read only. The test workflow never writes through the token at all, so a compromised step there can no longer push images or touch the repository.

One heads-up: if you ever restrict allowed actions in the repo settings with tag patterns like `owner/action@v3`, those patterns stop matching SHA refs and workflows fail at startup, the fix is `owner/action@*` there. Nothing to do if no such restriction is configured.

Found and fixed by [Plumber](https://github.com/getplumber/plumber)'s analysis, reviewed and submitted by me.