### PR TITLE
Fix title for user-filtered public RSS feeds

### DIFF
--- a/bookmarks/feeds.py
+++ b/bookmarks/feeds.py
@@ -116,8 +116,15 @@ class SharedBookmarksFeed(BaseBookmarksFeed):
 
 
 class PublicSharedBookmarksFeed(BaseBookmarksFeed):
-    title = "Public shared bookmarks"
     description = "All public shared bookmarks"
+
+    def title(self, context: FeedContext):
+        username = context.request.GET.get("user")
+        return (
+            f"Public shared bookmarks ({username})"
+            if username
+            else "Public shared bookmarks"
+        )
 
     def get_object(self, request):
         return super().get_object(request, None)

--- a/bookmarks/tests/test_feeds.py
+++ b/bookmarks/tests/test_feeds.py
@@ -276,6 +276,9 @@ class FeedsTestCase(TestCase, BookmarkFactoryMixin):
         response = self.client.get(feed_url + f"?user={user1.username}")
         self.assertEqual(response.status_code, 200)
         self.assertFeedItems(response, user1_bookmarks)
+        self.assertContains(
+            response, f"<title>Public shared bookmarks ({user1.username})</title>"
+        )
 
         response = self.client.get(feed_url + f"?user={user2.username}")
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
Includes the requested username in the title of user-filtered public RSS feeds.

Unfiltered feeds retain the existing title: `Public shared bookmarks`
User-filtered feeds now use: `Public shared bookmarks (username)`

Closes #1442