### PR TITLE
fix: replace bare except with except Exception

### DIFF
--- a/bookmarks/settings/__init__.py
+++ b/bookmarks/settings/__init__.py
@@ -2,5 +2,5 @@
 # ruff: noqa
 try:
     from .dev import *
-except:
+except Exception:
     from .prod import *

--- a/bookmarks/settings/prod.py
+++ b/bookmarks/settings/prod.py
@@ -18,7 +18,7 @@ DEBUG = False
 try:
     with open(os.path.join(BASE_DIR, "data", "secretkey.txt")) as f:
         SECRET_KEY = f.read().strip()
-except:
+except Exception:
     SECRET_KEY = get_random_secret_key()
 
 # Set ALLOWED_HOSTS


### PR DESCRIPTION

### Summary

Two bare `except:` clauses in settings catch everything, including
`KeyboardInterrupt`/`SystemExit`:

- `bookmarks/settings/prod.py` — fall back to a random secret key when the
  key file cannot be read
- `bookmarks/settings/__init__.py` — fall back to production settings when
  dev settings are unavailable

Replace with `except Exception:` — same intended fallback behavior, but
unexpected exceptions now propagate.

### Verification

- `python -m py_compile` on both files → OK

### Files changed

- `bookmarks/settings/prod.py` (1 line)
- `bookmarks/settings/__init__.py` (1 line)