### PR TITLE
Make UI texts translatable and add German translation

### DIFF
--- a/bookmarks/feeds.py
+++ b/bookmarks/feeds.py
@@ -5,6 +5,7 @@ from django.contrib.syndication.views import Feed
 from django.db.models import QuerySet, prefetch_related_objects
 from django.http import HttpRequest
 from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
 
 from bookmarks import queries
 from bookmarks.models import Bookmark, BookmarkSearch, FeedToken, User, UserProfile
@@ -76,8 +77,8 @@ class BaseBookmarksFeed(Feed):
 
 
 class AllBookmarksFeed(BaseBookmarksFeed):
-    title = "All bookmarks"
-    description = "All bookmarks"
+    title = _("All bookmarks")
+    description = _("All bookmarks")
 
     def get_query_set(self, feed_token: FeedToken, search: BookmarkSearch):
         return queries.query_bookmarks(feed_token.user, feed_token.user.profile, search)
@@ -87,8 +88,8 @@ class AllBookmarksFeed(BaseBookmarksFeed):
 
 
 class UnreadBookmarksFeed(BaseBookmarksFeed):
-    title = "Unread bookmarks"
-    description = "All unread bookmarks"
+    title = _("Unread bookmarks")
+    description = _("All unread bookmarks")
 
     def get_query_set(self, feed_token: FeedToken, search: BookmarkSearch):
         return queries.query_bookmarks(
@@ -100,8 +101,8 @@ class UnreadBookmarksFeed(BaseBookmarksFeed):
 
 
 class SharedBookmarksFeed(BaseBookmarksFeed):
-    title = "Shared bookmarks"
-    description = "All shared bookmarks"
+    title = _("Shared bookmarks")
+    description = _("All shared bookmarks")
 
     def get_query_set(self, feed_token: FeedToken, search: BookmarkSearch):
         user = resolve_user(search)
@@ -116,8 +117,8 @@ class SharedBookmarksFeed(BaseBookmarksFeed):
 
 
 class PublicSharedBookmarksFeed(BaseBookmarksFeed):
-    title = "Public shared bookmarks"
-    description = "All public shared bookmarks"
+    title = _("Public shared bookmarks")
+    description = _("All public shared bookmarks")
 
     def get_object(self, request):
         return super().get_object(request, None)

--- a/bookmarks/forms.py
+++ b/bookmarks/forms.py
@@ -2,6 +2,7 @@ from django import forms
 from django.contrib.auth.models import User
 from django.db import models
 from django.utils import timezone
+from django.utils.translation import gettext_lazy as _
 
 from bookmarks.models import (
     Bookmark,
@@ -110,7 +111,9 @@ class BookmarkForm(forms.ModelForm):
                 .exists()
             )
             if is_duplicate:
-                raise forms.ValidationError("A bookmark with this URL already exists.")
+                raise forms.ValidationError(
+                    _("A bookmark with this URL already exists.")
+                )
 
         return url
 
@@ -142,7 +145,9 @@ class TagForm(forms.ModelForm):
             queryset = queryset.exclude(pk=self.instance.pk)
 
         if queryset.exists():
-            raise forms.ValidationError(f'Tag "{name}" already exists.')
+            raise forms.ValidationError(
+                _('Tag "%(name)s" already exists.') % {"name": name}
+            )
 
         return name
 
@@ -172,7 +177,7 @@ class TagMergeForm(forms.Form):
         target_tag_names = parse_tag_string(target_tag_name, " ")
         if len(target_tag_names) != 1:
             raise forms.ValidationError(
-                "Please enter only one tag name for the target tag."
+                _("Please enter only one tag name for the target tag.")
             )
 
         target_tag_name = target_tag_names[0]
@@ -181,7 +186,7 @@ class TagMergeForm(forms.Form):
             target_tag = Tag.objects.get(name__iexact=target_tag_name, owner=self.user)
         except Tag.DoesNotExist:
             raise forms.ValidationError(
-                f'Tag "{target_tag_name}" does not exist.'
+                _('Tag "%(name)s" does not exist.') % {"name": target_tag_name}
             ) from None
 
         return target_tag
@@ -191,7 +196,7 @@ class TagMergeForm(forms.Form):
 
         merge_tag_names = parse_tag_string(merge_tags_string, " ")
         if not merge_tag_names:
-            raise forms.ValidationError("Please enter at least one tag to merge.")
+            raise forms.ValidationError(_("Please enter at least one tag to merge."))
 
         merge_tags = []
         for tag_name in merge_tag_names:
@@ -200,13 +205,13 @@ class TagMergeForm(forms.Form):
                 merge_tags.append(tag)
             except Tag.DoesNotExist:
                 raise forms.ValidationError(
-                    f'Tag "{tag_name}" does not exist.'
+                    _('Tag "%(name)s" does not exist.') % {"name": tag_name}
                 ) from None
 
         target_tag = self.cleaned_data.get("target_tag")
         if target_tag and target_tag in merge_tags:
             raise forms.ValidationError(
-                "The target tag cannot be selected for merging."
+                _("The target tag cannot be selected for merging.")
             )
 
         return merge_tags
@@ -247,22 +252,22 @@ class BookmarkBundleForm(forms.ModelForm):
 
 class BookmarkSearchForm(forms.Form):
     SORT_CHOICES = [
-        (BookmarkSearch.SORT_ADDED_ASC, "Added ↑"),
-        (BookmarkSearch.SORT_ADDED_DESC, "Added ↓"),
-        (BookmarkSearch.SORT_MODIFIED_ASC, "Modified ↑"),
-        (BookmarkSearch.SORT_MODIFIED_DESC, "Modified ↓"),
-        (BookmarkSearch.SORT_TITLE_ASC, "Title ↑"),
-        (BookmarkSearch.SORT_TITLE_DESC, "Title ↓"),
+        (BookmarkSearch.SORT_ADDED_ASC, _("Added ↑")),
+        (BookmarkSearch.SORT_ADDED_DESC, _("Added ↓")),
+        (BookmarkSearch.SORT_MODIFIED_ASC, _("Modified ↑")),
+        (BookmarkSearch.SORT_MODIFIED_DESC, _("Modified ↓")),
+        (BookmarkSearch.SORT_TITLE_ASC, _("Title ↑")),
+        (BookmarkSearch.SORT_TITLE_DESC, _("Title ↓")),
     ]
     FILTER_SHARED_CHOICES = [
-        (BookmarkSearch.FILTER_SHARED_OFF, "Off"),
-        (BookmarkSearch.FILTER_SHARED_SHARED, "Shared"),
-        (BookmarkSearch.FILTER_SHARED_UNSHARED, "Unshared"),
+        (BookmarkSearch.FILTER_SHARED_OFF, _("Off")),
+        (BookmarkSearch.FILTER_SHARED_SHARED, _("Shared")),
+        (BookmarkSearch.FILTER_SHARED_UNSHARED, _("Unshared")),
     ]
     FILTER_UNREAD_CHOICES = [
-        (BookmarkSearch.FILTER_UNREAD_OFF, "Off"),
-        (BookmarkSearch.FILTER_UNREAD_YES, "Unread"),
-        (BookmarkSearch.FILTER_UNREAD_NO, "Read"),
+        (BookmarkSearch.FILTER_UNREAD_OFF, _("Off")),
+        (BookmarkSearch.FILTER_UNREAD_YES, _("Unread")),
+        (BookmarkSearch.FILTER_UNREAD_NO, _("Read")),
     ]
 
     q = forms.CharField()
@@ -287,7 +292,7 @@ class BookmarkSearchForm(forms.Form):
         # set choices for user field if users are provided
         if users:
             user_choices = [(user.username, user.username) for user in users]
-            user_choices.insert(0, ("", "Everyone"))
+            user_choices.insert(0, ("", _("Everyone")))
             self.fields["user"].choices = user_choices
 
         for param in search.params:
@@ -382,4 +387,4 @@ class GlobalSettingsForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fields["guest_profile_user"].empty_label = "Standard profile"
+        self.fields["guest_profile_user"].empty_label = _("Standard profile")

--- a/bookmarks/frontend/components/confirm-dropdown.js
+++ b/bookmarks/frontend/components/confirm-dropdown.js
@@ -1,6 +1,7 @@
 import { html, LitElement } from "lit";
 import { FocusTrapController, isKeyboardActive } from "../utils/focus.js";
 import { PositionController } from "../utils/position-controller.js";
+import { translate } from "../utils/i18n.js";
 
 let confirmId = 0;
 
@@ -67,7 +68,9 @@ class ConfirmDropdown extends LitElement {
   }
 
   render() {
-    const questionText = this.button.dataset.confirmQuestion || "Are you sure?";
+    const questionText =
+      this.button.dataset.confirmQuestion ||
+      translate("i18nAreYouSure", "Are you sure?");
     return html`
       <div
         class="menu with-arrow"
@@ -78,9 +81,11 @@ class ConfirmDropdown extends LitElement {
         <span id=${this.confirmId} style="font-weight: bold;">
           ${questionText}
         </span>
-        <button type="button" class="btn" @click=${this.close}>Cancel</button>
+        <button type="button" class="btn" @click=${this.close}>
+          ${translate("i18nCancel", "Cancel")}
+        </button>
         <button type="submit" class="btn btn-error" @click=${this.confirm}>
-          Confirm
+          ${translate("i18nConfirm", "Confirm")}
         </button>
         <div class="menu-arrow"></div>
       </div>

--- a/bookmarks/frontend/components/filter-drawer.js
+++ b/bookmarks/frontend/components/filter-drawer.js
@@ -2,6 +2,7 @@ import { html, render } from "lit";
 import { Modal } from "./modal.js";
 import { HeadlessElement } from "../utils/element.js";
 import { isKeyboardActive } from "../utils/focus.js";
+import { translate } from "../utils/i18n.js";
 
 class FilterDrawerTrigger extends HeadlessElement {
   init() {
@@ -27,10 +28,10 @@ class FilterDrawer extends Modal {
         <div class="modal-overlay" data-close-modal></div>
         <div class="modal-container" role="dialog" aria-modal="true">
           <div class="modal-header">
-            <h2>Filters</h2>
+            <h2>${translate("i18nFilters", "Filters")}</h2>
             <button
               class="btn btn-noborder close"
-              aria-label="Close dialog"
+              aria-label="${translate("i18nCloseDialog", "Close dialog")}"
               data-close-modal
             >
               <svg

--- a/bookmarks/frontend/utils/i18n.js
+++ b/bookmarks/frontend/utils/i18n.js
@@ -1,0 +1,7 @@
+// Translated strings for use in JavaScript are provided by the server as data
+// attributes on the <html> element, see shared/layout.html. The fallback is
+// used when the attribute is not available, e.g. in pages that do not use the
+// shared layout.
+export function translate(key, fallback) {
+  return document.documentElement.dataset[key] || fallback;
+}

--- a/bookmarks/i18n.py
+++ b/bookmarks/i18n.py
@@ -1,0 +1,40 @@
+import os
+from collections.abc import Iterable
+
+from django.conf.locale import LANG_INFO
+from django.utils.translation import to_language
+
+MESSAGE_FILES = ("django.po", "django.mo")
+
+
+def discover_extra_languages(
+    locale_dir: str, known_codes: Iterable[str]
+) -> list[tuple[str, str]]:
+    """
+    Finds additional translations in a locale directory, e.g. the data folder.
+
+    Returns (code, name) tuples in the format of the LANGUAGES setting for every
+    sub directory that contains an LC_MESSAGES/django.po or django.mo file and
+    whose language code is not in known_codes. The name is taken from Django's
+    language info if available, otherwise the code is used.
+    """
+    if not os.path.isdir(locale_dir):
+        return []
+
+    known = {to_language(code) for code in known_codes}
+    languages = []
+    for entry in sorted(os.listdir(locale_dir)):
+        messages_dir = os.path.join(locale_dir, entry, "LC_MESSAGES")
+        if not os.path.isdir(messages_dir):
+            continue
+        if not any(
+            os.path.isfile(os.path.join(messages_dir, name)) for name in MESSAGE_FILES
+        ):
+            continue
+        code = to_language(entry)
+        if code in known:
+            continue
+        name = LANG_INFO.get(code, {}).get("name_local", code)
+        languages.append((code, name))
+
+    return languages

--- a/bookmarks/locale/de/LC_MESSAGES/django.po
+++ b/bookmarks/locale/de/LC_MESSAGES/django.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linkding\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-05 16:54+0000\n"
+"POT-Creation-Date: 2026-09-05 18:50+0000\n"
 "PO-Revision-Date: 2026-09-05 17:00+0000\n"
 "Last-Translator: \n"
 "Language-Team: German\n"
@@ -225,7 +225,6 @@ msgid "Separate"
 msgstr "Getrennt"
 
 #: bookmarks/models.py:375
-#| msgid "Password"
 msgid "New page"
 msgstr "Neue Seite"
 
@@ -479,7 +478,6 @@ msgid "Description"
 msgstr "Beschreibung"
 
 #: bookmarks/templates/bookmarks/edit.html:4
-#| msgid "Login - Linkding"
 msgid "Edit bookmark - Linkding"
 msgstr "Lesezeichen bearbeiten - Linkding"
 
@@ -495,8 +493,8 @@ msgstr "Ungültige Suchanfrage"
 #, python-format
 msgid ""
 "The search query you entered is not valid. Common reasons are unclosed "
-"parentheses or a logical operator (AND, OR, NOT) without operands. The error"
-" message from the parser is: \"%(error_message)s\"."
+"parentheses or a logical operator (AND, OR, NOT) without operands. The error "
+"message from the parser is: \"%(error_message)s\"."
 msgstr ""
 "Die eingegebene Suchanfrage ist ungültig. Häufige Ursachen sind nicht "
 "geschlossene Klammern oder ein logischer Operator (AND, OR, NOT) ohne "
@@ -534,8 +532,8 @@ msgstr ""
 
 #: bookmarks/templates/bookmarks/form.html:25
 msgid ""
-"Enter any number of tags separated by space and <strong>without</strong> the"
-" hash (#). If a tag does not exist it will be automatically created."
+"Enter any number of tags separated by space and <strong>without</strong> the "
+"hash (#). If a tag does not exist it will be automatically created."
 msgstr ""
 "Beliebig viele Tags durch Leerzeichen getrennt und <strong>ohne</strong> "
 "Raute (#) eingeben. Tags, die noch nicht existieren, werden automatisch "
@@ -588,8 +586,8 @@ msgstr "Speichern"
 #: bookmarks/templates/bundles/form.html:56
 #: bookmarks/templates/settings/create_api_token_modal.html:27
 #: bookmarks/templates/shared/layout.html:7
-#: bookmarks/templates/tags/edit.html:16
-#: bookmarks/templates/tags/merge.html:47 bookmarks/templates/tags/new.html:16
+#: bookmarks/templates/tags/edit.html:16 bookmarks/templates/tags/merge.html:47
+#: bookmarks/templates/tags/new.html:16
 msgid "Cancel"
 msgstr "Abbrechen"
 
@@ -598,7 +596,6 @@ msgid "Auto tags:"
 msgstr "Automatische Tags:"
 
 #: bookmarks/templates/bookmarks/new.html:4
-#| msgid "Login - Linkding"
 msgid "New bookmark - Linkding"
 msgstr "Neues Lesezeichen - Linkding"
 
@@ -658,12 +655,10 @@ msgid "Manage tags"
 msgstr "Tags verwalten"
 
 #: bookmarks/templates/bookmarks/user_section.html:4
-#| msgid "Username"
 msgid "User"
 msgstr "Benutzer"
 
 #: bookmarks/templates/bundles/edit.html:4
-#| msgid "Login - Linkding"
 msgid "Edit bundle - Linkding"
 msgstr "Bundle bearbeiten - Linkding"
 
@@ -686,8 +681,7 @@ msgstr "Alle diese Suchbegriffe müssen in einem Lesezeichen vorkommen."
 
 #: bookmarks/templates/bundles/form.html:19
 msgid "At least one of these tags must be present in a bookmark to match."
-msgstr ""
-"Mindestens einer dieser Tags muss in einem Lesezeichen vorhanden sein."
+msgstr "Mindestens einer dieser Tags muss in einem Lesezeichen vorhanden sein."
 
 #: bookmarks/templates/bundles/form.html:23
 msgid "Required tags"
@@ -722,7 +716,6 @@ msgid "Limit matches to shared or unshared bookmarks."
 msgstr "Treffer auf geteilte oder nicht geteilte Lesezeichen beschränken."
 
 #: bookmarks/templates/bundles/index.html:4
-#| msgid "Login - Linkding"
 msgid "Bundles - Linkding"
 msgstr "Bundles - Linkding"
 
@@ -745,7 +738,6 @@ msgid "Create your first bundle to get started"
 msgstr "Zum Einstieg ein erstes Bundle erstellen"
 
 #: bookmarks/templates/bundles/new.html:4
-#| msgid "Login - Linkding"
 msgid "New bundle - Linkding"
 msgstr "Neues Bundle - Linkding"
 
@@ -784,12 +776,10 @@ msgid "Login with OIDC"
 msgstr "Mit OIDC anmelden"
 
 #: bookmarks/templates/registration/password_change_done.html:4
-#| msgid "Login - Linkding"
 msgid "Password changed - Linkding"
 msgstr "Passwort geändert - Linkding"
 
 #: bookmarks/templates/registration/password_change_done.html:9
-#| msgid "Password"
 msgid "Password Changed"
 msgstr "Passwort geändert"
 
@@ -803,17 +793,14 @@ msgstr "Passwort ändern - Linkding"
 
 #: bookmarks/templates/registration/password_change_form.html:10
 #: bookmarks/templates/registration/password_change_form.html:30
-#| msgid "Password"
 msgid "Change Password"
 msgstr "Passwort ändern"
 
 #: bookmarks/templates/registration/password_change_form.html:15
-#| msgid "Password"
 msgid "Old password"
 msgstr "Altes Passwort"
 
 #: bookmarks/templates/registration/password_change_form.html:20
-#| msgid "Password"
 msgid "New password"
 msgstr "Neues Passwort"
 
@@ -846,7 +833,6 @@ msgid "Create Token"
 msgstr "Token erstellen"
 
 #: bookmarks/templates/settings/general.html:5
-#| msgid "Login - Linkding"
 msgid "Settings - Linkding"
 msgstr "Einstellungen - Linkding"
 
@@ -857,12 +843,10 @@ msgid "Settings"
 msgstr "Einstellungen"
 
 #: bookmarks/templates/settings/general.html:14
-#| msgid "Profile updated"
 msgid "Profile"
 msgstr "Profil"
 
 #: bookmarks/templates/settings/general.html:16
-#| msgid "Password"
 msgid "Change password"
 msgstr "Passwort ändern"
 
@@ -929,8 +913,8 @@ msgstr "Notizen dauerhaft anzeigen"
 #: bookmarks/templates/settings/general.html:63
 msgid ""
 "Whether to show bookmark notes permanently, without having to toggle them "
-"individually. Alternatively the keyboard shortcut <code>e</code> can be used"
-" to temporarily show all notes."
+"individually. Alternatively the keyboard shortcut <code>e</code> can be used "
+"to temporarily show all notes."
 msgstr ""
 "Notizen von Lesezeichen dauerhaft anzeigen, ohne sie einzeln einblenden zu "
 "müssen. Alternativ können mit dem Tastenkürzel <code>e</code> vorübergehend "
@@ -971,8 +955,8 @@ msgid ""
 "of the page first."
 msgstr ""
 "Wenn aktiviert, bleibt die Seitennavigation am unteren Bildschirmrand "
-"fixiert, sodass sie immer sichtbar ist, ohne erst ans Seitenende scrollen zu"
-" müssen."
+"fixiert, sodass sie immer sichtbar ist, ohne erst ans Seitenende scrollen zu "
+"müssen."
 
 #: bookmarks/templates/settings/general.html:102
 msgid "Collapse side panel"
@@ -994,8 +978,7 @@ msgstr "Bundles ausblenden"
 
 #: bookmarks/templates/settings/general.html:113
 msgid ""
-"Allows to hide the bundles in the side panel if you don't intend to use "
-"them."
+"Allows to hide the bundles in the side panel if you don't intend to use them."
 msgstr ""
 "Blendet die Bundles in der Seitenleiste aus, wenn sie nicht benötigt werden."
 
@@ -1013,8 +996,8 @@ msgid ""
 msgstr ""
 "Im strikten Modus müssen Tags mit einer Raute (#) beginnen. Im lockeren "
 "Modus können Tags auch ohne Raute gesucht werden. Tags ohne Raute sind "
-"allerdings nicht von Suchbegriffen zu unterscheiden, sodass das Suchergebnis"
-" auch Lesezeichen enthält, bei denen ein Suchbegriff anderweitig passt."
+"allerdings nicht von Suchbegriffen zu unterscheiden, sodass das Suchergebnis "
+"auch Lesezeichen enthält, bei denen ein Suchbegriff anderweitig passt."
 
 #: bookmarks/templates/settings/general.html:129
 msgid "Enable legacy search"
@@ -1022,21 +1005,21 @@ msgstr "Alte Suche aktivieren"
 
 #: bookmarks/templates/settings/general.html:131
 msgid ""
-"Since version 1.44.0, linkding has a new search engine that supports logical"
-" expressions (and, or, not). If you run into any issues with the new search,"
-" you can enable this option to temporarily switch back to the old search. "
+"Since version 1.44.0, linkding has a new search engine that supports logical "
+"expressions (and, or, not). If you run into any issues with the new search, "
+"you can enable this option to temporarily switch back to the old search. "
 "Please report any issues you encounter with the new search on <a "
 "href=\"https://github.com/sissbruecker/linkding/issues\" "
 "target=\"_blank\">GitHub</a> so they can be addressed. This option will be "
 "removed in a future version."
 msgstr ""
 "Seit Version 1.44.0 verwendet linkding eine neue Suchmaschine, die logische "
-"Ausdrücke (and, or, not) unterstützt. Bei Problemen mit der neuen Suche kann"
-" mit dieser Option vorübergehend zur alten Suche zurückgewechselt werden. "
-"Bitte Probleme mit der neuen Suche auf <a "
-"href=\"https://github.com/sissbruecker/linkding/issues\" "
-"target=\"_blank\">GitHub</a> melden, damit sie behoben werden können. Diese "
-"Option wird in einer zukünftigen Version entfernt."
+"Ausdrücke (and, or, not) unterstützt. Bei Problemen mit der neuen Suche kann "
+"mit dieser Option vorübergehend zur alten Suche zurückgewechselt werden. "
+"Bitte Probleme mit der neuen Suche auf <a href=\"https://github.com/"
+"sissbruecker/linkding/issues\" target=\"_blank\">GitHub</a> melden, damit "
+"sie behoben werden können. Diese Option wird in einer zukünftigen Version "
+"entfernt."
 
 #: bookmarks/templates/settings/general.html:141
 msgid "Tag grouping"
@@ -1044,8 +1027,8 @@ msgstr "Tag-Gruppierung"
 
 #: bookmarks/templates/settings/general.html:144
 msgid ""
-"In alphabetical mode, tags will be grouped by the first letter. If disabled,"
-" tags will not be grouped."
+"In alphabetical mode, tags will be grouped by the first letter. If disabled, "
+"tags will not be grouped."
 msgstr ""
 "Im alphabetischen Modus werden Tags nach dem Anfangsbuchstaben gruppiert. "
 "Wenn deaktiviert, werden Tags nicht gruppiert."
@@ -1057,8 +1040,8 @@ msgstr "Automatisches Tagging"
 
 #: bookmarks/templates/settings/general.html:160
 msgid ""
-"Automatically adds tags to bookmarks based on predefined rules. Each line is"
-" a single rule that maps a URL to one or more tags. For example:"
+"Automatically adds tags to bookmarks based on predefined rules. Each line is "
+"a single rule that maps a URL to one or more tags. For example:"
 msgstr ""
 "Fügt Lesezeichen anhand vordefinierter Regeln automatisch Tags hinzu. Jede "
 "Zeile ist eine Regel, die einer URL einen oder mehrere Tags zuordnet. Zum "
@@ -1073,20 +1056,19 @@ msgid ""
 "Automatically loads favicons for bookmarked websites and displays them next "
 "to each bookmark. Enabling this feature automatically downloads all missing "
 "favicons. By default, this feature uses a <b>Google service</b> to download "
-"favicons. If you don't want to use this service, check the <a "
-"href=\"https://linkding.link/options/#ld_favicon_provider\" "
-"target=\"_blank\">options documentation</a> on how to configure a custom "
-"favicon provider. Icons are downloaded in the background, and it may take a "
-"while for them to show up."
+"favicons. If you don't want to use this service, check the <a href=\"https://"
+"linkding.link/options/#ld_favicon_provider\" target=\"_blank\">options "
+"documentation</a> on how to configure a custom favicon provider. Icons are "
+"downloaded in the background, and it may take a while for them to show up."
 msgstr ""
 "Lädt automatisch Favicons für gespeicherte Websites und zeigt sie neben "
 "jedem Lesezeichen an. Beim Aktivieren dieser Funktion werden automatisch "
 "alle fehlenden Favicons heruntergeladen. Standardmäßig wird dafür ein "
 "<b>Google-Dienst</b> verwendet. Wer diesen Dienst nicht nutzen möchte, "
-"findet in der <a href=\"https://linkding.link/options/#ld_favicon_provider\""
-" target=\"_blank\">Dokumentation der Optionen</a>, wie ein eigener Favicon-"
-"Anbieter konfiguriert wird. Die Icons werden im Hintergrund heruntergeladen,"
-" es kann eine Weile dauern, bis sie erscheinen."
+"findet in der <a href=\"https://linkding.link/options/#ld_favicon_provider\" "
+"target=\"_blank\">Dokumentation der Optionen</a>, wie ein eigener Favicon-"
+"Anbieter konfiguriert wird. Die Icons werden im Hintergrund heruntergeladen, "
+"es kann eine Weile dauern, bis sie erscheinen."
 
 #: bookmarks/templates/settings/general.html:182
 msgid "Refresh Favicons"
@@ -1098,8 +1080,8 @@ msgstr "Vorschaubilder aktivieren"
 
 #: bookmarks/templates/settings/general.html:188
 msgid ""
-"Automatically loads preview images for bookmarked websites and displays them"
-" next to each bookmark. Enabling this feature automatically downloads all "
+"Automatically loads preview images for bookmarked websites and displays them "
+"next to each bookmark. Enabling this feature automatically downloads all "
 "missing preview images."
 msgstr ""
 "Lädt automatisch Vorschaubilder für gespeicherte Websites und zeigt sie "
@@ -1115,8 +1097,8 @@ msgid ""
 "Enabling this feature will automatically create snapshots of bookmarked "
 "websites on the <a href=\"https://web.archive.org/\" target=\"_blank\" "
 "rel=\"noopener\">Internet Archive Wayback Machine</a>. This allows to "
-"preserve, and later access the website as it was at the point in time it was"
-" bookmarked, in case it goes offline or its content is modified. Please "
+"preserve, and later access the website as it was at the point in time it was "
+"bookmarked, in case it goes offline or its content is modified. Please "
 "consider donating to the <a href=\"https://archive.org/donate\" "
 "target=\"_blank\" rel=\"noopener\">Internet Archive</a> if you make use of "
 "this feature."
@@ -1152,8 +1134,8 @@ msgstr "Öffentliches Teilen von Lesezeichen aktivieren"
 #, python-format
 msgid ""
 "Makes shared bookmarks publicly accessible, without requiring a login. That "
-"means that anyone with a link to this instance can view shared bookmarks via"
-" the <a href=\"%(shared_bookmarks_url)s\">shared bookmarks page</a>."
+"means that anyone with a link to this instance can view shared bookmarks via "
+"the <a href=\"%(shared_bookmarks_url)s\">shared bookmarks page</a>."
 msgstr ""
 "Macht geteilte Lesezeichen ohne Anmeldung öffentlich zugänglich. Das "
 "bedeutet, dass jeder mit einem Link zu dieser Instanz geteilte Lesezeichen "
@@ -1184,14 +1166,14 @@ msgstr "Lesezeichen standardmäßig als ungelesen erstellen"
 
 #: bookmarks/templates/settings/general.html:241
 msgid ""
-"Sets the default state for the \"Mark as unread\" option when creating a new"
-" bookmark. Setting this option will make all new bookmarks default to "
-"unread. This can be overridden when creating each new bookmark."
+"Sets the default state for the \"Mark as unread\" option when creating a new "
+"bookmark. Setting this option will make all new bookmarks default to unread. "
+"This can be overridden when creating each new bookmark."
 msgstr ""
 "Legt den Standardwert der Option \"Als ungelesen markieren\" beim Erstellen "
-"eines neuen Lesezeichens fest. Mit dieser Option sind alle neuen Lesezeichen"
-" standardmäßig ungelesen. Das kann beim Erstellen jedes Lesezeichens "
-"geändert werden."
+"eines neuen Lesezeichens fest. Mit dieser Option sind alle neuen Lesezeichen "
+"standardmäßig ungelesen. Das kann beim Erstellen jedes Lesezeichens geändert "
+"werden."
 
 #: bookmarks/templates/settings/general.html:249
 msgid "Create bookmarks as shared by default"
@@ -1200,8 +1182,8 @@ msgstr "Lesezeichen standardmäßig als geteilt erstellen"
 #: bookmarks/templates/settings/general.html:251
 msgid ""
 "Sets the default state for the \"Share\" option when creating a new "
-"bookmark. Setting this option will make all new bookmarks default to shared."
-" This can be overridden when creating each new bookmark."
+"bookmark. Setting this option will make all new bookmarks default to shared. "
+"This can be overridden when creating each new bookmark."
 msgstr ""
 "Legt den Standardwert der Option \"Teilen\" beim Erstellen eines neuen "
 "Lesezeichens fest. Mit dieser Option sind alle neuen Lesezeichen "
@@ -1242,8 +1224,8 @@ msgid ""
 "The user profile to use for users that are not logged in. This will affect "
 "how publicly shared bookmarks are displayed regarding theme, bookmark list "
 "settings, etc. You can either use your own profile or create a dedicated "
-"user for this purpose. By default, a standard profile with fixed settings is"
-" used."
+"user for this purpose. By default, a standard profile with fixed settings is "
+"used."
 msgstr ""
 "Das Benutzerprofil für nicht angemeldete Benutzer. Es bestimmt, wie "
 "öffentlich geteilte Lesezeichen in Bezug auf Design, Listeneinstellungen "
@@ -1262,8 +1244,8 @@ msgid ""
 "load on the server as well as bandwidth usage."
 msgstr ""
 "Lädt interne Links vor, wenn der Mauszeiger darüber fährt. Das kann die "
-"gefühlte Geschwindigkeit beim Navigieren in der Anwendung verbessern, erhöht"
-" aber auch die Last auf dem Server und den Datenverbrauch."
+"gefühlte Geschwindigkeit beim Navigieren in der Anwendung verbessern, erhöht "
+"aber auch die Last auf dem Server und den Datenverbrauch."
 
 #: bookmarks/templates/settings/general.html:325
 msgid "Import"
@@ -1332,7 +1314,6 @@ msgid "Changelog"
 msgstr "Änderungsprotokoll"
 
 #: bookmarks/templates/settings/integrations.html:4
-#| msgid "Login - Linkding"
 msgid "Integrations - Linkding"
 msgstr "Integrationen - Linkding"
 
@@ -1349,12 +1330,12 @@ msgstr "Browser-Erweiterung"
 #: bookmarks/templates/settings/integrations.html:12
 msgid ""
 "The browser extension allows you to quickly add new bookmarks without "
-"leaving the page that you are on. The extension is available in the official"
-" extension stores for:"
+"leaving the page that you are on. The extension is available in the official "
+"extension stores for:"
 msgstr ""
-"Mit der Browser-Erweiterung lassen sich neue Lesezeichen schnell hinzufügen,"
-" ohne die aktuelle Seite zu verlassen. Die Erweiterung ist in den "
-"offiziellen Stores verfügbar für:"
+"Mit der Browser-Erweiterung lassen sich neue Lesezeichen schnell hinzufügen, "
+"ohne die aktuelle Seite zu verlassen. Die Erweiterung ist in den offiziellen "
+"Stores verfügbar für:"
 
 #: bookmarks/templates/settings/integrations.html:28
 msgid ""
@@ -1362,10 +1343,10 @@ msgid ""
 "extension\" target=\"_blank\">open source</a> as well, which enables you to "
 "build and manually load it into any browser that supports Chrome extensions."
 msgstr ""
-"Die Erweiterung ist außerdem <a "
-"href=\"https://github.com/sissbruecker/linkding-extension\" "
-"target=\"_blank\">Open Source</a>, sodass sie selbst gebaut und manuell in "
-"jeden Browser geladen werden kann, der Chrome-Erweiterungen unterstützt."
+"Die Erweiterung ist außerdem <a href=\"https://github.com/sissbruecker/"
+"linkding-extension\" target=\"_blank\">Open Source</a>, sodass sie selbst "
+"gebaut und manuell in jeden Browser geladen werden kann, der Chrome-"
+"Erweiterungen unterstützt."
 
 #: bookmarks/templates/settings/integrations.html:34
 msgid "Bookmarklet"
@@ -1377,8 +1358,8 @@ msgid ""
 "bookmarks without opening the linkding application first. Here's how it "
 "works:"
 msgstr ""
-"Das Bookmarklet ist eine alternative, browserübergreifende Möglichkeit, neue"
-" Lesezeichen schnell hinzuzufügen, ohne zuerst linkding zu öffnen. So "
+"Das Bookmarklet ist eine alternative, browserübergreifende Möglichkeit, neue "
+"Lesezeichen schnell hinzuzufügen, ohne zuerst linkding zu öffnen. So "
 "funktioniert es:"
 
 #: bookmarks/templates/settings/integrations.html:43
@@ -1388,9 +1369,9 @@ msgid ""
 "detected-title-and-description-are-incorrect\" target=\"_blank\">Help</a>)"
 msgstr ""
 "Unten die bevorzugte Methode zur Erkennung von Titel und Beschreibung der "
-"Website wählen (<a "
-"href=\"https://linkding.link/troubleshooting/#automatically-detected-title-"
-"and-description-are-incorrect\" target=\"_blank\">Hilfe</a>)"
+"Website wählen (<a href=\"https://linkding.link/troubleshooting/"
+"#automatically-detected-title-and-description-are-incorrect\" "
+"target=\"_blank\">Hilfe</a>)"
 
 #: bookmarks/templates/settings/integrations.html:48
 msgid "Drag the bookmarklet below into your browser's bookmark bar / toolbar"
@@ -1461,14 +1442,14 @@ msgstr "Kopieren"
 #: bookmarks/templates/settings/integrations.html:132
 msgid ""
 "API tokens can be used to authenticate 3rd-party applications against the "
-"REST API. <strong>Please treat tokens as you would any other "
-"credential.</strong> Any party with access to a token can access and manage "
-"all your bookmarks."
+"REST API. <strong>Please treat tokens as you would any other credential.</"
+"strong> Any party with access to a token can access and manage all your "
+"bookmarks."
 msgstr ""
 "API-Tokens dienen zur Authentifizierung von Drittanwendungen gegenüber der "
-"REST-API. <strong>Tokens wie jede andere Anmeldeinformation "
-"behandeln.</strong> Jeder mit Zugriff auf einen Token kann auf alle "
-"Lesezeichen zugreifen und sie verwalten."
+"REST-API. <strong>Tokens wie jede andere Anmeldeinformation behandeln.</"
+"strong> Jeder mit Zugriff auf einen Token kann auf alle Lesezeichen "
+"zugreifen und sie verwalten."
 
 #: bookmarks/templates/settings/integrations.html:146
 msgid "Created"
@@ -1496,8 +1477,8 @@ msgid ""
 "shared with other people. Only shows shared bookmarks from users who have "
 "explicitly enabled public sharing."
 msgstr ""
-"Der öffentlich geteilte Feed enthält keinen Authentifizierungstoken und kann"
-" mit anderen Personen geteilt werden. Er zeigt nur geteilte Lesezeichen von "
+"Der öffentlich geteilte Feed enthält keinen Authentifizierungstoken und kann "
+"mit anderen Personen geteilt werden. Er zeigt nur geteilte Lesezeichen von "
 "Benutzern, die das öffentliche Teilen ausdrücklich aktiviert haben."
 
 #: bookmarks/templates/settings/integrations.html:218
@@ -1511,38 +1492,38 @@ msgid ""
 "bookmarks are included."
 msgstr ""
 "Ein <code>limit</code>-Parameter, der die maximale Anzahl an Lesezeichen im "
-"Feed festlegt. Standardmäßig sind nur die neuesten 100 passenden Lesezeichen"
-" enthalten."
+"Feed festlegt. Standardmäßig sind nur die neuesten 100 passenden Lesezeichen "
+"enthalten."
 
 #: bookmarks/templates/settings/integrations.html:227
 msgid ""
-"A <code>q</code> URL parameter for specifying a search query. You can get an"
-" example by doing a search in the bookmarks view and then copying the "
+"A <code>q</code> URL parameter for specifying a search query. You can get an "
+"example by doing a search in the bookmarks view and then copying the "
 "parameter from the URL."
 msgstr ""
 "Ein <code>q</code>-URL-Parameter für eine Suchanfrage. Ein Beispiel erhält "
-"man, indem man in der Lesezeichenansicht sucht und den Parameter aus der URL"
-" kopiert."
+"man, indem man in der Lesezeichenansicht sucht und den Parameter aus der URL "
+"kopiert."
 
 #: bookmarks/templates/settings/integrations.html:233
 msgid ""
-"An <code>unread</code> parameter for filtering for unread or read bookmarks."
-" Use <code>yes</code> for unread bookmarks and <code>no</code> for read "
+"An <code>unread</code> parameter for filtering for unread or read bookmarks. "
+"Use <code>yes</code> for unread bookmarks and <code>no</code> for read "
 "bookmarks."
 msgstr ""
 "Ein <code>unread</code>-Parameter zum Filtern nach ungelesenen oder "
-"gelesenen Lesezeichen. <code>yes</code> steht für ungelesene und "
-"<code>no</code> für gelesene Lesezeichen."
+"gelesenen Lesezeichen. <code>yes</code> steht für ungelesene und <code>no</"
+"code> für gelesene Lesezeichen."
 
 #: bookmarks/templates/settings/integrations.html:239
 msgid ""
 "A <code>shared</code> parameter for filtering for shared or unshared "
-"bookmarks. Use <code>yes</code> for shared bookmarks and <code>no</code> for"
-" unshared bookmarks."
+"bookmarks. Use <code>yes</code> for shared bookmarks and <code>no</code> for "
+"unshared bookmarks."
 msgstr ""
 "Ein <code>shared</code>-Parameter zum Filtern nach geteilten oder nicht "
-"geteilten Lesezeichen. <code>yes</code> steht für geteilte und "
-"<code>no</code> für nicht geteilte Lesezeichen."
+"geteilten Lesezeichen. <code>yes</code> steht für geteilte und <code>no</"
+"code> für nicht geteilte Lesezeichen."
 
 #: bookmarks/templates/settings/integrations.html:245
 msgid ""
@@ -1563,8 +1544,8 @@ msgid ""
 "deleting the feed token, new URLs will be generated when you reload this "
 "settings page."
 msgstr ""
-"<strong>Hinweis: Diese URLs enthalten einen Authentifizierungstoken, der wie"
-" jede andere Anmeldeinformation behandelt werden sollte.</strong> Jeder mit "
+"<strong>Hinweis: Diese URLs enthalten einen Authentifizierungstoken, der wie "
+"jede andere Anmeldeinformation behandelt werden sollte.</strong> Jeder mit "
 "Zugriff auf diese URLs kann alle Lesezeichen lesen. Falls eine URL "
 "kompromittiert wurde, kann der Feed-Token für den Benutzer im <a "
 "target=\"_blank\" href=\"%(feed_token_admin_url)s\">Admin-Bereich</a> "
@@ -1652,7 +1633,6 @@ msgstr ""
 "keine Leerzeichen enthalten (Leerzeichen werden durch Bindestriche ersetzt)."
 
 #: bookmarks/templates/tags/index.html:4
-#| msgid "Login - Linkding"
 msgid "Tags - Linkding"
 msgstr "Tags - Linkding"
 
@@ -1828,22 +1808,18 @@ msgstr[0] "vor %(count)d Woche"
 msgstr[1] "vor %(count)d Wochen"
 
 #: bookmarks/views/bookmarks.py:61
-#| msgid "Login - Linkding"
 msgid "Bookmarks - Linkding"
 msgstr "Lesezeichen - Linkding"
 
 #: bookmarks/views/bookmarks.py:100
-#| msgid "Login - Linkding"
 msgid "Archived bookmarks - Linkding"
 msgstr "Archivierte Lesezeichen - Linkding"
 
 #: bookmarks/views/bookmarks.py:137
-#| msgid "Login - Linkding"
 msgid "Shared bookmarks - Linkding"
 msgstr "Geteilte Lesezeichen - Linkding"
 
 #: bookmarks/views/bookmarks.py:161
-#| msgid "Login - Linkding"
 msgid "Bookmark details - Linkding"
 msgstr "Lesezeichen-Details - Linkding"
 
@@ -1918,8 +1894,8 @@ msgid ""
 "%(count)s bookmarks could not be imported. Please check the logs for more "
 "details."
 msgstr ""
-"%(count)s Lesezeichen konnten nicht importiert werden. Details stehen in den"
-" Logs."
+"%(count)s Lesezeichen konnten nicht importiert werden. Details stehen in den "
+"Logs."
 
 #: bookmarks/views/settings.py:275
 msgid "An error occurred during bookmark import."
@@ -1937,4 +1913,5 @@ msgstr "Tag \"%(name)s\" erfolgreich erstellt."
 #: bookmarks/views/tags.py:158
 #, python-format
 msgid "Successfully merged %(count)d tags (%(tags)s) into \"%(target)s\"."
-msgstr "%(count)d Tags (%(tags)s) erfolgreich in \"%(target)s\" zusammengeführt."
+msgstr ""
+"%(count)d Tags (%(tags)s) erfolgreich in \"%(target)s\" zusammengeführt."

--- a/bookmarks/locale/de/LC_MESSAGES/django.po
+++ b/bookmarks/locale/de/LC_MESSAGES/django.po
@@ -1,18 +1,13 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
-#, fuzzy
+# German translation for linkding.
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: linkding\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-05 15:49+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"POT-Creation-Date: 2026-09-05 16:54+0000\n"
+"PO-Revision-Date: 2026-09-05 17:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: German\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -22,73 +17,759 @@ msgstr ""
 #, python-format
 msgid "%d bookmark was successfully deleted."
 msgid_plural "%d bookmarks were successfully deleted."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%d Lesezeichen wurde erfolgreich gelöscht."
+msgstr[1] "%d Lesezeichen wurden erfolgreich gelöscht."
 
 #: bookmarks/admin.py:167
 #, python-format
 msgid "%d bookmark was successfully archived."
 msgid_plural "%d bookmarks were successfully archived."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%d Lesezeichen wurde erfolgreich archiviert."
+msgstr[1] "%d Lesezeichen wurden erfolgreich archiviert."
 
 #: bookmarks/admin.py:182
 #, python-format
 msgid "%d bookmark was successfully unarchived."
 msgid_plural "%d bookmarks were successfully unarchived."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%d Lesezeichen wurde erfolgreich wiederhergestellt."
+msgstr[1] "%d Lesezeichen wurden erfolgreich wiederhergestellt."
 
 #: bookmarks/admin.py:196
 #, python-format
 msgid "%d bookmark marked as read."
 msgid_plural "%d bookmarks marked as read."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%d Lesezeichen als gelesen markiert."
+msgstr[1] "%d Lesezeichen als gelesen markiert."
 
 #: bookmarks/admin.py:210
 #, python-format
 msgid "%d bookmark marked as unread."
 msgid_plural "%d bookmarks marked as unread."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%d Lesezeichen als ungelesen markiert."
+msgstr[1] "%d Lesezeichen als ungelesen markiert."
 
 #: bookmarks/admin.py:259
 #, python-format
 msgid "%d unused tag was successfully deleted."
 msgid_plural "%d unused tags were successfully deleted."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%d unbenutzter Tag wurde erfolgreich gelöscht."
+msgstr[1] "%d unbenutzte Tags wurden erfolgreich gelöscht."
 
 #: bookmarks/admin.py:270
 msgid "There were no unused tags in the selection"
-msgstr ""
+msgstr "Die Auswahl enthielt keine unbenutzten Tags"
 
 #: bookmarks/api/auth.py:24
 msgid "Invalid token header. No credentials provided."
-msgstr ""
+msgstr "Ungültiger Token-Header. Keine Anmeldedaten angegeben."
 
 #: bookmarks/api/auth.py:27
 msgid "Invalid token header. Token string should not contain spaces."
-msgstr ""
+msgstr "Ungültiger Token-Header. Der Token darf keine Leerzeichen enthalten."
 
 #: bookmarks/api/auth.py:34
 msgid ""
 "Invalid token header. Token string should not contain invalid characters."
 msgstr ""
+"Ungültiger Token-Header. Der Token darf keine ungültigen Zeichen enthalten."
+
+#: bookmarks/feeds.py:80 bookmarks/feeds.py:81
+#: bookmarks/templates/settings/integrations.html:204
+msgid "All bookmarks"
+msgstr "Alle Lesezeichen"
+
+#: bookmarks/feeds.py:91 bookmarks/templates/settings/integrations.html:207
+msgid "Unread bookmarks"
+msgstr "Ungelesene Lesezeichen"
+
+#: bookmarks/feeds.py:92
+msgid "All unread bookmarks"
+msgstr "Alle ungelesenen Lesezeichen"
+
+#: bookmarks/feeds.py:104 bookmarks/templates/settings/integrations.html:210
+#: bookmarks/templates/shared/nav_menu.html:82 bookmarks/views/contexts.py:285
+msgid "Shared bookmarks"
+msgstr "Geteilte Lesezeichen"
+
+#: bookmarks/feeds.py:105
+msgid "All shared bookmarks"
+msgstr "Alle geteilten Lesezeichen"
+
+#: bookmarks/feeds.py:120 bookmarks/templates/settings/integrations.html:213
+msgid "Public shared bookmarks"
+msgstr "Öffentlich geteilte Lesezeichen"
+
+#: bookmarks/feeds.py:121
+msgid "All public shared bookmarks"
+msgstr "Alle öffentlich geteilten Lesezeichen"
+
+#: bookmarks/forms.py:115
+msgid "A bookmark with this URL already exists."
+msgstr "Ein Lesezeichen mit dieser URL existiert bereits."
+
+#: bookmarks/forms.py:149
+#, python-format
+msgid "Tag \"%(name)s\" already exists."
+msgstr "Tag \"%(name)s\" existiert bereits."
+
+#: bookmarks/forms.py:180
+msgid "Please enter only one tag name for the target tag."
+msgstr "Bitte nur einen Tag-Namen für den Ziel-Tag eingeben."
+
+#: bookmarks/forms.py:189 bookmarks/forms.py:208
+#, python-format
+msgid "Tag \"%(name)s\" does not exist."
+msgstr "Tag \"%(name)s\" existiert nicht."
+
+#: bookmarks/forms.py:199
+msgid "Please enter at least one tag to merge."
+msgstr "Bitte mindestens einen Tag zum Zusammenführen eingeben."
+
+#: bookmarks/forms.py:214
+msgid "The target tag cannot be selected for merging."
+msgstr "Der Ziel-Tag kann nicht zum Zusammenführen ausgewählt werden."
+
+#: bookmarks/forms.py:255
+msgid "Added ↑"
+msgstr "Hinzugefügt ↑"
+
+#: bookmarks/forms.py:256
+msgid "Added ↓"
+msgstr "Hinzugefügt ↓"
+
+#: bookmarks/forms.py:257
+msgid "Modified ↑"
+msgstr "Geändert ↑"
+
+#: bookmarks/forms.py:258
+msgid "Modified ↓"
+msgstr "Geändert ↓"
+
+#: bookmarks/forms.py:259
+msgid "Title ↑"
+msgstr "Titel ↑"
+
+#: bookmarks/forms.py:260
+msgid "Title ↓"
+msgstr "Titel ↓"
+
+#: bookmarks/forms.py:263 bookmarks/forms.py:268
+msgid "Off"
+msgstr "Aus"
+
+#: bookmarks/forms.py:264 bookmarks/models.py:195
+#: bookmarks/templates/bookmarks/bookmark_list.html:143
+#: bookmarks/templates/bookmarks/details/form.html:84
+#: bookmarks/templates/shared/nav_menu.html:18 bookmarks/views/manifest.py:74
+msgid "Shared"
+msgstr "Geteilt"
+
+#: bookmarks/forms.py:265 bookmarks/models.py:196
+msgid "Unshared"
+msgstr "Nicht geteilt"
+
+#: bookmarks/forms.py:269 bookmarks/models.py:190
+#: bookmarks/templates/bookmarks/bookmark_list.html:130
+#: bookmarks/templates/bookmarks/details/form.html:74
+#: bookmarks/templates/shared/nav_menu.html:23
+#: bookmarks/templates/shared/nav_menu.html:87 bookmarks/views/manifest.py:66
+msgid "Unread"
+msgstr "Ungelesen"
+
+#: bookmarks/forms.py:270 bookmarks/models.py:191
+msgid "Read"
+msgstr "Gelesen"
+
+#: bookmarks/forms.py:295
+msgid "Everyone"
+msgstr "Alle"
+
+#: bookmarks/forms.py:390
+msgid "Standard profile"
+msgstr "Standardprofil"
+
+#: bookmarks/models.py:189 bookmarks/models.py:194
+msgid "All"
+msgstr "Alle"
+
+#: bookmarks/models.py:354
+msgid "Auto"
+msgstr "Automatisch"
+
+#: bookmarks/models.py:355
+msgid "Light"
+msgstr "Hell"
+
+#: bookmarks/models.py:356
+msgid "Dark"
+msgstr "Dunkel"
+
+#: bookmarks/models.py:362
+msgid "Relative"
+msgstr "Relativ"
+
+#: bookmarks/models.py:363
+msgid "Absolute"
+msgstr "Absolut"
+
+#: bookmarks/models.py:364
+msgid "Hidden"
+msgstr "Ausgeblendet"
+
+#: bookmarks/models.py:369
+msgid "Inline"
+msgstr "In einer Zeile"
+
+#: bookmarks/models.py:370
+msgid "Separate"
+msgstr "Getrennt"
+
+#: bookmarks/models.py:375
+#| msgid "Password"
+msgid "New page"
+msgstr "Neue Seite"
+
+#: bookmarks/models.py:376
+msgid "Same page"
+msgstr "Gleiche Seite"
+
+#: bookmarks/models.py:381 bookmarks/models.py:394
+msgid "Disabled"
+msgstr "Deaktiviert"
+
+#: bookmarks/models.py:382
+msgid "Enabled"
+msgstr "Aktiviert"
+
+#: bookmarks/models.py:387
+msgid "Strict"
+msgstr "Strikt"
+
+#: bookmarks/models.py:388
+msgid "Lax"
+msgstr "Locker"
+
+#: bookmarks/models.py:393
+msgid "Alphabetical"
+msgstr "Alphabetisch"
+
+#: bookmarks/models.py:546 bookmarks/templates/registration/login.html:10
+#: bookmarks/templates/registration/login.html:27
+#: bookmarks/templates/shared/layout.html:46
+msgid "Login"
+msgstr "Anmelden"
+
+#: bookmarks/models.py:547
+msgid "Shared Bookmarks"
+msgstr "Geteilte Lesezeichen"
+
+#: bookmarks/templates/admin/background_tasks.html:7
+msgid "ID"
+msgstr "ID"
+
+#: bookmarks/templates/admin/background_tasks.html:8
+#: bookmarks/templates/bundles/form.html:3
+#: bookmarks/templates/bundles/index.html:19
+#: bookmarks/templates/settings/integrations.html:145
+#: bookmarks/templates/tags/form.html:3 bookmarks/templates/tags/index.html:86
+msgid "Name"
+msgstr "Name"
+
+#: bookmarks/templates/admin/background_tasks.html:9
+msgid "Args"
+msgstr "Argumente"
+
+#: bookmarks/templates/admin/background_tasks.html:10
+msgid "Retries"
+msgstr "Wiederholungen"
+
+#: bookmarks/templates/admin/background_tasks.html:37
+#, python-format
+msgid "%(counter)s task"
+msgid_plural "%(counter)s tasks"
+msgstr[0] "%(counter)s Aufgabe"
+msgstr[1] "%(counter)s Aufgaben"
+
+#: bookmarks/templates/bookmarks/bookmark_list.html:5
+msgid "Bookmark list"
+msgstr "Lesezeichenliste"
+
+#: bookmarks/templates/bookmarks/bookmark_list.html:81
+#: bookmarks/templates/bookmarks/details/assets.html:24
+#: bookmarks/templates/settings/general.html:71
+msgid "View"
+msgstr "Ansehen"
+
+#: bookmarks/templates/bookmarks/bookmark_list.html:86
+#: bookmarks/templates/bookmarks/details/modal.html:17
+#: bookmarks/templates/bundles/index.html:38
+#: bookmarks/templates/settings/general.html:72
+#: bookmarks/templates/tags/index.html:107
+msgid "Edit"
+msgstr "Bearbeiten"
+
+#: bookmarks/templates/bookmarks/bookmark_list.html:93
+#: bookmarks/templates/bookmarks/bulk_edit_bar.html:13
+msgid "Unarchive"
+msgstr "Wiederherstellen"
+
+#: bookmarks/templates/bookmarks/bookmark_list.html:98
+#: bookmarks/templates/bookmarks/bulk_edit_bar.html:10
+#: bookmarks/templates/settings/general.html:73
+msgid "Archive"
+msgstr "Archivieren"
+
+#: bookmarks/templates/bookmarks/bookmark_list.html:106
+#: bookmarks/templates/bookmarks/details/assets.html:31
+#: bookmarks/templates/bundles/index.html:43
+#: bookmarks/templates/settings/general.html:74
+#: bookmarks/templates/tags/index.html:112
+msgid "Remove"
+msgstr "Entfernen"
+
+#: bookmarks/templates/bookmarks/bookmark_list.html:112
+#, python-format
+msgid "Shared by <a href=\"?%(owner_query)s\">%(username)s</a>"
+msgstr "Geteilt von <a href=\"?%(owner_query)s\">%(username)s</a>"
+
+#: bookmarks/templates/bookmarks/bookmark_list.html:126
+msgid "Mark as read?"
+msgstr "Als gelesen markieren?"
+
+#: bookmarks/templates/bookmarks/bookmark_list.html:139
+msgid "Unshare?"
+msgstr "Nicht mehr teilen?"
+
+#: bookmarks/templates/bookmarks/bookmark_list.html:151
+#: bookmarks/templates/bookmarks/details/form.html:119
+#: bookmarks/templates/bookmarks/form.html:58
+#: bookmarks/templates/bookmarks/form.html:60
+msgid "Notes"
+msgstr "Notizen"
+
+#: bookmarks/templates/bookmarks/bookmark_page.html:14
+msgid "Bulk edit"
+msgstr "Massenbearbeitung"
+
+#: bookmarks/templates/bookmarks/bookmark_page.html:21
+#: bookmarks/templates/shared/layout.html:9
+msgid "Filters"
+msgstr "Filter"
+
+#: bookmarks/templates/bookmarks/bulk_edit_bar.html:15
+#: bookmarks/templates/bookmarks/details/modal.html:29
+#: bookmarks/templates/settings/integrations.html:163
+msgid "Delete"
+msgstr "Löschen"
+
+#: bookmarks/templates/bookmarks/bulk_edit_bar.html:16
+msgid "Add tags"
+msgstr "Tags hinzufügen"
+
+#: bookmarks/templates/bookmarks/bulk_edit_bar.html:17
+msgid "Remove tags"
+msgstr "Tags entfernen"
+
+#: bookmarks/templates/bookmarks/bulk_edit_bar.html:18
+msgid "Mark as read"
+msgstr "Als gelesen markieren"
+
+#: bookmarks/templates/bookmarks/bulk_edit_bar.html:19
+#: bookmarks/templates/bookmarks/form.html:68
+msgid "Mark as unread"
+msgstr "Als ungelesen markieren"
+
+#: bookmarks/templates/bookmarks/bulk_edit_bar.html:21
+#: bookmarks/templates/bookmarks/form.html:75
+msgid "Share"
+msgstr "Teilen"
+
+#: bookmarks/templates/bookmarks/bulk_edit_bar.html:22
+msgid "Unshare"
+msgstr "Nicht mehr teilen"
+
+#: bookmarks/templates/bookmarks/bulk_edit_bar.html:24
+#: bookmarks/templates/bookmarks/form.html:37
+msgid "Refresh from website"
+msgstr "Von Website aktualisieren"
+
+#: bookmarks/templates/bookmarks/bulk_edit_bar.html:26
+#: bookmarks/templates/bookmarks/details/assets.html:45
+msgid "Create HTML snapshot"
+msgstr "HTML-Snapshot erstellen"
+
+#: bookmarks/templates/bookmarks/bulk_edit_bar.html:30
+msgid "Tag names..."
+msgstr "Tag-Namen..."
+
+#: bookmarks/templates/bookmarks/bulk_edit_bar.html:37
+msgid "Execute"
+msgstr "Ausführen"
+
+#: bookmarks/templates/bookmarks/bulk_edit_bar.html:42
+#, python-format
+msgid "All <span class=\"total\">%(total)s</span> bookmarks"
+msgstr "Alle <span class=\"total\">%(total)s</span> Lesezeichen"
+
+#: bookmarks/templates/bookmarks/bundle_section.html:5
+#: bookmarks/templates/bundles/index.html:9
+msgid "Bundles"
+msgstr "Bundles"
+
+#: bookmarks/templates/bookmarks/bundle_section.html:8
+msgid "Bundles menu"
+msgstr "Bundle-Menü"
+
+#: bookmarks/templates/bookmarks/bundle_section.html:15
+msgid "Manage bundles"
+msgstr "Bundles verwalten"
+
+#: bookmarks/templates/bookmarks/bundle_section.html:20
+msgid "Create bundle from search"
+msgstr "Bundle aus Suche erstellen"
+
+#: bookmarks/templates/bookmarks/close.html:7
+msgid "You can now close this window."
+msgstr "Dieses Fenster kann jetzt geschlossen werden."
+
+#: bookmarks/templates/bookmarks/details/assets.html:12
+msgid "(queued)"
+msgstr "(in Warteschlange)"
+
+#: bookmarks/templates/bookmarks/details/assets.html:15
+msgid "(failed)"
+msgstr "(fehlgeschlagen)"
+
+#: bookmarks/templates/bookmarks/details/assets.html:53
+msgid "Upload file"
+msgstr "Datei hochladen"
+
+#: bookmarks/templates/bookmarks/details/form.html:31
+msgid "Reader mode"
+msgstr "Lesemodus"
+
+#: bookmarks/templates/bookmarks/details/form.html:57
+msgid "Status"
+msgstr "Status"
+
+#: bookmarks/templates/bookmarks/details/form.html:65
+#: bookmarks/templates/shared/nav_menu.html:14 bookmarks/views/manifest.py:62
+msgid "Archived"
+msgstr "Archiviert"
+
+#: bookmarks/templates/bookmarks/details/form.html:92
+msgid "Files"
+msgstr "Dateien"
+
+#: bookmarks/templates/bookmarks/details/form.html:97
+#: bookmarks/templates/bookmarks/form.html:22
+#: bookmarks/templates/bookmarks/tag_section.html:4
+#: bookmarks/templates/bundles/form.html:16
+#: bookmarks/templates/tags/index.html:11
+msgid "Tags"
+msgstr "Tags"
+
+#: bookmarks/templates/bookmarks/details/form.html:106
+msgid "Date added"
+msgstr "Hinzugefügt am"
+
+#: bookmarks/templates/bookmarks/details/form.html:113
+#: bookmarks/templates/bookmarks/form.html:48
+msgid "Description"
+msgstr "Beschreibung"
+
+#: bookmarks/templates/bookmarks/edit.html:4
+#| msgid "Login - Linkding"
+msgid "Edit bookmark - Linkding"
+msgstr "Lesezeichen bearbeiten - Linkding"
+
+#: bookmarks/templates/bookmarks/edit.html:10
+msgid "Edit bookmark"
+msgstr "Lesezeichen bearbeiten"
+
+#: bookmarks/templates/bookmarks/empty_bookmarks.html:4
+msgid "Invalid search query"
+msgstr "Ungültige Suchanfrage"
+
+#: bookmarks/templates/bookmarks/empty_bookmarks.html:6
+#, python-format
+msgid ""
+"The search query you entered is not valid. Common reasons are unclosed "
+"parentheses or a logical operator (AND, OR, NOT) without operands. The error"
+" message from the parser is: \"%(error_message)s\"."
+msgstr ""
+"Die eingegebene Suchanfrage ist ungültig. Häufige Ursachen sind nicht "
+"geschlossene Klammern oder ein logischer Operator (AND, OR, NOT) ohne "
+"Operanden. Die Fehlermeldung des Parsers lautet: \"%(error_message)s\"."
+
+#: bookmarks/templates/bookmarks/empty_bookmarks.html:12
+msgid "You have no bookmarks yet"
+msgstr "Noch keine Lesezeichen vorhanden"
+
+#: bookmarks/templates/bookmarks/empty_bookmarks.html:17
+#, python-format
+msgid ""
+"You can get started by <a href=\"%(new_url)s\">adding</a> bookmarks, <a "
+"href=\"%(settings_url)s\">importing</a> your existing bookmarks or "
+"configuring the <a href=\"%(integrations_url)s\">browser extension</a> or "
+"the <a href=\"%(integrations_url)s\">bookmarklet</a>."
+msgstr ""
+"Zum Einstieg können Lesezeichen <a href=\"%(new_url)s\">hinzugefügt</a>, "
+"vorhandene Lesezeichen <a href=\"%(settings_url)s\">importiert</a> oder die "
+"<a href=\"%(integrations_url)s\">Browser-Erweiterung</a> oder das <a "
+"href=\"%(integrations_url)s\">Bookmarklet</a> eingerichtet werden."
+
+#: bookmarks/templates/bookmarks/form.html:8
+msgid "URL"
+msgstr "URL"
+
+#: bookmarks/templates/bookmarks/form.html:15
+msgid ""
+"This URL is already bookmarked. The form has been pre-filled with the "
+"existing bookmark, and saving the form will update the existing bookmark."
+msgstr ""
+"Diese URL ist bereits als Lesezeichen gespeichert. Das Formular wurde mit "
+"dem vorhandenen Lesezeichen vorausgefüllt, beim Speichern wird das "
+"vorhandene Lesezeichen aktualisiert."
+
+#: bookmarks/templates/bookmarks/form.html:25
+msgid ""
+"Enter any number of tags separated by space and <strong>without</strong> the"
+" hash (#). If a tag does not exist it will be automatically created."
+msgstr ""
+"Beliebig viele Tags durch Leerzeichen getrennt und <strong>ohne</strong> "
+"Raute (#) eingeben. Tags, die noch nicht existieren, werden automatisch "
+"erstellt."
+
+#: bookmarks/templates/bookmarks/form.html:34
+msgid "Title"
+msgstr "Titel"
+
+#: bookmarks/templates/bookmarks/form.html:40
+#: bookmarks/templates/bookmarks/form.html:50
+msgid "Clear"
+msgstr "Leeren"
+
+#: bookmarks/templates/bookmarks/form.html:63
+msgid "Additional notes, supports Markdown."
+msgstr "Zusätzliche Notizen, Markdown wird unterstützt."
+
+#: bookmarks/templates/bookmarks/form.html:70
+msgid ""
+"Unread bookmarks can be filtered for, and marked as read after you had a "
+"chance to look at them."
+msgstr ""
+"Ungelesene Lesezeichen können gefiltert und nach dem Lesen als gelesen "
+"markiert werden."
+
+#: bookmarks/templates/bookmarks/form.html:78
+msgid "Share this bookmark with other registered users and anonymous users."
+msgstr ""
+"Dieses Lesezeichen mit anderen registrierten Benutzern und anonymen "
+"Benutzern teilen."
+
+#: bookmarks/templates/bookmarks/form.html:80
+msgid "Share this bookmark with other registered users."
+msgstr "Dieses Lesezeichen mit anderen registrierten Benutzern teilen."
+
+#: bookmarks/templates/bookmarks/form.html:89
+msgid "Save and close"
+msgstr "Speichern und schließen"
+
+#: bookmarks/templates/bookmarks/form.html:93
+#: bookmarks/templates/bundles/form.html:53
+#: bookmarks/templates/settings/general.html:273
+#: bookmarks/templates/settings/general.html:317
+#: bookmarks/templates/tags/edit.html:17 bookmarks/templates/tags/new.html:17
+msgid "Save"
+msgstr "Speichern"
+
+#: bookmarks/templates/bookmarks/form.html:96
+#: bookmarks/templates/bundles/form.html:56
+#: bookmarks/templates/settings/create_api_token_modal.html:27
+#: bookmarks/templates/shared/layout.html:7
+#: bookmarks/templates/tags/edit.html:16
+#: bookmarks/templates/tags/merge.html:47 bookmarks/templates/tags/new.html:16
+msgid "Cancel"
+msgstr "Abbrechen"
+
+#: bookmarks/templates/bookmarks/form.html:98
+msgid "Auto tags:"
+msgstr "Automatische Tags:"
+
+#: bookmarks/templates/bookmarks/new.html:4
+#| msgid "Login - Linkding"
+msgid "New bookmark - Linkding"
+msgstr "Neues Lesezeichen - Linkding"
+
+#: bookmarks/templates/bookmarks/new.html:10
+msgid "New bookmark"
+msgstr "Neues Lesezeichen"
+
+#: bookmarks/templates/bookmarks/read.html:6
+msgid "Reader view"
+msgstr "Leseansicht"
+
+#: bookmarks/templates/bookmarks/read.html:47
+msgid "minutes"
+msgstr "Minuten"
+
+#: bookmarks/templates/bookmarks/search.html:5
+msgid "Search for words or #tags"
+msgstr "Nach Wörtern oder #Tags suchen"
+
+#: bookmarks/templates/bookmarks/search.html:13
+#: bookmarks/templates/tags/index.html:35
+msgid "Search"
+msgstr "Suchen"
+
+#: bookmarks/templates/bookmarks/search.html:18
+msgid "Search preferences"
+msgstr "Sucheinstellungen"
+
+#: bookmarks/templates/bookmarks/search.html:31
+#: bookmarks/templates/tags/index.html:39
+msgid "Sort by"
+msgstr "Sortieren nach"
+
+#: bookmarks/templates/bookmarks/search.html:42
+msgid "Shared filter"
+msgstr "Filter: Geteilt"
+
+#: bookmarks/templates/bookmarks/search.html:59
+msgid "Unread filter"
+msgstr "Filter: Ungelesen"
+
+#: bookmarks/templates/bookmarks/search.html:71
+#: bookmarks/templates/bookmarks/user_section.html:14
+msgid "Apply"
+msgstr "Anwenden"
+
+#: bookmarks/templates/bookmarks/search.html:73
+msgid "Save as default"
+msgstr "Als Standard speichern"
+
+#: bookmarks/templates/bookmarks/tag_section.html:8
+msgid "Tags menu"
+msgstr "Tag-Menü"
+
+#: bookmarks/templates/bookmarks/tag_section.html:15
+msgid "Manage tags"
+msgstr "Tags verwalten"
+
+#: bookmarks/templates/bookmarks/user_section.html:4
+#| msgid "Username"
+msgid "User"
+msgstr "Benutzer"
+
+#: bookmarks/templates/bundles/edit.html:4
+#| msgid "Login - Linkding"
+msgid "Edit bundle - Linkding"
+msgstr "Bundle bearbeiten - Linkding"
+
+#: bookmarks/templates/bundles/edit.html:10
+msgid "Edit bundle"
+msgstr "Bundle bearbeiten"
+
+#: bookmarks/templates/bundles/edit.html:23
+#: bookmarks/templates/bundles/new.html:23
+msgid "Preview"
+msgstr "Vorschau"
+
+#: bookmarks/templates/bundles/form.html:8
+msgid "Search terms"
+msgstr "Suchbegriffe"
+
+#: bookmarks/templates/bundles/form.html:12
+msgid "All of these search terms must be present in a bookmark to match."
+msgstr "Alle diese Suchbegriffe müssen in einem Lesezeichen vorkommen."
+
+#: bookmarks/templates/bundles/form.html:19
+msgid "At least one of these tags must be present in a bookmark to match."
+msgstr ""
+"Mindestens einer dieser Tags muss in einem Lesezeichen vorhanden sein."
+
+#: bookmarks/templates/bundles/form.html:23
+msgid "Required tags"
+msgstr "Erforderliche Tags"
+
+#: bookmarks/templates/bundles/form.html:26
+msgid "All of these tags must be present in a bookmark to match."
+msgstr "Alle diese Tags müssen in einem Lesezeichen vorhanden sein."
+
+#: bookmarks/templates/bundles/form.html:30
+msgid "Excluded tags"
+msgstr "Ausgeschlossene Tags"
+
+#: bookmarks/templates/bundles/form.html:33
+msgid "None of these tags must be present in a bookmark to match."
+msgstr "Keiner dieser Tags darf in einem Lesezeichen vorhanden sein."
+
+#: bookmarks/templates/bundles/form.html:37
+msgid "Reading State"
+msgstr "Lesestatus"
+
+#: bookmarks/templates/bundles/form.html:40
+msgid "Limit matches to unread or read bookmarks."
+msgstr "Treffer auf ungelesene oder gelesene Lesezeichen beschränken."
+
+#: bookmarks/templates/bundles/form.html:44
+msgid "Sharing State"
+msgstr "Freigabestatus"
+
+#: bookmarks/templates/bundles/form.html:47
+msgid "Limit matches to shared or unshared bookmarks."
+msgstr "Treffer auf geteilte oder nicht geteilte Lesezeichen beschränken."
+
+#: bookmarks/templates/bundles/index.html:4
+#| msgid "Login - Linkding"
+msgid "Bundles - Linkding"
+msgstr "Bundles - Linkding"
+
+#: bookmarks/templates/bundles/index.html:10
+msgid "Add bundle"
+msgstr "Bundle hinzufügen"
+
+#: bookmarks/templates/bundles/index.html:21
+#: bookmarks/templates/settings/integrations.html:148
+#: bookmarks/templates/tags/index.html:89
+msgid "Actions"
+msgstr "Aktionen"
+
+#: bookmarks/templates/bundles/index.html:54
+msgid "You have no bundles yet"
+msgstr "Noch keine Bundles vorhanden"
+
+#: bookmarks/templates/bundles/index.html:55
+msgid "Create your first bundle to get started"
+msgstr "Zum Einstieg ein erstes Bundle erstellen"
+
+#: bookmarks/templates/bundles/new.html:4
+#| msgid "Login - Linkding"
+msgid "New bundle - Linkding"
+msgstr "Neues Bundle - Linkding"
+
+#: bookmarks/templates/bundles/new.html:10
+msgid "New bundle"
+msgstr "Neues Bundle"
+
+#: bookmarks/templates/bundles/preview.html:4
+msgid "No bookmarks match the current bundle."
+msgstr "Keine Lesezeichen passen zum aktuellen Bundle."
+
+#: bookmarks/templates/bundles/preview.html:7
+#, python-format
+msgid "Found %(total)s bookmarks matching this bundle."
+msgstr "%(total)s Lesezeichen passen zu diesem Bundle."
 
 #: bookmarks/templates/registration/login.html:5
 msgid "Login - Linkding"
 msgstr "Anmelden - Linkding"
 
-#: bookmarks/templates/registration/login.html:10
-#: bookmarks/templates/registration/login.html:26
-msgid "Login"
-msgstr "Anmelden"
-
 #: bookmarks/templates/registration/login.html:16
 msgid "Your username and password didn't match. Please try again."
-msgstr "Benutzername und Passwort passen nicht zusammen. Bitte erneut versuchen."
+msgstr ""
+"Benutzername und Passwort passen nicht zusammen. Bitte erneut versuchen."
 
 #: bookmarks/templates/registration/login.html:19
 msgid "Username"
@@ -98,10 +779,1162 @@ msgstr "Benutzername"
 msgid "Password"
 msgstr "Passwort"
 
-#: bookmarks/templates/registration/login.html:33
+#: bookmarks/templates/registration/login.html:35
 msgid "Login with OIDC"
 msgstr "Mit OIDC anmelden"
 
-#: bookmarks/views/settings.py:110
+#: bookmarks/templates/registration/password_change_done.html:4
+#| msgid "Login - Linkding"
+msgid "Password changed - Linkding"
+msgstr "Passwort geändert - Linkding"
+
+#: bookmarks/templates/registration/password_change_done.html:9
+#| msgid "Password"
+msgid "Password Changed"
+msgstr "Passwort geändert"
+
+#: bookmarks/templates/registration/password_change_done.html:11
+msgid "Your password was changed successfully."
+msgstr "Das Passwort wurde erfolgreich geändert."
+
+#: bookmarks/templates/registration/password_change_form.html:5
+msgid "Change password - Linkding"
+msgstr "Passwort ändern - Linkding"
+
+#: bookmarks/templates/registration/password_change_form.html:10
+#: bookmarks/templates/registration/password_change_form.html:30
+#| msgid "Password"
+msgid "Change Password"
+msgstr "Passwort ändern"
+
+#: bookmarks/templates/registration/password_change_form.html:15
+#| msgid "Password"
+msgid "Old password"
+msgstr "Altes Passwort"
+
+#: bookmarks/templates/registration/password_change_form.html:20
+#| msgid "Password"
+msgid "New password"
+msgstr "Neues Passwort"
+
+#: bookmarks/templates/registration/password_change_form.html:25
+msgid "Confirm new password"
+msgstr "Neues Passwort bestätigen"
+
+#: bookmarks/templates/settings/create_api_token_modal.html:12
+msgid "Create API Token"
+msgstr "API-Token erstellen"
+
+#: bookmarks/templates/settings/create_api_token_modal.html:15
+msgid "Token name"
+msgstr "Token-Name"
+
+#: bookmarks/templates/settings/create_api_token_modal.html:20
+msgid "e.g., Browser Extension, Mobile App"
+msgstr "z. B. Browser-Erweiterung, Mobile App"
+
+#: bookmarks/templates/settings/create_api_token_modal.html:21
+msgid "API Token"
+msgstr "API-Token"
+
+#: bookmarks/templates/settings/create_api_token_modal.html:23
+msgid "A descriptive name to identify the purpose of the token"
+msgstr "Ein beschreibender Name, der den Zweck des Tokens erkennen lässt"
+
+#: bookmarks/templates/settings/create_api_token_modal.html:28
+msgid "Create Token"
+msgstr "Token erstellen"
+
+#: bookmarks/templates/settings/general.html:5
+#| msgid "Login - Linkding"
+msgid "Settings - Linkding"
+msgstr "Einstellungen - Linkding"
+
+#: bookmarks/templates/settings/general.html:9
+#: bookmarks/templates/shared/nav_menu.html:32
+#: bookmarks/templates/shared/nav_menu.html:95
+msgid "Settings"
+msgstr "Einstellungen"
+
+#: bookmarks/templates/settings/general.html:14
+#| msgid "Profile updated"
+msgid "Profile"
+msgstr "Profil"
+
+#: bookmarks/templates/settings/general.html:16
+#| msgid "Password"
+msgid "Change password"
+msgstr "Passwort ändern"
+
+#: bookmarks/templates/settings/general.html:24
+msgid "Theme"
+msgstr "Design"
+
+#: bookmarks/templates/settings/general.html:27
+msgid ""
+"Whether to use a light or dark theme, or automatically adjust the theme "
+"based on your system's settings."
+msgstr ""
+"Helles oder dunkles Design verwenden oder das Design automatisch an die "
+"Systemeinstellungen anpassen."
+
+#: bookmarks/templates/settings/general.html:31
+msgid "Bookmark date format"
+msgstr "Datumsformat für Lesezeichen"
+
+#: bookmarks/templates/settings/general.html:34
+msgid ""
+"Whether to show bookmark dates as relative (how long ago), or as absolute "
+"dates. Alternatively the date can be hidden."
+msgstr ""
+"Datum von Lesezeichen relativ (wie lange her) oder als absolutes Datum "
+"anzeigen. Alternativ kann das Datum ausgeblendet werden."
+
+#: bookmarks/templates/settings/general.html:41
+msgid "Bookmark description"
+msgstr "Beschreibung von Lesezeichen"
+
+#: bookmarks/templates/settings/general.html:44
+msgid ""
+"Whether to show bookmark descriptions and tags in the same line, or as "
+"separate blocks."
+msgstr ""
+"Beschreibung und Tags von Lesezeichen in derselben Zeile oder als getrennte "
+"Blöcke anzeigen."
+
+#: bookmarks/templates/settings/general.html:48
+msgid "Bookmark description max lines"
+msgstr "Maximale Zeilen für die Beschreibung"
+
+#: bookmarks/templates/settings/general.html:51
+msgid ""
+"Limits the number of lines that are displayed for the bookmark description."
+msgstr ""
+"Begrenzt die Anzahl der Zeilen, die für die Beschreibung eines Lesezeichens "
+"angezeigt werden."
+
+#: bookmarks/templates/settings/general.html:55
+msgid "Show bookmark URL"
+msgstr "Lesezeichen-URL anzeigen"
+
+#: bookmarks/templates/settings/general.html:57
+msgid "When enabled, this setting displays the bookmark URL below the title."
+msgstr ""
+"Wenn aktiviert, wird die URL des Lesezeichens unter dem Titel angezeigt."
+
+#: bookmarks/templates/settings/general.html:61
+msgid "Show notes permanently"
+msgstr "Notizen dauerhaft anzeigen"
+
+#: bookmarks/templates/settings/general.html:63
+msgid ""
+"Whether to show bookmark notes permanently, without having to toggle them "
+"individually. Alternatively the keyboard shortcut <code>e</code> can be used"
+" to temporarily show all notes."
+msgstr ""
+"Notizen von Lesezeichen dauerhaft anzeigen, ohne sie einzeln einblenden zu "
+"müssen. Alternativ können mit dem Tastenkürzel <code>e</code> vorübergehend "
+"alle Notizen angezeigt werden."
+
+#: bookmarks/templates/settings/general.html:70
+msgid "Bookmark actions"
+msgstr "Lesezeichen-Aktionen"
+
+#: bookmarks/templates/settings/general.html:75
+msgid "Which actions to display for each bookmark."
+msgstr "Welche Aktionen für jedes Lesezeichen angezeigt werden."
+
+#: bookmarks/templates/settings/general.html:78
+msgid "Open bookmarks in"
+msgstr "Lesezeichen öffnen in"
+
+#: bookmarks/templates/settings/general.html:81
+msgid "Whether to open bookmarks a new page or in the same page."
+msgstr "Lesezeichen in einer neuen Seite oder in derselben Seite öffnen."
+
+#: bookmarks/templates/settings/general.html:85
+msgid "Items per page"
+msgstr "Einträge pro Seite"
+
+#: bookmarks/templates/settings/general.html:89
+msgid "The number of bookmarks to display per page."
+msgstr "Die Anzahl der Lesezeichen, die pro Seite angezeigt werden."
+
+#: bookmarks/templates/settings/general.html:93
+msgid "Sticky pagination"
+msgstr "Fixierte Seitennavigation"
+
+#: bookmarks/templates/settings/general.html:95
+msgid ""
+"When enabled, the pagination controls will stick to the bottom of the "
+"screen, so that they are always visible without having to scroll to the end "
+"of the page first."
+msgstr ""
+"Wenn aktiviert, bleibt die Seitennavigation am unteren Bildschirmrand "
+"fixiert, sodass sie immer sichtbar ist, ohne erst ans Seitenende scrollen zu"
+" müssen."
+
+#: bookmarks/templates/settings/general.html:102
+msgid "Collapse side panel"
+msgstr "Seitenleiste einklappen"
+
+#: bookmarks/templates/settings/general.html:104
+msgid ""
+"When enabled, the tags side panel will be collapsed by default to give more "
+"space to the bookmark list. Instead, the tags are shown in an expandable "
+"drawer."
+msgstr ""
+"Wenn aktiviert, ist die Tag-Seitenleiste standardmäßig eingeklappt, um der "
+"Lesezeichenliste mehr Platz zu geben. Die Tags werden stattdessen in einer "
+"ausklappbaren Leiste angezeigt."
+
+#: bookmarks/templates/settings/general.html:111
+msgid "Hide bundles"
+msgstr "Bundles ausblenden"
+
+#: bookmarks/templates/settings/general.html:113
+msgid ""
+"Allows to hide the bundles in the side panel if you don't intend to use "
+"them."
+msgstr ""
+"Blendet die Bundles in der Seitenleiste aus, wenn sie nicht benötigt werden."
+
+#: bookmarks/templates/settings/general.html:117
+msgid "Tag search"
+msgstr "Tag-Suche"
+
+#: bookmarks/templates/settings/general.html:120
+msgid ""
+"In strict mode, tags must be prefixed with a hash character (#). In lax "
+"mode, tags can also be searched without the hash character. Note that tags "
+"without the hash character are indistinguishable from search terms, which "
+"means the search result will also include bookmarks where a search term "
+"matches otherwise."
+msgstr ""
+"Im strikten Modus müssen Tags mit einer Raute (#) beginnen. Im lockeren "
+"Modus können Tags auch ohne Raute gesucht werden. Tags ohne Raute sind "
+"allerdings nicht von Suchbegriffen zu unterscheiden, sodass das Suchergebnis"
+" auch Lesezeichen enthält, bei denen ein Suchbegriff anderweitig passt."
+
+#: bookmarks/templates/settings/general.html:129
+msgid "Enable legacy search"
+msgstr "Alte Suche aktivieren"
+
+#: bookmarks/templates/settings/general.html:131
+msgid ""
+"Since version 1.44.0, linkding has a new search engine that supports logical"
+" expressions (and, or, not). If you run into any issues with the new search,"
+" you can enable this option to temporarily switch back to the old search. "
+"Please report any issues you encounter with the new search on <a "
+"href=\"https://github.com/sissbruecker/linkding/issues\" "
+"target=\"_blank\">GitHub</a> so they can be addressed. This option will be "
+"removed in a future version."
+msgstr ""
+"Seit Version 1.44.0 verwendet linkding eine neue Suchmaschine, die logische "
+"Ausdrücke (and, or, not) unterstützt. Bei Problemen mit der neuen Suche kann"
+" mit dieser Option vorübergehend zur alten Suche zurückgewechselt werden. "
+"Bitte Probleme mit der neuen Suche auf <a "
+"href=\"https://github.com/sissbruecker/linkding/issues\" "
+"target=\"_blank\">GitHub</a> melden, damit sie behoben werden können. Diese "
+"Option wird in einer zukünftigen Version entfernt."
+
+#: bookmarks/templates/settings/general.html:141
+msgid "Tag grouping"
+msgstr "Tag-Gruppierung"
+
+#: bookmarks/templates/settings/general.html:144
+msgid ""
+"In alphabetical mode, tags will be grouped by the first letter. If disabled,"
+" tags will not be grouped."
+msgstr ""
+"Im alphabetischen Modus werden Tags nach dem Anfangsbuchstaben gruppiert. "
+"Wenn deaktiviert, werden Tags nicht gruppiert."
+
+#: bookmarks/templates/settings/general.html:153
+#: bookmarks/templates/settings/general.html:156
+msgid "Auto Tagging"
+msgstr "Automatisches Tagging"
+
+#: bookmarks/templates/settings/general.html:160
+msgid ""
+"Automatically adds tags to bookmarks based on predefined rules. Each line is"
+" a single rule that maps a URL to one or more tags. For example:"
+msgstr ""
+"Fügt Lesezeichen anhand vordefinierter Regeln automatisch Tags hinzu. Jede "
+"Zeile ist eine Regel, die einer URL einen oder mehrere Tags zuordnet. Zum "
+"Beispiel:"
+
+#: bookmarks/templates/settings/general.html:169
+msgid "Enable Favicons"
+msgstr "Favicons aktivieren"
+
+#: bookmarks/templates/settings/general.html:171
+msgid ""
+"Automatically loads favicons for bookmarked websites and displays them next "
+"to each bookmark. Enabling this feature automatically downloads all missing "
+"favicons. By default, this feature uses a <b>Google service</b> to download "
+"favicons. If you don't want to use this service, check the <a "
+"href=\"https://linkding.link/options/#ld_favicon_provider\" "
+"target=\"_blank\">options documentation</a> on how to configure a custom "
+"favicon provider. Icons are downloaded in the background, and it may take a "
+"while for them to show up."
+msgstr ""
+"Lädt automatisch Favicons für gespeicherte Websites und zeigt sie neben "
+"jedem Lesezeichen an. Beim Aktivieren dieser Funktion werden automatisch "
+"alle fehlenden Favicons heruntergeladen. Standardmäßig wird dafür ein "
+"<b>Google-Dienst</b> verwendet. Wer diesen Dienst nicht nutzen möchte, "
+"findet in der <a href=\"https://linkding.link/options/#ld_favicon_provider\""
+" target=\"_blank\">Dokumentation der Optionen</a>, wie ein eigener Favicon-"
+"Anbieter konfiguriert wird. Die Icons werden im Hintergrund heruntergeladen,"
+" es kann eine Weile dauern, bis sie erscheinen."
+
+#: bookmarks/templates/settings/general.html:182
+msgid "Refresh Favicons"
+msgstr "Favicons aktualisieren"
+
+#: bookmarks/templates/settings/general.html:186
+msgid "Enable Preview Images"
+msgstr "Vorschaubilder aktivieren"
+
+#: bookmarks/templates/settings/general.html:188
+msgid ""
+"Automatically loads preview images for bookmarked websites and displays them"
+" next to each bookmark. Enabling this feature automatically downloads all "
+"missing preview images."
+msgstr ""
+"Lädt automatisch Vorschaubilder für gespeicherte Websites und zeigt sie "
+"neben jedem Lesezeichen an. Beim Aktivieren dieser Funktion werden "
+"automatisch alle fehlenden Vorschaubilder heruntergeladen."
+
+#: bookmarks/templates/settings/general.html:195
+msgid "Internet Archive integration"
+msgstr "Internet-Archive-Integration"
+
+#: bookmarks/templates/settings/general.html:198
+msgid ""
+"Enabling this feature will automatically create snapshots of bookmarked "
+"websites on the <a href=\"https://web.archive.org/\" target=\"_blank\" "
+"rel=\"noopener\">Internet Archive Wayback Machine</a>. This allows to "
+"preserve, and later access the website as it was at the point in time it was"
+" bookmarked, in case it goes offline or its content is modified. Please "
+"consider donating to the <a href=\"https://archive.org/donate\" "
+"target=\"_blank\" rel=\"noopener\">Internet Archive</a> if you make use of "
+"this feature."
+msgstr ""
+"Wenn aktiviert, werden von gespeicherten Websites automatisch Snapshots auf "
+"der <a href=\"https://web.archive.org/\" target=\"_blank\" "
+"rel=\"noopener\">Wayback Machine des Internet Archive</a> erstellt. So "
+"bleibt die Website in dem Zustand erhalten, in dem sie gespeichert wurde, "
+"und ist später auch dann abrufbar, wenn sie offline geht oder ihr Inhalt "
+"verändert wird. Wer diese Funktion nutzt, sollte eine Spende an das <a "
+"href=\"https://archive.org/donate\" target=\"_blank\" "
+"rel=\"noopener\">Internet Archive</a> in Erwägung ziehen."
+
+#: bookmarks/templates/settings/general.html:208
+msgid "Enable bookmark sharing"
+msgstr "Teilen von Lesezeichen aktivieren"
+
+#: bookmarks/templates/settings/general.html:210
+msgid ""
+"Allows to share bookmarks with other users, and to view shared bookmarks. "
+"Disabling this feature will hide all previously shared bookmarks from other "
+"users."
+msgstr ""
+"Ermöglicht, Lesezeichen mit anderen Benutzern zu teilen und geteilte "
+"Lesezeichen anzusehen. Beim Deaktivieren werden alle zuvor geteilten "
+"Lesezeichen für andere Benutzer ausgeblendet."
+
+#: bookmarks/templates/settings/general.html:217
+msgid "Enable public bookmark sharing"
+msgstr "Öffentliches Teilen von Lesezeichen aktivieren"
+
+#: bookmarks/templates/settings/general.html:220
+#, python-format
+msgid ""
+"Makes shared bookmarks publicly accessible, without requiring a login. That "
+"means that anyone with a link to this instance can view shared bookmarks via"
+" the <a href=\"%(shared_bookmarks_url)s\">shared bookmarks page</a>."
+msgstr ""
+"Macht geteilte Lesezeichen ohne Anmeldung öffentlich zugänglich. Das "
+"bedeutet, dass jeder mit einem Link zu dieser Instanz geteilte Lesezeichen "
+"über die <a href=\"%(shared_bookmarks_url)s\">Seite mit geteilten "
+"Lesezeichen</a> ansehen kann."
+
+#: bookmarks/templates/settings/general.html:228
+msgid "Automatically create HTML snapshots"
+msgstr "HTML-Snapshots automatisch erstellen"
+
+#: bookmarks/templates/settings/general.html:230
+msgid ""
+"Automatically creates HTML snapshots when adding bookmarks. Alternatively, "
+"when disabled, snapshots can be created manually in the details view of a "
+"bookmark."
+msgstr ""
+"Erstellt beim Hinzufügen von Lesezeichen automatisch HTML-Snapshots. Wenn "
+"deaktiviert, können Snapshots alternativ manuell in der Detailansicht eines "
+"Lesezeichens erstellt werden."
+
+#: bookmarks/templates/settings/general.html:235
+msgid "Create missing HTML snapshots"
+msgstr "Fehlende HTML-Snapshots erstellen"
+
+#: bookmarks/templates/settings/general.html:239
+msgid "Create bookmarks as unread by default"
+msgstr "Lesezeichen standardmäßig als ungelesen erstellen"
+
+#: bookmarks/templates/settings/general.html:241
+msgid ""
+"Sets the default state for the \"Mark as unread\" option when creating a new"
+" bookmark. Setting this option will make all new bookmarks default to "
+"unread. This can be overridden when creating each new bookmark."
+msgstr ""
+"Legt den Standardwert der Option \"Als ungelesen markieren\" beim Erstellen "
+"eines neuen Lesezeichens fest. Mit dieser Option sind alle neuen Lesezeichen"
+" standardmäßig ungelesen. Das kann beim Erstellen jedes Lesezeichens "
+"geändert werden."
+
+#: bookmarks/templates/settings/general.html:249
+msgid "Create bookmarks as shared by default"
+msgstr "Lesezeichen standardmäßig als geteilt erstellen"
+
+#: bookmarks/templates/settings/general.html:251
+msgid ""
+"Sets the default state for the \"Share\" option when creating a new "
+"bookmark. Setting this option will make all new bookmarks default to shared."
+" This can be overridden when creating each new bookmark."
+msgstr ""
+"Legt den Standardwert der Option \"Teilen\" beim Erstellen eines neuen "
+"Lesezeichens fest. Mit dieser Option sind alle neuen Lesezeichen "
+"standardmäßig geteilt. Das kann beim Erstellen jedes Lesezeichens geändert "
+"werden."
+
+#: bookmarks/templates/settings/general.html:261
+#: bookmarks/templates/settings/general.html:263
+msgid "Custom CSS"
+msgstr "Eigenes CSS"
+
+#: bookmarks/templates/settings/general.html:267
+msgid "Allows to add custom CSS to the page."
+msgstr "Ermöglicht, der Seite eigenes CSS hinzuzufügen."
+
+#: bookmarks/templates/settings/general.html:281
+msgid "Global settings"
+msgstr "Globale Einstellungen"
+
+#: bookmarks/templates/settings/general.html:288
+msgid "Landing page"
+msgstr "Startseite"
+
+#: bookmarks/templates/settings/general.html:291
+msgid ""
+"The page that unauthenticated users are redirected to when accessing the "
+"root URL."
+msgstr ""
+"Die Seite, auf die nicht angemeldete Benutzer beim Aufruf der Root-URL "
+"weitergeleitet werden."
+
+#: bookmarks/templates/settings/general.html:295
+msgid "Guest user profile"
+msgstr "Gastprofil"
+
+#: bookmarks/templates/settings/general.html:298
+msgid ""
+"The user profile to use for users that are not logged in. This will affect "
+"how publicly shared bookmarks are displayed regarding theme, bookmark list "
+"settings, etc. You can either use your own profile or create a dedicated "
+"user for this purpose. By default, a standard profile with fixed settings is"
+" used."
+msgstr ""
+"Das Benutzerprofil für nicht angemeldete Benutzer. Es bestimmt, wie "
+"öffentlich geteilte Lesezeichen in Bezug auf Design, Listeneinstellungen "
+"usw. angezeigt werden. Dafür kann das eigene Profil verwendet oder ein "
+"eigener Benutzer angelegt werden. Standardmäßig wird ein Standardprofil mit "
+"festen Einstellungen verwendet."
+
+#: bookmarks/templates/settings/general.html:306
+msgid "Enable prefetching links on hover"
+msgstr "Links beim Überfahren vorladen"
+
+#: bookmarks/templates/settings/general.html:308
+msgid ""
+"Prefetches internal links when hovering over them. This can improve the "
+"perceived performance when navigating application, but also increases the "
+"load on the server as well as bandwidth usage."
+msgstr ""
+"Lädt interne Links vor, wenn der Mauszeiger darüber fährt. Das kann die "
+"gefühlte Geschwindigkeit beim Navigieren in der Anwendung verbessern, erhöht"
+" aber auch die Last auf dem Server und den Datenverbrauch."
+
+#: bookmarks/templates/settings/general.html:325
+msgid "Import"
+msgstr "Import"
+
+#: bookmarks/templates/settings/general.html:327
+msgid ""
+"Import bookmarks and tags in the Netscape HTML format. This will execute a "
+"sync where new bookmarks are added and existing ones are updated."
+msgstr ""
+"Lesezeichen und Tags im Netscape-HTML-Format importieren. Dabei wird ein "
+"Abgleich ausgeführt, bei dem neue Lesezeichen hinzugefügt und vorhandene "
+"aktualisiert werden."
+
+#: bookmarks/templates/settings/general.html:342
+msgid "Import public bookmarks as shared"
+msgstr "Öffentliche Lesezeichen als geteilt importieren"
+
+#: bookmarks/templates/settings/general.html:345
+msgid ""
+"When importing bookmarks from a service that supports marking bookmarks as "
+"public or private (using the <code>PRIVATE</code> attribute), enabling this "
+"option will import all bookmarks that are marked as not private as shared "
+"bookmarks. Otherwise, all bookmarks will be imported as private bookmarks."
+msgstr ""
+"Beim Import aus einem Dienst, der Lesezeichen als öffentlich oder privat "
+"kennzeichnen kann (über das Attribut <code>PRIVATE</code>), werden mit "
+"dieser Option alle nicht als privat markierten Lesezeichen als geteilte "
+"Lesezeichen importiert. Andernfalls werden alle Lesezeichen als private "
+"Lesezeichen importiert."
+
+#: bookmarks/templates/settings/general.html:358
+msgid "Upload"
+msgstr "Hochladen"
+
+#: bookmarks/templates/settings/general.html:365
+msgid "Export"
+msgstr "Export"
+
+#: bookmarks/templates/settings/general.html:366
+msgid "Export all bookmarks in Netscape HTML format."
+msgstr "Alle Lesezeichen im Netscape-HTML-Format exportieren."
+
+#: bookmarks/templates/settings/general.html:369
+msgid "Download (.html)"
+msgstr "Herunterladen (.html)"
+
+#: bookmarks/templates/settings/general.html:378
+msgid "About"
+msgstr "Über"
+
+#: bookmarks/templates/settings/general.html:382
+msgid "Version"
+msgstr "Version"
+
+#: bookmarks/templates/settings/general.html:386
+msgid "Links"
+msgstr "Links"
+
+#: bookmarks/templates/settings/general.html:390
+msgid "Documentation"
+msgstr "Dokumentation"
+
+#: bookmarks/templates/settings/general.html:392
+msgid "Changelog"
+msgstr "Änderungsprotokoll"
+
+#: bookmarks/templates/settings/integrations.html:4
+#| msgid "Login - Linkding"
+msgid "Integrations - Linkding"
+msgstr "Integrationen - Linkding"
+
+#: bookmarks/templates/settings/integrations.html:8
+#: bookmarks/templates/shared/nav_menu.html:38
+#: bookmarks/templates/shared/nav_menu.html:98
+msgid "Integrations"
+msgstr "Integrationen"
+
+#: bookmarks/templates/settings/integrations.html:10
+msgid "Browser Extension"
+msgstr "Browser-Erweiterung"
+
+#: bookmarks/templates/settings/integrations.html:12
+msgid ""
+"The browser extension allows you to quickly add new bookmarks without "
+"leaving the page that you are on. The extension is available in the official"
+" extension stores for:"
+msgstr ""
+"Mit der Browser-Erweiterung lassen sich neue Lesezeichen schnell hinzufügen,"
+" ohne die aktuelle Seite zu verlassen. Die Erweiterung ist in den "
+"offiziellen Stores verfügbar für:"
+
+#: bookmarks/templates/settings/integrations.html:28
+msgid ""
+"The extension is <a href=\"https://github.com/sissbruecker/linkding-"
+"extension\" target=\"_blank\">open source</a> as well, which enables you to "
+"build and manually load it into any browser that supports Chrome extensions."
+msgstr ""
+"Die Erweiterung ist außerdem <a "
+"href=\"https://github.com/sissbruecker/linkding-extension\" "
+"target=\"_blank\">Open Source</a>, sodass sie selbst gebaut und manuell in "
+"jeden Browser geladen werden kann, der Chrome-Erweiterungen unterstützt."
+
+#: bookmarks/templates/settings/integrations.html:34
+msgid "Bookmarklet"
+msgstr "Bookmarklet"
+
+#: bookmarks/templates/settings/integrations.html:36
+msgid ""
+"The bookmarklet is an alternative, cross-browser way to quickly add new "
+"bookmarks without opening the linkding application first. Here's how it "
+"works:"
+msgstr ""
+"Das Bookmarklet ist eine alternative, browserübergreifende Möglichkeit, neue"
+" Lesezeichen schnell hinzuzufügen, ohne zuerst linkding zu öffnen. So "
+"funktioniert es:"
+
+#: bookmarks/templates/settings/integrations.html:43
+msgid ""
+"Choose your preferred method for detecting website titles and descriptions "
+"below (<a href=\"https://linkding.link/troubleshooting/#automatically-"
+"detected-title-and-description-are-incorrect\" target=\"_blank\">Help</a>)"
+msgstr ""
+"Unten die bevorzugte Methode zur Erkennung von Titel und Beschreibung der "
+"Website wählen (<a "
+"href=\"https://linkding.link/troubleshooting/#automatically-detected-title-"
+"and-description-are-incorrect\" target=\"_blank\">Hilfe</a>)"
+
+#: bookmarks/templates/settings/integrations.html:48
+msgid "Drag the bookmarklet below into your browser's bookmark bar / toolbar"
+msgstr ""
+"Das Bookmarklet unten in die Lesezeichenleiste / Symbolleiste des Browsers "
+"ziehen"
+
+#: bookmarks/templates/settings/integrations.html:49
+msgid "Open the website that you want to bookmark"
+msgstr "Die Website öffnen, die gespeichert werden soll"
+
+#: bookmarks/templates/settings/integrations.html:50
+msgid "Click the bookmarklet in your browser's toolbar"
+msgstr "Auf das Bookmarklet in der Symbolleiste des Browsers klicken"
+
+#: bookmarks/templates/settings/integrations.html:51
+msgid ""
+"linkding opens in a new window or tab and allows you to add a bookmark for "
+"the site"
+msgstr ""
+"linkding öffnet sich in einem neuen Fenster oder Tab und ermöglicht, ein "
+"Lesezeichen für die Seite hinzuzufügen"
+
+#: bookmarks/templates/settings/integrations.html:52
+msgid ""
+"After saving the bookmark, the linkding window closes, and you are back on "
+"your website"
+msgstr ""
+"Nach dem Speichern des Lesezeichens schließt sich das linkding-Fenster und "
+"die ursprüngliche Website ist wieder sichtbar"
+
+#: bookmarks/templates/settings/integrations.html:57
+msgid "Choose your preferred bookmarklet:"
+msgstr "Bevorzugtes Bookmarklet wählen:"
+
+#: bookmarks/templates/settings/integrations.html:65
+msgid "Detect title and description on the server"
+msgstr "Titel und Beschreibung auf dem Server erkennen"
+
+#: bookmarks/templates/settings/integrations.html:73
+msgid "Detect title and description in the browser"
+msgstr "Titel und Beschreibung im Browser erkennen"
+
+#: bookmarks/templates/settings/integrations.html:80
+#: bookmarks/templates/settings/integrations.html:85
+#: bookmarks/templates/shared/nav_menu.html:6
+#: bookmarks/templates/shared/nav_menu.html:58 bookmarks/views/manifest.py:58
+msgid "Add bookmark"
+msgstr "Lesezeichen hinzufügen"
+
+#: bookmarks/templates/settings/integrations.html:114
+msgid "REST API"
+msgstr "REST-API"
+
+#: bookmarks/templates/settings/integrations.html:119
+msgid "Copy this token now, it will only be shown once:"
+msgstr "Diesen Token jetzt kopieren, er wird nur einmal angezeigt:"
+
+#: bookmarks/templates/settings/integrations.html:121
+msgid "New token key"
+msgstr "Neuer Token-Schlüssel"
+
+#: bookmarks/templates/settings/integrations.html:127
+#: bookmarks/templates/settings/integrations.html:177
+msgid "Copy"
+msgstr "Kopieren"
+
+#: bookmarks/templates/settings/integrations.html:132
+msgid ""
+"API tokens can be used to authenticate 3rd-party applications against the "
+"REST API. <strong>Please treat tokens as you would any other "
+"credential.</strong> Any party with access to a token can access and manage "
+"all your bookmarks."
+msgstr ""
+"API-Tokens dienen zur Authentifizierung von Drittanwendungen gegenüber der "
+"REST-API. <strong>Tokens wie jede andere Anmeldeinformation "
+"behandeln.</strong> Jeder mit Zugriff auf einen Token kann auf alle "
+"Lesezeichen zugreifen und sie verwalten."
+
+#: bookmarks/templates/settings/integrations.html:146
+msgid "Created"
+msgstr "Erstellt"
+
+#: bookmarks/templates/settings/integrations.html:173
+msgid "Create API token"
+msgstr "API-Token erstellen"
+
+#: bookmarks/templates/settings/integrations.html:176
+msgid "Copied!"
+msgstr "Kopiert!"
+
+#: bookmarks/templates/settings/integrations.html:200
+msgid "RSS Feeds"
+msgstr "RSS-Feeds"
+
+#: bookmarks/templates/settings/integrations.html:201
+msgid "The following URLs provide RSS feeds for your bookmarks:"
+msgstr "Die folgenden URLs stellen RSS-Feeds für die Lesezeichen bereit:"
+
+#: bookmarks/templates/settings/integrations.html:215
+msgid ""
+"The public shared feed does not contain an authentication token and can be "
+"shared with other people. Only shows shared bookmarks from users who have "
+"explicitly enabled public sharing."
+msgstr ""
+"Der öffentlich geteilte Feed enthält keinen Authentifizierungstoken und kann"
+" mit anderen Personen geteilt werden. Er zeigt nur geteilte Lesezeichen von "
+"Benutzern, die das öffentliche Teilen ausdrücklich aktiviert haben."
+
+#: bookmarks/templates/settings/integrations.html:218
+msgid "Feed URLs support the following URL parameters:"
+msgstr "Feed-URLs unterstützen die folgenden URL-Parameter:"
+
+#: bookmarks/templates/settings/integrations.html:221
+msgid ""
+"A <code>limit</code> parameter for specifying the maximum number of "
+"bookmarks to include in the feed. By default, only the latest 100 matching "
+"bookmarks are included."
+msgstr ""
+"Ein <code>limit</code>-Parameter, der die maximale Anzahl an Lesezeichen im "
+"Feed festlegt. Standardmäßig sind nur die neuesten 100 passenden Lesezeichen"
+" enthalten."
+
+#: bookmarks/templates/settings/integrations.html:227
+msgid ""
+"A <code>q</code> URL parameter for specifying a search query. You can get an"
+" example by doing a search in the bookmarks view and then copying the "
+"parameter from the URL."
+msgstr ""
+"Ein <code>q</code>-URL-Parameter für eine Suchanfrage. Ein Beispiel erhält "
+"man, indem man in der Lesezeichenansicht sucht und den Parameter aus der URL"
+" kopiert."
+
+#: bookmarks/templates/settings/integrations.html:233
+msgid ""
+"An <code>unread</code> parameter for filtering for unread or read bookmarks."
+" Use <code>yes</code> for unread bookmarks and <code>no</code> for read "
+"bookmarks."
+msgstr ""
+"Ein <code>unread</code>-Parameter zum Filtern nach ungelesenen oder "
+"gelesenen Lesezeichen. <code>yes</code> steht für ungelesene und "
+"<code>no</code> für gelesene Lesezeichen."
+
+#: bookmarks/templates/settings/integrations.html:239
+msgid ""
+"A <code>shared</code> parameter for filtering for shared or unshared "
+"bookmarks. Use <code>yes</code> for shared bookmarks and <code>no</code> for"
+" unshared bookmarks."
+msgstr ""
+"Ein <code>shared</code>-Parameter zum Filtern nach geteilten oder nicht "
+"geteilten Lesezeichen. <code>yes</code> steht für geteilte und "
+"<code>no</code> für nicht geteilte Lesezeichen."
+
+#: bookmarks/templates/settings/integrations.html:245
+msgid ""
+"A <code>user</code> parameter for filtering bookmarks by user name. Only "
+"applies to the shared bookmark feeds."
+msgstr ""
+"Ein <code>user</code>-Parameter zum Filtern von Lesezeichen nach "
+"Benutzername. Gilt nur für die Feeds mit geteilten Lesezeichen."
+
+#: bookmarks/templates/settings/integrations.html:252
+#, python-format
+msgid ""
+"<strong>Please note that these URLs include an authentication token that "
+"should be treated like any other credential.</strong> Any party with access "
+"to these URLs can read all your bookmarks. If you think that a URL was "
+"compromised you can delete the feed token for your user in the <a "
+"target=\"_blank\" href=\"%(feed_token_admin_url)s\">admin panel</a>. After "
+"deleting the feed token, new URLs will be generated when you reload this "
+"settings page."
+msgstr ""
+"<strong>Hinweis: Diese URLs enthalten einen Authentifizierungstoken, der wie"
+" jede andere Anmeldeinformation behandelt werden sollte.</strong> Jeder mit "
+"Zugriff auf diese URLs kann alle Lesezeichen lesen. Falls eine URL "
+"kompromittiert wurde, kann der Feed-Token für den Benutzer im <a "
+"target=\"_blank\" href=\"%(feed_token_admin_url)s\">Admin-Bereich</a> "
+"gelöscht werden. Nach dem Löschen des Feed-Tokens werden beim Neuladen "
+"dieser Einstellungsseite neue URLs erzeugt."
+
+#: bookmarks/templates/shared/head.html:24 bookmarks/views/manifest.py:10
+msgid "Self-hosted bookmark service"
+msgstr "Selbst gehosteter Lesezeichen-Dienst"
+
+#: bookmarks/templates/shared/layout.html:6
+msgid "Are you sure?"
+msgstr "Wirklich fortfahren?"
+
+#: bookmarks/templates/shared/layout.html:8
+msgid "Confirm"
+msgstr "Bestätigen"
+
+#: bookmarks/templates/shared/layout.html:10
+#: bookmarks/templates/shared/modal_header.html:6
+msgid "Close dialog"
+msgstr "Dialog schließen"
+
+#: bookmarks/templates/shared/layout.html:37
+msgid "Application logo"
+msgstr "Anwendungslogo"
+
+#: bookmarks/templates/shared/nav_menu.html:8
+#: bookmarks/templates/shared/nav_menu.html:75
+#: bookmarks/templates/tags/index.html:87 bookmarks/views/contexts.py:269
+msgid "Bookmarks"
+msgstr "Lesezeichen"
+
+#: bookmarks/templates/shared/nav_menu.html:11
+msgid "Active"
+msgstr "Aktiv"
+
+#: bookmarks/templates/shared/nav_menu.html:27
+#: bookmarks/templates/shared/nav_menu.html:91 bookmarks/views/manifest.py:70
+msgid "Untagged"
+msgstr "Ohne Tags"
+
+#: bookmarks/templates/shared/nav_menu.html:35
+msgid "General"
+msgstr "Allgemein"
+
+#: bookmarks/templates/shared/nav_menu.html:42
+#: bookmarks/templates/shared/nav_menu.html:102
+msgid "Admin"
+msgstr "Admin"
+
+#: bookmarks/templates/shared/nav_menu.html:52
+#: bookmarks/templates/shared/nav_menu.html:112
+msgid "Logout"
+msgstr "Abmelden"
+
+#: bookmarks/templates/shared/nav_menu.html:66
+msgid "Navigation menu"
+msgstr "Navigationsmenü"
+
+#: bookmarks/templates/shared/nav_menu.html:78 bookmarks/views/contexts.py:277
+msgid "Archived bookmarks"
+msgstr "Archivierte Lesezeichen"
+
+#: bookmarks/templates/shared/pagination.html:7
+#: bookmarks/templates/shared/pagination.html:11
+msgid "Previous"
+msgstr "Zurück"
+
+#: bookmarks/templates/shared/pagination.html:29
+#: bookmarks/templates/shared/pagination.html:33
+msgid "Next"
+msgstr "Weiter"
+
+#: bookmarks/templates/tags/edit.html:13
+msgid "Edit Tag"
+msgstr "Tag bearbeiten"
+
+#: bookmarks/templates/tags/form.html:6
+msgid ""
+"Tag names are case-insensitive and cannot contain spaces (spaces will be "
+"replaced with hyphens)."
+msgstr ""
+"Tag-Namen unterscheiden nicht zwischen Groß- und Kleinschreibung und dürfen "
+"keine Leerzeichen enthalten (Leerzeichen werden durch Bindestriche ersetzt)."
+
+#: bookmarks/templates/tags/index.html:4
+#| msgid "Login - Linkding"
+msgid "Tags - Linkding"
+msgstr "Tags - Linkding"
+
+#: bookmarks/templates/tags/index.html:15 bookmarks/templates/tags/new.html:13
+msgid "Create Tag"
+msgstr "Tag erstellen"
+
+#: bookmarks/templates/tags/index.html:18
+#: bookmarks/templates/tags/merge.html:13
+#: bookmarks/templates/tags/merge.html:48
+msgid "Merge Tags"
+msgstr "Tags zusammenführen"
+
+#: bookmarks/templates/tags/index.html:27
+msgid "Search tags"
+msgstr "Tags suchen"
+
+#: bookmarks/templates/tags/index.html:33
+msgid "Search tags..."
+msgstr "Tags suchen..."
+
+#: bookmarks/templates/tags/index.html:47
+msgid "Name A-Z"
+msgstr "Name A-Z"
+
+#: bookmarks/templates/tags/index.html:48
+msgid "Name Z-A"
+msgstr "Name Z-A"
+
+#: bookmarks/templates/tags/index.html:49
+msgid "Fewest bookmarks"
+msgstr "Wenigste Lesezeichen"
+
+#: bookmarks/templates/tags/index.html:50
+msgid "Most bookmarks"
+msgstr "Meiste Lesezeichen"
+
+#: bookmarks/templates/tags/index.html:61
+msgid "Show only unused tags"
+msgstr "Nur unbenutzte Tags anzeigen"
+
+#: bookmarks/templates/tags/index.html:69
+#, python-format
+msgid "Showing %(count)s of %(total_tags)s tags"
+msgstr "%(count)s von %(total_tags)s Tags"
+
+#: bookmarks/templates/tags/index.html:73
+#, python-format
+msgid "%(total_tags)s tags total"
+msgstr "%(total_tags)s Tags insgesamt"
+
+#: bookmarks/templates/tags/index.html:123
+msgid "No tags found"
+msgstr "Keine Tags gefunden"
+
+#: bookmarks/templates/tags/index.html:124
+msgid "Try adjusting your search or filters"
+msgstr "Suche oder Filter anpassen"
+
+#: bookmarks/templates/tags/index.html:126
+msgid "You have no tags yet"
+msgstr "Noch keine Tags vorhanden"
+
+#: bookmarks/templates/tags/index.html:127
+msgid "Tags will appear here when you add bookmarks with tags"
+msgstr "Tags erscheinen hier, sobald Lesezeichen mit Tags hinzugefügt werden"
+
+#: bookmarks/templates/tags/merge.html:17
+msgid "How to merge tags"
+msgstr "So werden Tags zusammengeführt"
+
+#: bookmarks/templates/tags/merge.html:20
+msgid "Enter the name of the tag you want to keep"
+msgstr "Den Namen des Tags eingeben, der erhalten bleiben soll"
+
+#: bookmarks/templates/tags/merge.html:21
+msgid "Enter the names of tags to merge into the target tag"
+msgstr ""
+"Die Namen der Tags eingeben, die in den Ziel-Tag zusammengeführt werden "
+"sollen"
+
+#: bookmarks/templates/tags/merge.html:22
+msgid ""
+"The target tag is added to all bookmarks that have any of the merge tags"
+msgstr ""
+"Der Ziel-Tag wird allen Lesezeichen hinzugefügt, die einen der "
+"zusammengeführten Tags haben"
+
+#: bookmarks/templates/tags/merge.html:23
+msgid "The merged tags are deleted"
+msgstr "Die zusammengeführten Tags werden gelöscht"
+
+#: bookmarks/templates/tags/merge.html:27
+msgid "Target tag"
+msgstr "Ziel-Tag"
+
+#: bookmarks/templates/tags/merge.html:30
+msgid ""
+"Enter the name of the tag you want to keep. The tags entered below will be "
+"merged into this one."
+msgstr ""
+"Den Namen des Tags eingeben, der erhalten bleiben soll. Die unten "
+"eingegebenen Tags werden in diesen zusammengeführt."
+
+#: bookmarks/templates/tags/merge.html:35
+msgid "Tags to merge"
+msgstr "Zusammenzuführende Tags"
+
+#: bookmarks/templates/tags/merge.html:38
+msgid ""
+"Enter the names of tags to merge into the target tag, separated by spaces. "
+"These tags will be deleted after merging."
+msgstr ""
+"Die Namen der Tags eingeben, die in den Ziel-Tag zusammengeführt werden "
+"sollen, durch Leerzeichen getrennt. Diese Tags werden nach dem "
+"Zusammenführen gelöscht."
+
+#: bookmarks/utils.py:26
+msgid "Monday"
+msgstr "Montag"
+
+#: bookmarks/utils.py:27
+msgid "Tuesday"
+msgstr "Dienstag"
+
+#: bookmarks/utils.py:28
+msgid "Wednesday"
+msgstr "Mittwoch"
+
+#: bookmarks/utils.py:29
+msgid "Thursday"
+msgstr "Donnerstag"
+
+#: bookmarks/utils.py:30
+msgid "Friday"
+msgstr "Freitag"
+
+#: bookmarks/utils.py:31
+msgid "Saturday"
+msgstr "Samstag"
+
+#: bookmarks/utils.py:32
+msgid "Sunday"
+msgstr "Sonntag"
+
+#: bookmarks/utils.py:76 bookmarks/utils.py:105
+msgid "Today"
+msgstr "Heute"
+
+#: bookmarks/utils.py:78 bookmarks/utils.py:107
+msgid "Yesterday"
+msgstr "Gestern"
+
+#: bookmarks/utils.py:91
+#, python-format
+msgid "%(count)d year ago"
+msgid_plural "%(count)d years ago"
+msgstr[0] "vor %(count)d Jahr"
+msgstr[1] "vor %(count)d Jahren"
+
+#: bookmarks/utils.py:95
+#, python-format
+msgid "%(count)d month ago"
+msgid_plural "%(count)d months ago"
+msgstr[0] "vor %(count)d Monat"
+msgstr[1] "vor %(count)d Monaten"
+
+#: bookmarks/utils.py:99
+#, python-format
+msgid "%(count)d week ago"
+msgid_plural "%(count)d weeks ago"
+msgstr[0] "vor %(count)d Woche"
+msgstr[1] "vor %(count)d Wochen"
+
+#: bookmarks/views/bookmarks.py:61
+#| msgid "Login - Linkding"
+msgid "Bookmarks - Linkding"
+msgstr "Lesezeichen - Linkding"
+
+#: bookmarks/views/bookmarks.py:100
+#| msgid "Login - Linkding"
+msgid "Archived bookmarks - Linkding"
+msgstr "Archivierte Lesezeichen - Linkding"
+
+#: bookmarks/views/bookmarks.py:137
+#| msgid "Login - Linkding"
+msgid "Shared bookmarks - Linkding"
+msgstr "Geteilte Lesezeichen - Linkding"
+
+#: bookmarks/views/bookmarks.py:161
+#| msgid "Login - Linkding"
+msgid "Bookmark details - Linkding"
+msgstr "Lesezeichen-Details - Linkding"
+
+#: bookmarks/views/bundles.py:32
+#, python-format
+msgid "Bundle '%(name)s' removed successfully."
+msgstr "Bundle '%(name)s' erfolgreich entfernt."
+
+#: bookmarks/views/bundles.py:68
+msgid "Bundle saved successfully."
+msgstr "Bundle erfolgreich gespeichert."
+
+#: bookmarks/views/contexts.py:156
+msgid "View latest snapshot"
+msgstr "Neuesten Snapshot ansehen"
+
+#: bookmarks/views/contexts.py:160
+msgid "View snapshot on the Internet Archive Wayback Machine"
+msgstr "Snapshot auf der Wayback Machine des Internet Archive ansehen"
+
+#: bookmarks/views/settings.py:77
+msgid "Global settings updated"
+msgstr "Globale Einstellungen aktualisiert"
+
+#: bookmarks/views/settings.py:83
+msgid "Scheduled favicon update. This may take a while..."
+msgstr "Favicon-Aktualisierung geplant. Das kann eine Weile dauern..."
+
+#: bookmarks/views/settings.py:91
+#, python-format
+msgid "Queued %(count)d missing snapshots. This may take a while..."
+msgstr ""
+"%(count)d fehlende Snapshots in die Warteschlange gestellt. Das kann eine "
+"Weile dauern..."
+
+#: bookmarks/views/settings.py:98
+msgid "No missing snapshots found."
+msgstr "Keine fehlenden Snapshots gefunden."
+
+#: bookmarks/views/settings.py:113
 msgid "Profile updated"
 msgstr "Profil aktualisiert"
+
+#: bookmarks/views/settings.py:125
+msgid "Profile update failed, check the form below for errors"
+msgstr ""
+"Profil konnte nicht aktualisiert werden, bitte die Fehler im Formular unten "
+"prüfen"
+
+#: bookmarks/views/settings.py:221
+#, python-format
+msgid "API token \"%(name)s\" created successfully"
+msgstr "API-Token \"%(name)s\" erfolgreich erstellt"
+
+#: bookmarks/views/settings.py:239
+#, python-format
+msgid "API token \"%(name)s\" has been deleted."
+msgstr "API-Token \"%(name)s\" wurde gelöscht."
+
+#: bookmarks/views/settings.py:255
+msgid "Please select a file to import."
+msgstr "Bitte eine Datei zum Importieren auswählen."
+
+#: bookmarks/views/settings.py:262
+#, python-format
+msgid "%(count)s bookmarks were successfully imported."
+msgstr "%(count)s Lesezeichen wurden erfolgreich importiert."
+
+#: bookmarks/views/settings.py:268
+#, python-format
+msgid ""
+"%(count)s bookmarks could not be imported. Please check the logs for more "
+"details."
+msgstr ""
+"%(count)s Lesezeichen konnten nicht importiert werden. Details stehen in den"
+" Logs."
+
+#: bookmarks/views/settings.py:275
+msgid "An error occurred during bookmark import."
+msgstr "Beim Import der Lesezeichen ist ein Fehler aufgetreten."
+
+#: bookmarks/views/settings.py:304
+msgid "An error occurred during bookmark export."
+msgstr "Beim Export der Lesezeichen ist ein Fehler aufgetreten."
+
+#: bookmarks/views/tags.py:75
+#, python-format
+msgid "Tag \"%(name)s\" created successfully."
+msgstr "Tag \"%(name)s\" erfolgreich erstellt."
+
+#: bookmarks/views/tags.py:158
+#, python-format
+msgid "Successfully merged %(count)d tags (%(tags)s) into \"%(target)s\"."
+msgstr "%(count)d Tags (%(tags)s) erfolgreich in \"%(target)s\" zusammengeführt."

--- a/bookmarks/locale/de/LC_MESSAGES/django.po
+++ b/bookmarks/locale/de/LC_MESSAGES/django.po
@@ -1,0 +1,107 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-05 15:49+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: bookmarks/admin.py:152
+#, python-format
+msgid "%d bookmark was successfully deleted."
+msgid_plural "%d bookmarks were successfully deleted."
+msgstr[0] ""
+msgstr[1] ""
+
+#: bookmarks/admin.py:167
+#, python-format
+msgid "%d bookmark was successfully archived."
+msgid_plural "%d bookmarks were successfully archived."
+msgstr[0] ""
+msgstr[1] ""
+
+#: bookmarks/admin.py:182
+#, python-format
+msgid "%d bookmark was successfully unarchived."
+msgid_plural "%d bookmarks were successfully unarchived."
+msgstr[0] ""
+msgstr[1] ""
+
+#: bookmarks/admin.py:196
+#, python-format
+msgid "%d bookmark marked as read."
+msgid_plural "%d bookmarks marked as read."
+msgstr[0] ""
+msgstr[1] ""
+
+#: bookmarks/admin.py:210
+#, python-format
+msgid "%d bookmark marked as unread."
+msgid_plural "%d bookmarks marked as unread."
+msgstr[0] ""
+msgstr[1] ""
+
+#: bookmarks/admin.py:259
+#, python-format
+msgid "%d unused tag was successfully deleted."
+msgid_plural "%d unused tags were successfully deleted."
+msgstr[0] ""
+msgstr[1] ""
+
+#: bookmarks/admin.py:270
+msgid "There were no unused tags in the selection"
+msgstr ""
+
+#: bookmarks/api/auth.py:24
+msgid "Invalid token header. No credentials provided."
+msgstr ""
+
+#: bookmarks/api/auth.py:27
+msgid "Invalid token header. Token string should not contain spaces."
+msgstr ""
+
+#: bookmarks/api/auth.py:34
+msgid ""
+"Invalid token header. Token string should not contain invalid characters."
+msgstr ""
+
+#: bookmarks/templates/registration/login.html:5
+msgid "Login - Linkding"
+msgstr "Anmelden - Linkding"
+
+#: bookmarks/templates/registration/login.html:10
+#: bookmarks/templates/registration/login.html:26
+msgid "Login"
+msgstr "Anmelden"
+
+#: bookmarks/templates/registration/login.html:16
+msgid "Your username and password didn't match. Please try again."
+msgstr "Benutzername und Passwort passen nicht zusammen. Bitte erneut versuchen."
+
+#: bookmarks/templates/registration/login.html:19
+msgid "Username"
+msgstr "Benutzername"
+
+#: bookmarks/templates/registration/login.html:23
+msgid "Password"
+msgstr "Passwort"
+
+#: bookmarks/templates/registration/login.html:33
+msgid "Login with OIDC"
+msgstr "Mit OIDC anmelden"
+
+#: bookmarks/views/settings.py:110
+msgid "Profile updated"
+msgstr "Profil aktualisiert"

--- a/bookmarks/models.py
+++ b/bookmarks/models.py
@@ -11,6 +11,7 @@ from django.db.models import Q
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 from django.http import QueryDict
+from django.utils.translation import gettext_lazy as _
 
 from bookmarks.utils import normalize_url, unique
 from bookmarks.validators import BookmarkURLValidator
@@ -185,14 +186,14 @@ class BookmarkBundle(models.Model):
     FILTER_STATE_YES = "yes"
     FILTER_STATE_NO = "no"
     FILTER_UNREAD_CHOICES = [
-        (FILTER_STATE_OFF, "All"),
-        (FILTER_STATE_YES, "Unread"),
-        (FILTER_STATE_NO, "Read"),
+        (FILTER_STATE_OFF, _("All")),
+        (FILTER_STATE_YES, _("Unread")),
+        (FILTER_STATE_NO, _("Read")),
     ]
     FILTER_SHARED_CHOICES = [
-        (FILTER_STATE_OFF, "All"),
-        (FILTER_STATE_YES, "Shared"),
-        (FILTER_STATE_NO, "Unshared"),
+        (FILTER_STATE_OFF, _("All")),
+        (FILTER_STATE_YES, _("Shared")),
+        (FILTER_STATE_NO, _("Unshared")),
     ]
 
     name = models.CharField(max_length=256, blank=False)
@@ -350,47 +351,47 @@ class UserProfile(models.Model):
     THEME_LIGHT = "light"
     THEME_DARK = "dark"
     THEME_CHOICES = [
-        (THEME_AUTO, "Auto"),
-        (THEME_LIGHT, "Light"),
-        (THEME_DARK, "Dark"),
+        (THEME_AUTO, _("Auto")),
+        (THEME_LIGHT, _("Light")),
+        (THEME_DARK, _("Dark")),
     ]
     BOOKMARK_DATE_DISPLAY_RELATIVE = "relative"
     BOOKMARK_DATE_DISPLAY_ABSOLUTE = "absolute"
     BOOKMARK_DATE_DISPLAY_HIDDEN = "hidden"
     BOOKMARK_DATE_DISPLAY_CHOICES = [
-        (BOOKMARK_DATE_DISPLAY_RELATIVE, "Relative"),
-        (BOOKMARK_DATE_DISPLAY_ABSOLUTE, "Absolute"),
-        (BOOKMARK_DATE_DISPLAY_HIDDEN, "Hidden"),
+        (BOOKMARK_DATE_DISPLAY_RELATIVE, _("Relative")),
+        (BOOKMARK_DATE_DISPLAY_ABSOLUTE, _("Absolute")),
+        (BOOKMARK_DATE_DISPLAY_HIDDEN, _("Hidden")),
     ]
     BOOKMARK_DESCRIPTION_DISPLAY_INLINE = "inline"
     BOOKMARK_DESCRIPTION_DISPLAY_SEPARATE = "separate"
     BOOKMARK_DESCRIPTION_DISPLAY_CHOICES = [
-        (BOOKMARK_DESCRIPTION_DISPLAY_INLINE, "Inline"),
-        (BOOKMARK_DESCRIPTION_DISPLAY_SEPARATE, "Separate"),
+        (BOOKMARK_DESCRIPTION_DISPLAY_INLINE, _("Inline")),
+        (BOOKMARK_DESCRIPTION_DISPLAY_SEPARATE, _("Separate")),
     ]
     BOOKMARK_LINK_TARGET_BLANK = "_blank"
     BOOKMARK_LINK_TARGET_SELF = "_self"
     BOOKMARK_LINK_TARGET_CHOICES = [
-        (BOOKMARK_LINK_TARGET_BLANK, "New page"),
-        (BOOKMARK_LINK_TARGET_SELF, "Same page"),
+        (BOOKMARK_LINK_TARGET_BLANK, _("New page")),
+        (BOOKMARK_LINK_TARGET_SELF, _("Same page")),
     ]
     WEB_ARCHIVE_INTEGRATION_DISABLED = "disabled"
     WEB_ARCHIVE_INTEGRATION_ENABLED = "enabled"
     WEB_ARCHIVE_INTEGRATION_CHOICES = [
-        (WEB_ARCHIVE_INTEGRATION_DISABLED, "Disabled"),
-        (WEB_ARCHIVE_INTEGRATION_ENABLED, "Enabled"),
+        (WEB_ARCHIVE_INTEGRATION_DISABLED, _("Disabled")),
+        (WEB_ARCHIVE_INTEGRATION_ENABLED, _("Enabled")),
     ]
     TAG_SEARCH_STRICT = "strict"
     TAG_SEARCH_LAX = "lax"
     TAG_SEARCH_CHOICES = [
-        (TAG_SEARCH_STRICT, "Strict"),
-        (TAG_SEARCH_LAX, "Lax"),
+        (TAG_SEARCH_STRICT, _("Strict")),
+        (TAG_SEARCH_LAX, _("Lax")),
     ]
     TAG_GROUPING_ALPHABETICAL = "alphabetical"
     TAG_GROUPING_DISABLED = "disabled"
     TAG_GROUPING_CHOICES = [
-        (TAG_GROUPING_ALPHABETICAL, "Alphabetical"),
-        (TAG_GROUPING_DISABLED, "Disabled"),
+        (TAG_GROUPING_ALPHABETICAL, _("Alphabetical")),
+        (TAG_GROUPING_DISABLED, _("Disabled")),
     ]
     user = models.OneToOneField(User, related_name="profile", on_delete=models.CASCADE)
     theme = models.CharField(
@@ -542,8 +543,8 @@ class GlobalSettings(models.Model):
     LANDING_PAGE_LOGIN = "login"
     LANDING_PAGE_SHARED_BOOKMARKS = "shared_bookmarks"
     LANDING_PAGE_CHOICES = [
-        (LANDING_PAGE_LOGIN, "Login"),
-        (LANDING_PAGE_SHARED_BOOKMARKS, "Shared Bookmarks"),
+        (LANDING_PAGE_LOGIN, _("Login")),
+        (LANDING_PAGE_SHARED_BOOKMARKS, _("Shared Bookmarks")),
     ]
 
     landing_page = models.CharField(

--- a/bookmarks/settings/base.py
+++ b/bookmarks/settings/base.py
@@ -14,6 +14,8 @@ import json
 import os
 import shlex
 
+from bookmarks.i18n import discover_extra_languages
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 # BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -126,10 +128,17 @@ SESSION_COOKIE_NAME = "ld_sessionid"
 
 LANGUAGE_CODE = "en-us"
 
+# Translations in the data folder take precedence over the ones bundled with
+# the application, and additional languages found there are added to LANGUAGES
+LOCALE_PATHS = [os.path.join(BASE_DIR, "data", "locale")]
+
 LANGUAGES = [
     ("en", "English"),
     ("de", "Deutsch"),
 ]
+LANGUAGES += discover_extra_languages(
+    LOCALE_PATHS[0], [code for code, name in LANGUAGES]
+)
 
 TIME_ZONE = os.getenv("TZ", "UTC")
 

--- a/bookmarks/settings/base.py
+++ b/bookmarks/settings/base.py
@@ -126,6 +126,11 @@ SESSION_COOKIE_NAME = "ld_sessionid"
 
 LANGUAGE_CODE = "en-us"
 
+LANGUAGES = [
+    ("en", "English"),
+    ("de", "Deutsch"),
+]
+
 TIME_ZONE = os.getenv("TZ", "UTC")
 
 USE_I18N = True

--- a/bookmarks/templates/admin/background_tasks.html
+++ b/bookmarks/templates/admin/background_tasks.html
@@ -1,12 +1,13 @@
 {% extends "admin/base_site.html" %}
+{% load i18n %}
 {% block content %}
   <table style="width: 100%">
     <thead>
       <tr>
-        <th>ID</th>
-        <th>Name</th>
-        <th>Args</th>
-        <th>Retries</th>
+        <th>{% translate "ID" %}</th>
+        <th>{% translate "Name" %}</th>
+        <th>{% translate "Args" %}</th>
+        <th>{% translate "Retries" %}</th>
       </tr>
     </thead>
     <tbody>
@@ -33,6 +34,6 @@
       {% endfor %}
       &nbsp;
     {% endif %}
-    {{ page.paginator.count }} tasks
+    {% blocktranslate count counter=page.paginator.count %}{{ counter }} task{% plural %}{{ counter }} tasks{% endblocktranslate %}
   </p>
 {% endblock %}

--- a/bookmarks/templates/bookmarks/bookmark_list.html
+++ b/bookmarks/templates/bookmarks/bookmark_list.html
@@ -1,8 +1,8 @@
-{% load static shared pagination %}
+{% load static shared pagination i18n %}
 {% if bookmark_list.is_empty %}
   {% include 'bookmarks/empty_bookmarks.html' %}
 {% else %}
-  <section aria-label="Bookmark list">
+  <section aria-label="{% translate 'Bookmark list' %}">
     <ul class="bookmark-list{% if bookmark_list.show_notes %} show-notes{% endif %}"
         role="list"
         tabindex="-1"
@@ -78,24 +78,24 @@
                   <a href="{{ bookmark_item.details_url }}"
                      class="view-action"
                      data-turbo-action="replace"
-                     data-turbo-frame="details-modal">View</a>
+                     data-turbo-frame="details-modal">{% translate "View" %}</a>
                 {% endif %}
                 {% if bookmark_item.is_editable %}
                   {# Bookmark owner actions #}
                   {% if bookmark_list.show_edit_action %}
-                    <a href="{% url 'linkding:bookmarks.edit' bookmark_item.id %}?return_url={{ bookmark_list.return_url|urlencode }}">Edit</a>
+                    <a href="{% url 'linkding:bookmarks.edit' bookmark_item.id %}?return_url={{ bookmark_list.return_url|urlencode }}">{% translate "Edit" %}</a>
                   {% endif %}
                   {% if bookmark_list.show_archive_action %}
                     {% if bookmark_item.is_archived %}
                       <button type="submit"
                               name="unarchive"
                               value="{{ bookmark_item.id }}"
-                              class="btn btn-link btn-sm">Unarchive</button>
+                              class="btn btn-link btn-sm">{% translate "Unarchive" %}</button>
                     {% else %}
                       <button type="submit"
                               name="archive"
                               value="{{ bookmark_item.id }}"
-                              class="btn btn-link btn-sm">Archive</button>
+                              class="btn btn-link btn-sm">{% translate "Archive" %}</button>
                     {% endif %}
                   {% endif %}
                   {% if bookmark_list.show_remove_action %}
@@ -103,12 +103,15 @@
                             type="submit"
                             name="remove"
                             value="{{ bookmark_item.id }}"
-                            class="btn btn-link btn-sm">Remove</button>
+                            class="btn btn-link btn-sm">{% translate "Remove" %}</button>
                   {% endif %}
                 {% else %}
                   {# Shared bookmark actions #}
-                  <span>Shared by
-                    <a href="?{% replace_query_param user=bookmark_item.owner.username %}">{{ bookmark_item.owner.username }}</a>
+                  {% replace_query_param user=bookmark_item.owner.username as owner_query %}
+                  <span>
+                    {% blocktranslate trimmed with username=bookmark_item.owner.username %}
+                      Shared by <a href="?{{ owner_query }}">{{ username }}</a>
+                    {% endblocktranslate %}
                   </span>
                 {% endif %}
                 {% if bookmark_item.has_extra_actions %}
@@ -120,11 +123,11 @@
                               value="{{ bookmark_item.id }}"
                               class="btn btn-link btn-sm btn-icon"
                               data-confirm
-                              data-confirm-question="Mark as read?">
+                              data-confirm-question="{% translate 'Mark as read?' %}">
                         <svg width="16" height="16">
                           <use href="{% static 'icons.svg' %}?v={{ app_version }}#unread"></use>
                         </svg>
-                        Unread
+                        {% translate "Unread" %}
                       </button>
                     {% endif %}
                     {% if bookmark_item.show_unshare %}
@@ -133,11 +136,11 @@
                               value="{{ bookmark_item.id }}"
                               class="btn btn-link btn-sm btn-icon"
                               data-confirm
-                              data-confirm-question="Unshare?">
+                              data-confirm-question="{% translate 'Unshare?' %}">
                         <svg width="16" height="16">
                           <use href="{% static 'icons.svg' %}?v={{ app_version }}#share"></use>
                         </svg>
-                        Shared
+                        {% translate "Shared" %}
                       </button>
                     {% endif %}
                     {% if bookmark_item.show_notes_button %}
@@ -145,7 +148,7 @@
                         <svg width="16" height="16">
                           <use href="{% static 'icons.svg' %}?v={{ app_version }}#note"></use>
                         </svg>
-                        Notes
+                        {% translate "Notes" %}
                       </button>
                     {% endif %}
                   </div>

--- a/bookmarks/templates/bookmarks/bookmark_page.html
+++ b/bookmarks/templates/bookmarks/bookmark_page.html
@@ -1,5 +1,5 @@
 {% extends "shared/layout.html" %}
-{% load static shared bookmarks %}
+{% load static shared bookmarks i18n %}
 {% block content %}
   <ld-bookmark-page {% if not bookmark_list.bulk_edit_enabled %}no-bulk-edit{% endif %}
                     class="bookmarks-page grid columns-md-1 {% if bookmark_list.collapse_side_panel %}collapse-side-panel{% endif %}">
@@ -10,14 +10,15 @@
         <div class="header-controls">
           {% bookmark_search bookmark_list.search mode=bookmark_list.search_mode %}
           {% if bookmark_list.bulk_edit_enabled %}
-            <button class="btn hide-sm ml-2 bulk-edit-active-toggle" title="Bulk edit">
+            <button class="btn hide-sm ml-2 bulk-edit-active-toggle"
+                    title="{% translate 'Bulk edit' %}">
               <svg width="20px" height="20px">
                 <use href="{% static 'icons.svg' %}?v={{ app_version }}#bulk-edit"></use>
               </svg>
             </button>
           {% endif %}
           <ld-filter-drawer-trigger>
-            <button class="btn ml-2">Filters</button>
+            <button class="btn ml-2">{% translate "Filters" %}</button>
           </ld-filter-drawer-trigger>
         </div>
       </div>

--- a/bookmarks/templates/bookmarks/bulk_edit_bar.html
+++ b/bookmarks/templates/bookmarks/bulk_edit_bar.html
@@ -1,4 +1,4 @@
-{% load shared %}
+{% load shared i18n %}
 {% htmlmin %}
 <div class="bulk-edit-bar">
   <label class="form-checkbox bulk-edit-checkbox all">
@@ -7,37 +7,41 @@
   </label>
   <select name="bulk_action" class="form-select select-sm">
     {% if not 'bulk_archive' in bookmark_list.bulk_edit_disabled_actions %}
-      <option value="bulk_archive">Archive</option>
+      <option value="bulk_archive">{% translate "Archive" %}</option>
     {% endif %}
     {% if not 'bulk_unarchive' in bookmark_list.bulk_edit_disabled_actions %}
-      <option value="bulk_unarchive">Unarchive</option>
+      <option value="bulk_unarchive">{% translate "Unarchive" %}</option>
     {% endif %}
-    <option value="bulk_delete">Delete</option>
-    <option value="bulk_tag">Add tags</option>
-    <option value="bulk_untag">Remove tags</option>
-    <option value="bulk_read">Mark as read</option>
-    <option value="bulk_unread">Mark as unread</option>
+    <option value="bulk_delete">{% translate "Delete" %}</option>
+    <option value="bulk_tag">{% translate "Add tags" %}</option>
+    <option value="bulk_untag">{% translate "Remove tags" %}</option>
+    <option value="bulk_read">{% translate "Mark as read" %}</option>
+    <option value="bulk_unread">{% translate "Mark as unread" %}</option>
     {% if request.user_profile.enable_sharing %}
-      <option value="bulk_share">Share</option>
-      <option value="bulk_unshare">Unshare</option>
+      <option value="bulk_share">{% translate "Share" %}</option>
+      <option value="bulk_unshare">{% translate "Unshare" %}</option>
     {% endif %}
-    <option value="bulk_refresh">Refresh from website</option>
-    {% if bookmark_list.snapshot_feature_enabled %}<option value="bulk_snapshot">Create HTML snapshot</option>{% endif %}
+    <option value="bulk_refresh">{% translate "Refresh from website" %}</option>
+    {% if bookmark_list.snapshot_feature_enabled %}
+      <option value="bulk_snapshot">{% translate "Create HTML snapshot" %}</option>
+    {% endif %}
   </select>
   <ld-tag-autocomplete input-name="bulk_tag_string"
-                       input-placeholder="Tag names..."
+                       input-placeholder="{% translate 'Tag names...' %}"
                        variant="small">
   </ld-tag-autocomplete>
   <button data-confirm
           type="submit"
           name="bulk_execute"
           class="btn btn-link btn-sm">
-    <span>Execute</span>
+    <span>{% translate "Execute" %}</span>
   </button>
   <label class="form-checkbox select-across d-none">
     <input type="checkbox" name="bulk_select_across">
     <i class="form-icon"></i>
-    All <span class="total">{{ bookmark_list.bookmarks_total }}</span> bookmarks
+    {% blocktranslate trimmed with total=bookmark_list.bookmarks_total %}
+      All <span class="total">{{ total }}</span> bookmarks
+    {% endblocktranslate %}
   </label>
 </div>
 {% endhtmlmin %}

--- a/bookmarks/templates/bookmarks/bundle_section.html
+++ b/bookmarks/templates/bookmarks/bundle_section.html
@@ -1,23 +1,23 @@
-{% load static %}
+{% load static i18n %}
 {% if not request.user_profile.hide_bundles %}
   <section aria-labelledby="bundles-heading">
     <div class="section-header no-wrap">
-      <h2 id="bundles-heading">Bundles</h2>
+      <h2 id="bundles-heading">{% translate "Bundles" %}</h2>
       <ld-dropdown class="dropdown dropdown-right ml-auto">
-        <button class="btn btn-noborder dropdown-toggle" aria-label="Bundles menu">
+        <button class="btn btn-noborder dropdown-toggle"
+                aria-label="{% translate 'Bundles menu' %}">
           <svg width="20" height="20">
             <use href="{% static 'icons.svg' %}?v={{ app_version }}#menu"></use>
           </svg>
         </button>
         <ul class="menu" role="list" tabindex="-1">
           <li class="menu-item">
-            <a href="{% url 'linkding:bundles.index' %}" class="menu-link">Manage bundles</a>
+            <a href="{% url 'linkding:bundles.index' %}" class="menu-link">{% translate "Manage bundles" %}</a>
           </li>
           {% if bookmark_list.search.q %}
             <li class="menu-item">
               <a href="{% url 'linkding:bundles.new' %}?q={{ bookmark_list.search.q|urlencode }}"
-                 class="menu-link">Create
-              bundle from search</a>
+                 class="menu-link">{% translate "Create bundle from search" %}</a>
             </li>
           {% endif %}
         </ul>

--- a/bookmarks/templates/bookmarks/close.html
+++ b/bookmarks/templates/bookmarks/close.html
@@ -1,7 +1,8 @@
 {% extends "shared/layout.html" %}
+{% load i18n %}
 {% block content %}
   <script type="application/javascript">
     window.close()
   </script>
-  <p>You can now close this window.</p>
+  <p>{% translate "You can now close this window." %}</p>
 {% endblock %}

--- a/bookmarks/templates/bookmarks/details/assets.html
+++ b/bookmarks/templates/bookmarks/details/assets.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 <div>
   {% if details.assets %}
     <div class="item-list assets">
@@ -7,8 +8,12 @@
           <div class="list-item-text {{ asset.text_classes }}">
             <span class="truncate">
               {{ asset.display_name }}
-              {% if asset.status == 'pending' %}(queued){% endif %}
-              {% if asset.status == 'failure' %}(failed){% endif %}
+              {% if asset.status == 'pending' %}
+                {% translate "(queued)" %}
+              {% endif %}
+              {% if asset.status == 'failure' %}
+                {% translate "(failed)" %}
+              {% endif %}
             </span>
             {% if asset.file_size %}<span class="filesize">{{ asset.file_size|filesizeformat }}</span>{% endif %}
           </div>
@@ -16,14 +21,14 @@
             {% if asset.file %}
               <a class="btn btn-link"
                  href="{% url 'linkding:assets.view' asset.id %}"
-                 target="_blank">View</a>
+                 target="_blank">{% translate "View" %}</a>
             {% endif %}
             {% if details.is_editable %}
               <button data-confirm
                       type="submit"
                       name="remove_asset"
                       value="{{ asset.id }}"
-                      class="btn btn-link">Remove</button>
+                      class="btn btn-link">{% translate "Remove" %}</button>
             {% endif %}
           </div>
         </div>
@@ -37,7 +42,7 @@
                 name="create_html_snapshot"
                 value="{{ details.bookmark.id }}"
                 class="btn btn-sm"
-                {% if details.has_pending_assets %}disabled{% endif %}>Create HTML snapshot</button>
+                {% if details.has_pending_assets %}disabled{% endif %}>{% translate "Create HTML snapshot" %}</button>
       {% endif %}
       {% if details.uploads_enabled %}
         <ld-upload-button>
@@ -45,7 +50,7 @@
                   name="upload_asset"
                   value="{{ details.bookmark.id }}"
                   type="submit"
-                  class="btn btn-sm">Upload file</button>
+                  class="btn btn-sm">{% translate "Upload file" %}</button>
           <input id="upload-asset-file"
                  name="upload_asset_file"
                  type="file"

--- a/bookmarks/templates/bookmarks/details/form.html
+++ b/bookmarks/templates/bookmarks/details/form.html
@@ -1,5 +1,6 @@
 {% load static %}
 {% load shared %}
+{% load i18n %}
 <ld-form>
   <form action="{{ details.action_url }}"
         method="post"
@@ -27,7 +28,7 @@
               <use href="{% static 'icons.svg' %}?v={{ app_version }}#unread"></use>
             </svg>
           {% endif %}
-          <span>Reader mode</span>
+          <span>{% translate "Reader mode" %}</span>
         </a>
       {% endif %}
       {% if details.web_archive_snapshot_url %}
@@ -53,7 +54,7 @@
     <div class="sections grid columns-2 columns-sm-1 gap-0">
       {% if details.is_editable %}
         <section class="status col-2">
-          <h3>Status</h3>
+          <h3>{% translate "Status" %}</h3>
           <div class="d-flex" style="gap: .8rem">
             <div class="form-group">
               <label class="form-checkbox">
@@ -61,7 +62,7 @@
                        type="checkbox"
                        name="is_archived"
                        {% if details.bookmark.is_archived %}checked{% endif %}>
-                <i class="form-icon"></i> Archived
+                <i class="form-icon"></i> {% translate "Archived" %}
               </label>
             </div>
             <div class="form-group">
@@ -70,7 +71,7 @@
                        type="checkbox"
                        name="unread"
                        {% if details.bookmark.unread %}checked{% endif %}>
-                <i class="form-icon"></i> Unread
+                <i class="form-icon"></i> {% translate "Unread" %}
               </label>
             </div>
             {% if details.profile.enable_sharing %}
@@ -80,7 +81,7 @@
                          type="checkbox"
                          name="shared"
                          {% if details.bookmark.shared %}checked{% endif %}>
-                  <i class="form-icon"></i> Shared
+                  <i class="form-icon"></i> {% translate "Shared" %}
                 </label>
               </div>
             {% endif %}
@@ -88,12 +89,12 @@
         </section>
       {% endif %}
       <section class="files col-2">
-        <h3>Files</h3>
+        <h3>{% translate "Files" %}</h3>
         <div>{% include 'bookmarks/details/assets.html' %}</div>
       </section>
       {% if details.bookmark.tag_names %}
         <section class="tags col-1">
-          <h3 id="details-modal-tags-title">Tags</h3>
+          <h3 id="details-modal-tags-title">{% translate "Tags" %}</h3>
           <div>
             {% for tag in details.tags %}
               <a href="{% url 'linkding:bookmarks.index' %}?{{ tag.query_string }}">{{ tag.name }}</a>
@@ -102,20 +103,20 @@
         </section>
       {% endif %}
       <section class="date-added col-1">
-        <h3>Date added</h3>
+        <h3>{% translate "Date added" %}</h3>
         <div>
           <span>{{ details.bookmark.date_added }}</span>
         </div>
       </section>
       {% if details.bookmark.resolved_description %}
         <section class="description col-2">
-          <h3>Description</h3>
+          <h3>{% translate "Description" %}</h3>
           <div>{{ details.bookmark.resolved_description }}</div>
         </section>
       {% endif %}
       {% if details.bookmark.notes %}
         <section class="notes col-2">
-          <h3>Notes</h3>
+          <h3>{% translate "Notes" %}</h3>
           <div class="markdown">{% markdown details.bookmark.notes %}</div>
         </section>
       {% endif %}

--- a/bookmarks/templates/bookmarks/details/modal.html
+++ b/bookmarks/templates/bookmarks/details/modal.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 <turbo-frame id="details-modal" target="_top">
 {% if details %}
   <ld-details-modal class="modal active bookmark-details"
@@ -13,7 +14,7 @@
           <div class="actions">
             <div class="left-actions">
               <a class="btn btn-wide"
-                 href="{% url 'linkding:bookmarks.edit' details.bookmark.id %}?return_url={{ details.edit_return_url|urlencode }}">Edit</a>
+                 href="{% url 'linkding:bookmarks.edit' details.bookmark.id %}?return_url={{ details.edit_return_url|urlencode }}">{% translate "Edit" %}</a>
             </div>
             <div class="right-actions">
               <form action="{{ details.delete_url }}"
@@ -25,7 +26,7 @@
                         class="btn btn-error btn-wide"
                         type="submit"
                         name="remove"
-                        value="{{ details.bookmark.id }}">Delete</button>
+                        value="{{ details.bookmark.id }}">{% translate "Delete" %}</button>
               </form>
             </div>
           </div>

--- a/bookmarks/templates/bookmarks/edit.html
+++ b/bookmarks/templates/bookmarks/edit.html
@@ -1,12 +1,13 @@
 {% extends 'shared/layout.html' %}
+{% load i18n %}
 {% block head %}
-  {% with page_title="Edit bookmark - Linkding" %}{{ block.super }}{% endwith %}
+  {% with page_title=_("Edit bookmark - Linkding") %}{{ block.super }}{% endwith %}
 {% endblock %}
 {% block content %}
   <div class="bookmarks-form-page">
     <main aria-labelledby="main-heading">
       <div class="section-header">
-        <h1 id="main-heading">Edit bookmark</h1>
+        <h1 id="main-heading">{% translate "Edit bookmark" %}</h1>
       </div>
       <ld-form data-submit-on-ctrl-enter>
         <form action="{% url 'linkding:bookmarks.edit' bookmark_id %}?return_url={{ return_url|urlencode }}"

--- a/bookmarks/templates/bookmarks/empty_bookmarks.html
+++ b/bookmarks/templates/bookmarks/empty_bookmarks.html
@@ -1,16 +1,24 @@
+{% load i18n %}
 <div class="empty mt-4">
   {% if not bookmark_list.query_is_valid %}
-    <p class="empty-title h5">Invalid search query</p>
+    <p class="empty-title h5">{% translate "Invalid search query" %}</p>
     <p class="empty-subtitle">
-      The search query you entered is not valid. Common reasons are unclosed parentheses or a logical operator (AND, OR,
-      NOT) without operands. The error message from the parser is: "{{ bookmark_list.query_error_message }}".
+      {% blocktranslate trimmed with error_message=bookmark_list.query_error_message %}
+        The search query you entered is not valid. Common reasons are unclosed parentheses or a logical operator (AND, OR,
+        NOT) without operands. The error message from the parser is: "{{ error_message }}".
+      {% endblocktranslate %}
     </p>
   {% else %}
-    <p class="empty-title h5">You have no bookmarks yet</p>
+    <p class="empty-title h5">{% translate "You have no bookmarks yet" %}</p>
+    {% url 'linkding:bookmarks.new' as new_url %}
+    {% url 'linkding:settings.general' as settings_url %}
+    {% url 'linkding:settings.integrations' as integrations_url %}
     <p class="empty-subtitle">
-      You can get started by <a href="{% url 'linkding:bookmarks.new' %}">adding</a> bookmarks,
-      <a href="{% url 'linkding:settings.general' %}">importing</a> your existing bookmarks or configuring the
-      <a href="{% url 'linkding:settings.integrations' %}">browser extension</a> or the <a href="{% url 'linkding:settings.integrations' %}">bookmarklet</a>.
+      {% blocktranslate trimmed %}
+        You can get started by <a href="{{ new_url }}">adding</a> bookmarks,
+        <a href="{{ settings_url }}">importing</a> your existing bookmarks or configuring the
+        <a href="{{ integrations_url }}">browser extension</a> or the <a href="{{ integrations_url }}">bookmarklet</a>.
+      {% endblocktranslate %}
     </p>
   {% endif %}
 </div>

--- a/bookmarks/templates/bookmarks/form.html
+++ b/bookmarks/templates/bookmarks/form.html
@@ -1,36 +1,43 @@
 {% load static %}
 {% load shared %}
+{% load i18n %}
 <div class="bookmarks-form">
   {% csrf_token %}
   {{ form.auto_close }}
   <div class="form-group">
-    {% formlabel form.url "URL" %}
+    {% formlabel form.url _("URL") %}
     <div class="has-icon-right">
       {% formfield form.url autofocus=True %}
       <i class="form-icon loading"></i>
     </div>
     {{ form.url.errors }}
     <div class="form-input-hint bookmark-exists">
-      This URL is already bookmarked.
-      The form has been pre-filled with the existing bookmark, and saving the form will update the existing bookmark.
+      {% blocktranslate trimmed %}
+        This URL is already bookmarked.
+        The form has been pre-filled with the existing bookmark, and saving the form will update the existing bookmark.
+      {% endblocktranslate %}
     </div>
   </div>
   <div class="form-group">
-    {% formlabel form.tag_string "Tags" %}
+    {% formlabel form.tag_string _("Tags") %}
     {% formfield form.tag_string has_help=True %}
     {% formhelp form.tag_string %}
-      Enter any number of tags separated by space and <strong>without</strong> the hash (#).
-      If a tag does not exist it will be automatically created.
+      {% blocktranslate trimmed %}
+        Enter any number of tags separated by space and <strong>without</strong> the hash (#).
+        If a tag does not exist it will be automatically created.
+      {% endblocktranslate %}
     {% endformhelp %}
     <div class="form-input-hint auto-tags"></div>
   </div>
   <div class="form-group">
     <div class="d-flex justify-between align-baseline">
-      {% formlabel form.title "Title" %}
+      {% formlabel form.title _("Title") %}
       <div class="flex">
-        <button id="refresh-button" class="btn btn-link suffix-button" type="button">Refresh from website</button>
+        <button id="refresh-button" class="btn btn-link suffix-button" type="button">
+          {% translate "Refresh from website" %}
+        </button>
         <ld-clear-button data-for="{{ form.title.id_for_label }}">
-          <button class="ml-2 btn btn-link suffix-button" type="button">Clear</button>
+          <button class="ml-2 btn btn-link suffix-button" type="button">{% translate "Clear" %}</button>
         </ld-clear-button>
       </div>
     </div>
@@ -38,9 +45,9 @@
   </div>
   <div class="form-group">
     <div class="d-flex justify-between align-baseline">
-      {% formlabel form.description "Description" %}
+      {% formlabel form.description _("Description") %}
       <ld-clear-button data-for="{{ form.description.id_for_label }}">
-        <button class="btn btn-link suffix-button" type="button">Clear</button>
+        <button class="btn btn-link suffix-button" type="button">{% translate "Clear" %}</button>
       </ld-clear-button>
     </div>
     {% formfield form.description rows="3" %}
@@ -48,29 +55,29 @@
   <div class="form-group">
     <details class="notes"{% if form.has_notes %} open{% endif %}>
       <summary>
-        <span class="form-label d-inline-block">Notes</span>
+        <span class="form-label d-inline-block">{% translate "Notes" %}</span>
       </summary>
-      <label for="{{ form.notes.id_for_label }}" class="text-assistive">Notes</label>
+      <label for="{{ form.notes.id_for_label }}" class="text-assistive">{% translate "Notes" %}</label>
       {% formfield form.notes rows="8" has_help=True %}
       {% formhelp form.notes %}
-        Additional notes, supports Markdown.
+        {% translate "Additional notes, supports Markdown." %}
       {% endformhelp %}
     </details>
   </div>
   <div class="form-group">
-    {% formfield form.unread label="Mark as unread" has_help=True %}
+    {% formfield form.unread label=_("Mark as unread") has_help=True %}
     {% formhelp form.unread %}
-      Unread bookmarks can be filtered for, and marked as read after you had a chance to look at them.
+      {% translate "Unread bookmarks can be filtered for, and marked as read after you had a chance to look at them." %}
     {% endformhelp %}
   </div>
   {% if request.user_profile.enable_sharing %}
     <div class="form-group">
-      {% formfield form.shared label="Share" has_help=True %}
+      {% formfield form.shared label=_("Share") has_help=True %}
       {% formhelp form.shared %}
         {% if request.user_profile.enable_public_sharing %}
-          Share this bookmark with other registered users and anonymous users.
+          {% translate "Share this bookmark with other registered users and anonymous users." %}
         {% else %}
-          Share this bookmark with other registered users.
+          {% translate "Share this bookmark with other registered users." %}
         {% endif %}
       {% endformhelp %}
     </div>
@@ -78,14 +85,17 @@
   <div class="divider"></div>
   <div class="form-group d-flex justify-between">
     {% if form.is_auto_close %}
-      <input type="submit" value="Save and close" class="btn btn-primary btn-wide">
+      <input type="submit"
+             value="{% translate 'Save and close' %}"
+             class="btn btn-primary btn-wide">
     {% else %}
       <input type="submit"
-             value="Save"
+             value="{% translate 'Save' %}"
              class="btn btn-primary btn btn-primary btn-wide">
     {% endif %}
-    <a href="{{ return_url }}" class="btn">Cancel</a>
+    <a href="{{ return_url }}" class="btn">{% translate "Cancel" %}</a>
   </div>
+  {% translate "Auto tags:" as auto_tags_label %}
   <script type="application/javascript">
     /**
      * - Pre-fill title and description with metadata from website as soon as URL changes
@@ -176,7 +186,7 @@
             if (autoTags.length > 0) {
               autoTags.sort();
               autoTagsHint.style['display'] = 'block';
-              autoTagsHint.innerHTML = `Auto tags: ${autoTags.join(" ")}`;
+              autoTagsHint.innerHTML = `{{ auto_tags_label|escapejs }} ${autoTags.join(" ")}`;
             } else {
               autoTagsHint.style['display'] = 'none';
             }

--- a/bookmarks/templates/bookmarks/new.html
+++ b/bookmarks/templates/bookmarks/new.html
@@ -1,12 +1,13 @@
 {% extends 'shared/layout.html' %}
+{% load i18n %}
 {% block head %}
-  {% with page_title="New bookmark - Linkding" %}{{ block.super }}{% endwith %}
+  {% with page_title=_("New bookmark - Linkding") %}{{ block.super }}{% endwith %}
 {% endblock %}
 {% block content %}
   <div class="bookmarks-form-page">
     <main aria-labelledby="main-heading">
       <div class="section-header">
-        <h1 id="main-heading">New bookmark</h1>
+        <h1 id="main-heading">{% translate "New bookmark" %}</h1>
       </div>
       <ld-form data-submit-on-ctrl-enter>
         <form action="{% url 'linkding:bookmarks.new' %}" method="post" novalidate>

--- a/bookmarks/templates/bookmarks/read.html
+++ b/bookmarks/templates/bookmarks/read.html
@@ -1,9 +1,9 @@
-{% load static %}
+{% load static i18n %}
 <!DOCTYPE html>
 <html lang="en" class="reader-mode">
   <head>
     <meta charset="UTF-8">
-    <title>Reader view</title>
+    <title>{% translate "Reader view" %}</title>
     <meta name="viewport"
           content="width=device-width, initial-scale=1.0, minimal-ui">
     {# Include specific theme variant based on user profile setting #}
@@ -44,6 +44,7 @@
     <template id="content">{{ content|safe }}</template>
     <script src="{% static 'vendor/Readability.js' %}"
             type="application/javascript"></script>
+    {% translate 'minutes' as minutes_label %}
     <script type="application/javascript">
       function estimateReadingTime(charCount, wordsPerMinute) {
         const avgWordLength = 5;
@@ -85,7 +86,7 @@
           const maxTime = estimateReadingTime(article.length, 175);
 
           const articleReadingTime = document.createElement('p');
-          articleReadingTime.textContent = `${minTime}-${maxTime} minutes`;
+          articleReadingTime.textContent = `${minTime}-${maxTime} {{ minutes_label|escapejs }}`;
           articleReadingTime.classList.add('reading-time');
           container.append(articleReadingTime);
         }

--- a/bookmarks/templates/bookmarks/search.html
+++ b/bookmarks/templates/bookmarks/search.html
@@ -1,8 +1,8 @@
-{% load static shared %}
+{% load static shared i18n %}
 <div class="search-container">
   <form id="search" action="" method="get" role="search">
     <ld-search-autocomplete input-name="q"
-                            input-placeholder="Search for words or #tags"
+                            input-placeholder="{% translate 'Search for words or #tags' %}"
                             input-value="{{ search.q|default_if_none:'' }}"
                             target="{{ request.user_profile.bookmark_link_target }}"
                             mode="{{ mode }}"
@@ -10,12 +10,12 @@
                             shared="{{ search.shared }}"
                             unread="{{ search.unread }}">
     </ld-search-autocomplete>
-    <input type="submit" value="Search" class="d-none">
+    <input type="submit" value="{% translate 'Search' %}" class="d-none">
     {% for hidden_field in search_form.hidden_fields %}{{ hidden_field }}{% endfor %}
   </form>
   <ld-dropdown class="search-options dropdown dropdown-right">
     <button type="button"
-            aria-label="Search preferences"
+            aria-label="{% translate 'Search preferences' %}"
             class="btn dropdown-toggle{% if search.has_modified_preferences %} badge{% endif %}">
       <svg width="20" height="20">
         <use href="{% static 'icons.svg' %}?v={{ app_version }}#preferences"></use>
@@ -27,7 +27,9 @@
         {% if 'sort' in preferences_form.editable_fields %}
           <div class="form-group">
             <label for="{{ preferences_form.sort.id_for_label }}"
-                   class="form-label{% if 'sort' in search.modified_params %} text-bold{% endif %}">Sort by</label>
+                   class="form-label{% if 'sort' in search.modified_params %} text-bold{% endif %}">
+              {% translate "Sort by" %}
+            </label>
             {% formfield preferences_form.sort class='select-sm' %}
           </div>
         {% endif %}
@@ -37,7 +39,7 @@
                aria-labelledby="search-shared-label">
             <label id="search-shared-label"
                    class="form-label{% if 'shared' in search.modified_params %} text-bold{% endif %}">
-              Shared filter
+              {% translate "Shared filter" %}
             </label>
             {% for radio in preferences_form.shared %}
               <label for="{{ radio.id_for_label }}" class="form-radio form-inline">
@@ -54,7 +56,7 @@
                aria-labelledby="search-unread-label">
             <label id="search-unread-label"
                    class="form-label{% if 'unread' in search.modified_params %} text-bold{% endif %}">
-              Unread filter
+              {% translate "Unread filter" %}
             </label>
             {% for radio in preferences_form.unread %}
               <label for="{{ radio.id_for_label }}" class="form-radio form-inline">
@@ -66,9 +68,9 @@
           </div>
         {% endif %}
         <div class="actions">
-          <button type="submit" class="btn btn-sm btn-primary" name="apply">Apply</button>
+          <button type="submit" class="btn btn-sm btn-primary" name="apply">{% translate "Apply" %}</button>
           {% if request.user.is_authenticated %}
-            <button type="submit" class="btn btn-sm" name="save">Save as default</button>
+            <button type="submit" class="btn btn-sm" name="save">{% translate "Save as default" %}</button>
           {% endif %}
         </div>
         {% for hidden_field in preferences_form.hidden_fields %}{{ hidden_field }}{% endfor %}

--- a/bookmarks/templates/bookmarks/tag_section.html
+++ b/bookmarks/templates/bookmarks/tag_section.html
@@ -1,17 +1,18 @@
-{% load static %}
+{% load static i18n %}
 <section aria-labelledby="tags-heading">
   <div class="section-header no-wrap">
-    <h2 id="tags-heading">Tags</h2>
+    <h2 id="tags-heading">{% translate "Tags" %}</h2>
     {% if user.is_authenticated %}
       <ld-dropdown class="dropdown dropdown-right ml-auto">
-        <button class="btn btn-noborder dropdown-toggle" aria-label="Tags menu">
+        <button class="btn btn-noborder dropdown-toggle"
+                aria-label="{% translate 'Tags menu' %}">
           <svg width="20" height="20">
             <use href="{% static 'icons.svg' %}?v={{ app_version }}#menu"></use>
           </svg>
         </button>
         <ul class="menu" role="list" tabindex="-1">
           <li class="menu-item">
-            <a href="{% url 'linkding:tags.index' %}" class="menu-link">Manage tags</a>
+            <a href="{% url 'linkding:tags.index' %}" class="menu-link">{% translate "Manage tags" %}</a>
           </li>
         </ul>
       </ld-dropdown>

--- a/bookmarks/templates/bookmarks/user_section.html
+++ b/bookmarks/templates/bookmarks/user_section.html
@@ -1,7 +1,7 @@
-{% load shared %}
+{% load shared i18n %}
 <section aria-labelledby="user-heading">
   <div class="section-header">
-    <h2 id="user-heading">User</h2>
+    <h2 id="user-heading">{% translate "User" %}</h2>
   </div>
   <div>
     <ld-form data-form-reset>
@@ -11,7 +11,7 @@
           <div class="d-flex">
             {% formfield user_list.form.user data_submit_on_change="" %}
             <noscript>
-              <button type="submit" class="btn btn-link ml-2">Apply</button>
+              <button type="submit" class="btn btn-link ml-2">{% translate "Apply" %}</button>
             </noscript>
           </div>
         </div>

--- a/bookmarks/templates/bundles/edit.html
+++ b/bookmarks/templates/bundles/edit.html
@@ -1,12 +1,13 @@
 {% extends 'shared/layout.html' %}
+{% load i18n %}
 {% block head %}
-  {% with page_title="Edit bundle - Linkding" %}{{ block.super }}{% endwith %}
+  {% with page_title=_("Edit bundle - Linkding") %}{{ block.super }}{% endwith %}
 {% endblock %}
 {% block content %}
   <div class="bundles-editor-page grid columns-md-1">
     <main aria-labelledby="main-heading">
       <div class="section-header">
-        <h1 id="main-heading">Edit bundle</h1>
+        <h1 id="main-heading">{% translate "Edit bundle" %}</h1>
       </div>
       {% include 'shared/messages.html' %}
       <form id="bundle-form"
@@ -19,7 +20,7 @@
     </main>
     <aside class="col-2" aria-labelledby="preview-heading">
       <div class="section-header">
-        <h2 id="preview-heading">Preview</h2>
+        <h2 id="preview-heading">{% translate "Preview" %}</h2>
       </div>
       {% include 'bundles/preview.html' %}
     </aside>

--- a/bookmarks/templates/bundles/form.html
+++ b/bookmarks/templates/bundles/form.html
@@ -1,59 +1,59 @@
-{% load shared %}
+{% load shared i18n %}
 <div class="form-group">
-  {% formlabel form.name "Name" %}
+  {% formlabel form.name _("Name") %}
   {% formfield form.name %}
   {{ form.name.errors }}
 </div>
 <div class="form-group">
-  {% formlabel form.search "Search terms" %}
+  {% formlabel form.search _("Search terms") %}
   {% formfield form.search has_help=True %}
   {{ form.search.errors }}
   {% formhelp form.search %}
-    All of these search terms must be present in a bookmark to match.
+    {% translate "All of these search terms must be present in a bookmark to match." %}
   {% endformhelp %}
 </div>
 <div class="form-group">
-  {% formlabel form.any_tags "Tags" %}
+  {% formlabel form.any_tags _("Tags") %}
   {% formfield form.any_tags has_help=True %}
   {% formhelp form.any_tags %}
-    At least one of these tags must be present in a bookmark to match.
+    {% translate "At least one of these tags must be present in a bookmark to match." %}
   {% endformhelp %}
 </div>
 <div class="form-group">
-  {% formlabel form.all_tags "Required tags" %}
+  {% formlabel form.all_tags _("Required tags") %}
   {% formfield form.all_tags has_help=True %}
   {% formhelp form.all_tags %}
-    All of these tags must be present in a bookmark to match.
+    {% translate "All of these tags must be present in a bookmark to match." %}
   {% endformhelp %}
 </div>
 <div class="form-group">
-  {% formlabel form.excluded_tags "Excluded tags" %}
+  {% formlabel form.excluded_tags _("Excluded tags") %}
   {% formfield form.excluded_tags has_help=True %}
   {% formhelp form.excluded_tags %}
-    None of these tags must be present in a bookmark to match.
+    {% translate "None of these tags must be present in a bookmark to match." %}
   {% endformhelp %}
 </div>
 <div class="form-group">
-  {% formlabel form.filter_unread "Reading State" %}
+  {% formlabel form.filter_unread _("Reading State") %}
   {% formfield form.filter_unread has_help=True %}
   {% formhelp form.filter_unread %}
-    Limit matches to unread or read bookmarks.
+    {% translate "Limit matches to unread or read bookmarks." %}
   {% endformhelp %}
 </div>
 <div class="form-group">
-  {% formlabel form.filter_shared "Sharing State" %}
+  {% formlabel form.filter_shared _("Sharing State") %}
   {% formfield form.filter_shared has_help=True %}
   {% formhelp form.filter_shared %}
-    Limit matches to shared or unshared bookmarks.
+    {% translate "Limit matches to shared or unshared bookmarks." %}
   {% endformhelp %}
 </div>
 <div class="form-footer d-flex mt-4">
   <input type="submit"
          name="save"
-         value="Save"
+         value="{% translate 'Save' %}"
          class="btn btn-primary btn-wide">
   <a href="{% url 'linkding:bundles.index' %}"
-     class="btn btn-wide ml-auto">Cancel</a>
+     class="btn btn-wide ml-auto">{% translate "Cancel" %}</a>
   <a href="{% url 'linkding:bundles.preview' %}"
      data-turbo-frame="preview"
      class="d-none"

--- a/bookmarks/templates/bundles/index.html
+++ b/bookmarks/templates/bundles/index.html
@@ -1,13 +1,13 @@
 {% extends "shared/layout.html" %}
-{% load static %}
+{% load static i18n %}
 {% block head %}
-  {% with page_title="Bundles - Linkding" %}{{ block.super }}{% endwith %}
+  {% with page_title=_("Bundles - Linkding") %}{{ block.super }}{% endwith %}
 {% endblock %}
 {% block content %}
   <main class="bundles-page crud-page" aria-labelledby="main-heading">
     <div class="crud-header">
-      <h1 id="main-heading">Bundles</h1>
-      <a href="{% url 'linkding:bundles.new' %}" class="btn">Add bundle</a>
+      <h1 id="main-heading">{% translate "Bundles" %}</h1>
+      <a href="{% url 'linkding:bundles.new' %}" class="btn">{% translate "Add bundle" %}</a>
     </div>
     {% include 'shared/messages.html' %}
     {% if bundles %}
@@ -16,9 +16,9 @@
         <table class="table crud-table">
           <thead>
             <tr>
-              <th>Name</th>
+              <th>{% translate "Name" %}</th>
               <th class="actions">
-                <span class="text-assistive">Actions</span>
+                <span class="text-assistive">{% translate "Actions" %}</span>
               </th>
             </tr>
           </thead>
@@ -35,12 +35,12 @@
                 </td>
                 <td class="actions">
                   <a class="btn btn-link"
-                     href="{% url 'linkding:bundles.edit' bundle.id %}">Edit</a>
+                     href="{% url 'linkding:bundles.edit' bundle.id %}">{% translate "Edit" %}</a>
                   <button data-confirm
                           type="submit"
                           name="remove_bundle"
                           value="{{ bundle.id }}"
-                          class="btn btn-link">Remove</button>
+                          class="btn btn-link">{% translate "Remove" %}</button>
                 </td>
               </tr>
             {% endfor %}
@@ -51,8 +51,8 @@
       </form>
     {% else %}
       <div class="empty">
-        <p class="empty-title h5">You have no bundles yet</p>
-        <p class="empty-subtitle">Create your first bundle to get started</p>
+        <p class="empty-title h5">{% translate "You have no bundles yet" %}</p>
+        <p class="empty-subtitle">{% translate "Create your first bundle to get started" %}</p>
       </div>
     {% endif %}
   </main>

--- a/bookmarks/templates/bundles/new.html
+++ b/bookmarks/templates/bundles/new.html
@@ -1,12 +1,13 @@
 {% extends 'shared/layout.html' %}
+{% load i18n %}
 {% block head %}
-  {% with page_title="New bundle - Linkding" %}{{ block.super }}{% endwith %}
+  {% with page_title=_("New bundle - Linkding") %}{{ block.super }}{% endwith %}
 {% endblock %}
 {% block content %}
   <div class="bundles-editor-page grid columns-md-1">
     <main aria-labelledby="main-heading">
       <div class="section-header">
-        <h1 id="main-heading">New bundle</h1>
+        <h1 id="main-heading">{% translate "New bundle" %}</h1>
       </div>
       {% include 'shared/messages.html' %}
       <form id="bundle-form"
@@ -19,7 +20,7 @@
     </main>
     <aside class="col-2" aria-labelledby="preview-heading">
       <div class="section-header">
-        <h2 id="preview-heading">Preview</h2>
+        <h2 id="preview-heading">{% translate "Preview" %}</h2>
       </div>
       {% include 'bundles/preview.html' %}
     </aside>

--- a/bookmarks/templates/bundles/preview.html
+++ b/bookmarks/templates/bundles/preview.html
@@ -1,8 +1,13 @@
+{% load i18n %}
 <turbo-frame id="preview">
 {% if bookmark_list.is_empty %}
-  <div>No bookmarks match the current bundle.</div>
+  <div>{% translate "No bookmarks match the current bundle." %}</div>
 {% else %}
-  <div class="mb-4">Found {{ bookmark_list.bookmarks_total }} bookmarks matching this bundle.</div>
+  <div class="mb-4">
+    {% blocktranslate trimmed with total=bookmark_list.bookmarks_total %}
+      Found {{ total }} bookmarks matching this bundle.
+    {% endblocktranslate %}
+  </div>
   {% with pagination_frame="preview" %}
     {% include 'bookmarks/bookmark_list.html' %}
   {% endwith %}

--- a/bookmarks/templates/registration/login.html
+++ b/bookmarks/templates/registration/login.html
@@ -1,35 +1,38 @@
 {% extends 'shared/layout.html' %}
 {% load shared %}
+{% load i18n %}
 {% block head %}
-  {% with page_title="Login - Linkding" %}{{ block.super }}{% endwith %}
+  {% with page_title=_("Login - Linkding") %}{{ block.super }}{% endwith %}
 {% endblock %}
 {% block content %}
   <main class="auth-page" aria-labelledby="main-heading">
     <div class="section-header">
-      <h1 id="main-heading">Login</h1>
+      <h1 id="main-heading">{% translate "Login" %}</h1>
     </div>
     {% if not disable_login %}
       <form method="post" action="{% url 'login' %}">
         {% csrf_token %}
         {% if form.errors %}
-          <p class="form-input-hint is-error">Your username and password didn't match. Please try again.</p>
+          <p class="form-input-hint is-error">{% translate "Your username and password didn't match. Please try again." %}</p>
         {% endif %}
         <div class="form-group">
-          {% formlabel form.username 'Username' %}
+          {% formlabel form.username _("Username") %}
           {% formfield form.username class='form-input' %}
         </div>
         <div class="form-group">
-          {% formlabel form.password 'Password' %}
+          {% formlabel form.password _("Password") %}
           {% formfield form.password class='form-input' %}
         </div>
-        <input type="submit" value="Login" class="btn btn-primary width-100 mt-4" />
+        <input type="submit"
+               value="{% translate 'Login' %}"
+               class="btn btn-primary width-100 mt-4" />
         <input type="hidden" name="next" value="{{ next }}" />
       </form>
     {% endif %}
     {% if enable_oidc %}
       <a class="btn width-100 mt-4"
          href="{% url 'oidc_authentication_init' %}"
-         data-turbo="false">Login with OIDC</a>
+         data-turbo="false">{% translate "Login with OIDC" %}</a>
     {% endif %}
   </main>
 {% endblock %}

--- a/bookmarks/templates/registration/password_change_done.html
+++ b/bookmarks/templates/registration/password_change_done.html
@@ -1,12 +1,13 @@
 {% extends 'shared/layout.html' %}
+{% load i18n %}
 {% block head %}
-  {% with page_title="Password changed - Linkding" %}{{ block.super }}{% endwith %}
+  {% with page_title=_("Password changed - Linkding") %}{{ block.super }}{% endwith %}
 {% endblock %}
 {% block content %}
   <main class="auth-page" aria-labelledby="main-heading">
     <div class="section-header">
-      <h1 id="main-heading">Password Changed</h1>
+      <h1 id="main-heading">{% translate "Password Changed" %}</h1>
     </div>
-    <p class="text-success">Your password was changed successfully.</p>
+    <p class="text-success">{% translate "Your password was changed successfully." %}</p>
   </main>
 {% endblock %}

--- a/bookmarks/templates/registration/password_change_form.html
+++ b/bookmarks/templates/registration/password_change_form.html
@@ -1,32 +1,33 @@
 {% extends 'shared/layout.html' %}
 {% load shared %}
+{% load i18n %}
 {% block head %}
-  {% with page_title="Change password - Linkding" %}{{ block.super }}{% endwith %}
+  {% with page_title=_("Change password - Linkding") %}{{ block.super }}{% endwith %}
 {% endblock %}
 {% block content %}
   <main class="auth-page" aria-labelledby="main-heading">
     <div class="section-header">
-      <h1 id="main-heading">Change Password</h1>
+      <h1 id="main-heading">{% translate "Change Password" %}</h1>
     </div>
     <form method="post" action="{% url 'change_password' %}">
       {% csrf_token %}
       <div class="form-group">
-        {% formlabel form.old_password 'Old password' %}
+        {% formlabel form.old_password _("Old password") %}
         {% formfield form.old_password class='form-input' %}
         {{ form.old_password.errors }}
       </div>
       <div class="form-group">
-        {% formlabel form.new_password1 'New password' %}
+        {% formlabel form.new_password1 _("New password") %}
         {% formfield form.new_password1 class='form-input' %}
         {{ form.new_password1.errors }}
       </div>
       <div class="form-group">
-        {% formlabel form.new_password2 'Confirm new password' %}
+        {% formlabel form.new_password2 _("Confirm new password") %}
         {% formfield form.new_password2 class='form-input' %}
         {{ form.new_password2.errors }}
       </div>
       <input type="submit"
-             value="Change Password"
+             value="{% translate 'Change Password' %}"
              class="btn btn-primary width-100 mt-4">
     </form>
   </main>

--- a/bookmarks/templates/settings/create_api_token_modal.html
+++ b/bookmarks/templates/settings/create_api_token_modal.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 <turbo-frame id="api-modal">
 <form method="post"
       action="{% url 'linkding:settings.integrations.create_api_token' %}"
@@ -8,23 +9,23 @@
             data-turbo-frame="api-modal">
     <div class="modal-overlay" data-close-modal></div>
     <div class="modal-container" role="dialog" aria-modal="true">
-      {% include 'shared/modal_header.html' with title="Create API Token" %}
+      {% include 'shared/modal_header.html' with title=_("Create API Token") %}
       <div class="modal-body">
         <div class="form-group">
-          <label class="form-label" for="token-name">Token name</label>
+          <label class="form-label" for="token-name">{% translate "Token name" %}</label>
           <input type="text"
                  class="form-input"
                  id="token-name"
                  name="name"
-                 placeholder="e.g., Browser Extension, Mobile App"
-                 value="API Token"
+                 placeholder="{% translate 'e.g., Browser Extension, Mobile App' %}"
+                 value="{% translate 'API Token' %}"
                  maxlength="128">
-          <p class="form-input-hint">A descriptive name to identify the purpose of the token</p>
+          <p class="form-input-hint">{% translate "A descriptive name to identify the purpose of the token" %}</p>
         </div>
       </div>
       <div class="modal-footer d-flex justify-between">
-        <button type="button" class="btn btn-wide" data-close-modal>Cancel</button>
-        <button type="submit" class="btn btn-primary">Create Token</button>
+        <button type="button" class="btn btn-wide" data-close-modal>{% translate "Cancel" %}</button>
+        <button type="submit" class="btn btn-primary">{% translate "Create Token" %}</button>
       </div>
     </div>
   </ld-modal>

--- a/bookmarks/templates/settings/general.html
+++ b/bookmarks/templates/settings/general.html
@@ -1,18 +1,19 @@
 {% extends "shared/layout.html" %}
 {% load shared %}
+{% load i18n %}
 {% block head %}
-  {% with page_title="Settings - Linkding" %}{{ block.super }}{% endwith %}
+  {% with page_title=_("Settings - Linkding") %}{{ block.super }}{% endwith %}
 {% endblock %}
 {% block content %}
   <main class="settings-page" aria-labelledby="main-heading">
-    <h1 id="main-heading">Settings</h1>
+    <h1 id="main-heading">{% translate "Settings" %}</h1>
     {# Profile section #}
     {% if success_message %}<div class="toast toast-success mb-4">{{ success_message }}</div>{% endif %}
     {% if error_message %}<div class="toast toast-error mb-4">{{ error_message }}</div>{% endif %}
     <section aria-labelledby="profile-heading">
-      <h2 id="profile-heading">Profile</h2>
+      <h2 id="profile-heading">{% translate "Profile" %}</h2>
       <p>
-        <a href="{% url 'change_password' %}">Change password</a>
+        <a href="{% url 'change_password' %}">{% translate "Change password" %}</a>
       </p>
       <form action="{% url 'linkding:settings.update' %}"
             method="post"
@@ -20,223 +21,256 @@
             data-turbo="false">
         {% csrf_token %}
         <div class="form-group">
-          {% formlabel form.theme "Theme" %}
+          {% formlabel form.theme _("Theme") %}
           {% formfield form.theme has_help=True class="width-25 width-sm-100" %}
           {% formhelp form.theme %}
-            Whether to use a light or dark theme, or automatically adjust the theme based on your system's settings.
+            {% translate "Whether to use a light or dark theme, or automatically adjust the theme based on your system's settings." %}
           {% endformhelp %}
         </div>
         <div class="form-group">
-          {% formlabel form.bookmark_date_display "Bookmark date format" %}
+          {% formlabel form.bookmark_date_display _("Bookmark date format") %}
           {% formfield form.bookmark_date_display has_help=True class="width-25 width-sm-100" %}
           {% formhelp form.bookmark_date_display %}
-            Whether to show bookmark dates as relative (how long ago), or as absolute dates. Alternatively the date can
-            be hidden.
+            {% blocktranslate trimmed %}
+              Whether to show bookmark dates as relative (how long ago), or as absolute dates. Alternatively the date can
+              be hidden.
+            {% endblocktranslate %}
           {% endformhelp %}
         </div>
         <div class="form-group">
-          {% formlabel form.bookmark_description_display "Bookmark description" %}
+          {% formlabel form.bookmark_description_display _("Bookmark description") %}
           {% formfield form.bookmark_description_display has_help=True class="width-25 width-sm-100" %}
           {% formhelp form.bookmark_description_display %}
-            Whether to show bookmark descriptions and tags in the same line, or as separate blocks.
+            {% translate "Whether to show bookmark descriptions and tags in the same line, or as separate blocks." %}
           {% endformhelp %}
         </div>
         <div class="form-group {% if request.user_profile.bookmark_description_display == 'inline' %}d-hide{% endif %}">
-          {% formlabel form.bookmark_description_max_lines "Bookmark description max lines" %}
+          {% formlabel form.bookmark_description_max_lines _("Bookmark description max lines") %}
           {% formfield form.bookmark_description_max_lines has_help=True class="width-25 width-sm-100" %}
           {% formhelp form.bookmark_description_max_lines %}
-            Limits the number of lines that are displayed for the bookmark description.
+            {% translate "Limits the number of lines that are displayed for the bookmark description." %}
           {% endformhelp %}
         </div>
         <div class="form-group">
-          {% formfield form.display_url label="Show bookmark URL" has_help=True %}
+          {% formfield form.display_url label=_("Show bookmark URL") has_help=True %}
           {% formhelp form.display_url %}
-            When enabled, this setting displays the bookmark URL below the title.
+            {% translate "When enabled, this setting displays the bookmark URL below the title." %}
           {% endformhelp %}
         </div>
         <div class="form-group">
-          {% formfield form.permanent_notes label="Show notes permanently" has_help=True %}
+          {% formfield form.permanent_notes label=_("Show notes permanently") has_help=True %}
           {% formhelp form.permanent_notes %}
-            Whether to show bookmark notes permanently, without having to toggle them individually.
-            Alternatively the keyboard shortcut <code>e</code> can be used to temporarily show all notes.
+            {% blocktranslate trimmed %}
+              Whether to show bookmark notes permanently, without having to toggle them individually.
+              Alternatively the keyboard shortcut <code>e</code> can be used to temporarily show all notes.
+            {% endblocktranslate %}
           {% endformhelp %}
         </div>
         <div class="form-group">
-          <span class="form-label">Bookmark actions</span>
-          {% formfield form.display_view_bookmark_action label="View" %}
-          {% formfield form.display_edit_bookmark_action label="Edit" %}
-          {% formfield form.display_archive_bookmark_action label="Archive" %}
-          {% formfield form.display_remove_bookmark_action label="Remove" %}
-          <div class="form-input-hint">Which actions to display for each bookmark.</div>
+          <span class="form-label">{% translate "Bookmark actions" %}</span>
+          {% formfield form.display_view_bookmark_action label=_("View") %}
+          {% formfield form.display_edit_bookmark_action label=_("Edit") %}
+          {% formfield form.display_archive_bookmark_action label=_("Archive") %}
+          {% formfield form.display_remove_bookmark_action label=_("Remove") %}
+          <div class="form-input-hint">{% translate "Which actions to display for each bookmark." %}</div>
         </div>
         <div class="form-group">
-          {% formlabel form.bookmark_link_target "Open bookmarks in" %}
+          {% formlabel form.bookmark_link_target _("Open bookmarks in") %}
           {% formfield form.bookmark_link_target has_help=True class="width-25 width-sm-100" %}
           {% formhelp form.bookmark_link_target %}
-            Whether to open bookmarks a new page or in the same page.
+            {% translate "Whether to open bookmarks a new page or in the same page." %}
           {% endformhelp %}
         </div>
         <div class="form-group">
-          {% formlabel form.items_per_page "Items per page" %}
+          {% formlabel form.items_per_page _("Items per page") %}
           {% formfield form.items_per_page has_help=True class="width-25 width-sm-100" min="10" %}
           {{ form.items_per_page.errors }}
           {% formhelp form.items_per_page %}
-            The number of bookmarks to display per page.
+            {% translate "The number of bookmarks to display per page." %}
           {% endformhelp %}
         </div>
         <div class="form-group">
-          {% formfield form.sticky_pagination label="Sticky pagination" has_help=True %}
+          {% formfield form.sticky_pagination label=_("Sticky pagination") has_help=True %}
           {% formhelp form.sticky_pagination %}
-            When enabled, the pagination controls will stick to the bottom of the screen, so that they are always
-            visible without having to scroll to the end of the page first.
+            {% blocktranslate trimmed %}
+              When enabled, the pagination controls will stick to the bottom of the screen, so that they are always
+              visible without having to scroll to the end of the page first.
+            {% endblocktranslate %}
           {% endformhelp %}
         </div>
         <div class="form-group">
-          {% formfield form.collapse_side_panel label="Collapse side panel" has_help=True %}
+          {% formfield form.collapse_side_panel label=_("Collapse side panel") has_help=True %}
           {% formhelp form.collapse_side_panel %}
-            When enabled, the tags side panel will be collapsed by default to give more space to the bookmark list.
-            Instead, the tags are shown in an expandable drawer.
+            {% blocktranslate trimmed %}
+              When enabled, the tags side panel will be collapsed by default to give more space to the bookmark list.
+              Instead, the tags are shown in an expandable drawer.
+            {% endblocktranslate %}
           {% endformhelp %}
         </div>
         <div class="form-group">
-          {% formfield form.hide_bundles label="Hide bundles" has_help=True %}
+          {% formfield form.hide_bundles label=_("Hide bundles") has_help=True %}
           {% formhelp form.hide_bundles %}
-            Allows to hide the bundles in the side panel if you don't intend to use them.
+            {% translate "Allows to hide the bundles in the side panel if you don't intend to use them." %}
           {% endformhelp %}
         </div>
         <div class="form-group">
-          {% formlabel form.tag_search "Tag search" %}
+          {% formlabel form.tag_search _("Tag search") %}
           {% formfield form.tag_search has_help=True class="width-25 width-sm-100" %}
           {% formhelp form.tag_search %}
-            In strict mode, tags must be prefixed with a hash character (#).
-            In lax mode, tags can also be searched without the hash character.
-            Note that tags without the hash character are indistinguishable from search terms, which means the search
-            result will also include bookmarks where a search term matches otherwise.
+            {% blocktranslate trimmed %}
+              In strict mode, tags must be prefixed with a hash character (#).
+              In lax mode, tags can also be searched without the hash character.
+              Note that tags without the hash character are indistinguishable from search terms, which means the search
+              result will also include bookmarks where a search term matches otherwise.
+            {% endblocktranslate %}
           {% endformhelp %}
         </div>
         <div class="form-group">
-          {% formfield form.legacy_search label="Enable legacy search" has_help=True %}
+          {% formfield form.legacy_search label=_("Enable legacy search") has_help=True %}
           {% formhelp form.legacy_search %}
-            Since version 1.44.0, linkding has a new search engine that supports logical expressions (and, or, not).
-            If you run into any issues with the new search, you can enable this option to temporarily switch back to the old search.
-            Please report any issues you encounter with the new search on <a href="https://github.com/sissbruecker/linkding/issues"
+            {% blocktranslate trimmed %}
+              Since version 1.44.0, linkding has a new search engine that supports logical expressions (and, or, not).
+              If you run into any issues with the new search, you can enable this option to temporarily switch back to the old search.
+              Please report any issues you encounter with the new search on <a href="https://github.com/sissbruecker/linkding/issues"
     target="_blank">GitHub</a> so they can be addressed.
-            This option will be removed in a future version.
+              This option will be removed in a future version.
+            {% endblocktranslate %}
           {% endformhelp %}
         </div>
         <div class="form-group">
-          {% formlabel form.tag_grouping "Tag grouping" %}
+          {% formlabel form.tag_grouping _("Tag grouping") %}
           {% formfield form.tag_grouping has_help=True class="width-25 width-sm-100" %}
           {% formhelp form.tag_grouping %}
-            In alphabetical mode, tags will be grouped by the first letter.
-            If disabled, tags will not be grouped.
+            {% blocktranslate trimmed %}
+              In alphabetical mode, tags will be grouped by the first letter.
+              If disabled, tags will not be grouped.
+            {% endblocktranslate %}
           {% endformhelp %}
         </div>
         <div class="form-group">
           <details {% if form.auto_tagging_rules.value %}open{% endif %}>
             <summary>
-              <span class="form-label d-inline-block">Auto Tagging</span>
+              <span class="form-label d-inline-block">{% translate "Auto Tagging" %}</span>
             </summary>
             <label for="{{ form.auto_tagging_rules.id_for_label }}"
-                   class="text-assistive">Auto Tagging</label>
+                   class="text-assistive">{% translate "Auto Tagging" %}</label>
             <div>{% formfield form.auto_tagging_rules has_help=True class="monospace" rows="6" %}</div>
           </details>
           {% formhelp form.auto_tagging_rules %}
-            Automatically adds tags to bookmarks based on predefined rules.
-            Each line is a single rule that maps a URL to one or more tags. For example:
+            {% blocktranslate trimmed %}
+              Automatically adds tags to bookmarks based on predefined rules.
+              Each line is a single rule that maps a URL to one or more tags. For example:
+            {% endblocktranslate %}
             <pre>youtube.com video
 reddit.com/r/Music music reddit</pre>
           {% endformhelp %}
         </div>
         <div class="form-group">
-          {% formfield form.enable_favicons label="Enable Favicons" has_help=True %}
+          {% formfield form.enable_favicons label=_("Enable Favicons") has_help=True %}
           {% formhelp form.enable_favicons %}
-            Automatically loads favicons for bookmarked websites and displays them next to each bookmark.
-            Enabling this feature automatically downloads all missing favicons.
-            By default, this feature uses a <b>Google service</b> to download favicons.
-            If you don't want to use this service, check the
-            <a href="https://linkding.link/options/#ld_favicon_provider"
-               target="_blank">options documentation</a> on how to configure a custom favicon provider.
-            Icons are downloaded in the background, and it may take a while for them to show up.
+            {% blocktranslate trimmed %}
+              Automatically loads favicons for bookmarked websites and displays them next to each bookmark.
+              Enabling this feature automatically downloads all missing favicons.
+              By default, this feature uses a <b>Google service</b> to download favicons.
+              If you don't want to use this service, check the
+              <a href="https://linkding.link/options/#ld_favicon_provider"
+                 target="_blank">options documentation</a> on how to configure a custom favicon provider.
+              Icons are downloaded in the background, and it may take a while for them to show up.
+            {% endblocktranslate %}
           {% endformhelp %}
           {% if request.user_profile.enable_favicons and enable_refresh_favicons %}
-            <button class="btn mt-2" name="refresh_favicons">Refresh Favicons</button>
+            <button class="btn mt-2" name="refresh_favicons">{% translate "Refresh Favicons" %}</button>
           {% endif %}
         </div>
         <div class="form-group">
-          {% formfield form.enable_preview_images label="Enable Preview Images" has_help=True %}
+          {% formfield form.enable_preview_images label=_("Enable Preview Images") has_help=True %}
           {% formhelp form.enable_preview_images %}
-            Automatically loads preview images for bookmarked websites and displays them next to each bookmark.
-            Enabling this feature automatically downloads all missing preview images.
+            {% blocktranslate trimmed %}
+              Automatically loads preview images for bookmarked websites and displays them next to each bookmark.
+              Enabling this feature automatically downloads all missing preview images.
+            {% endblocktranslate %}
           {% endformhelp %}
         </div>
         <div class="form-group">
-          {% formlabel form.web_archive_integration "Internet Archive integration" %}
+          {% formlabel form.web_archive_integration _("Internet Archive integration") %}
           {% formfield form.web_archive_integration has_help=True class="width-25 width-sm-100" %}
           {% formhelp form.web_archive_integration %}
-            Enabling this feature will automatically create snapshots of bookmarked websites on the
-            <a href="https://web.archive.org/" target="_blank" rel="noopener">Internet Archive Wayback Machine</a>.
-            This allows to preserve, and later access the website as it was at the point in time it was bookmarked, in
-            case it goes offline or its content is modified.
-            Please consider donating to the <a href="https://archive.org/donate" target="_blank" rel="noopener">Internet Archive</a> if you make use of this feature.
+            {% blocktranslate trimmed %}
+              Enabling this feature will automatically create snapshots of bookmarked websites on the
+              <a href="https://web.archive.org/" target="_blank" rel="noopener">Internet Archive Wayback Machine</a>.
+              This allows to preserve, and later access the website as it was at the point in time it was bookmarked, in
+              case it goes offline or its content is modified.
+              Please consider donating to the <a href="https://archive.org/donate" target="_blank" rel="noopener">Internet Archive</a> if you make use of this feature.
+            {% endblocktranslate %}
           {% endformhelp %}
         </div>
         <div class="form-group">
-          {% formfield form.enable_sharing label="Enable bookmark sharing" has_help=True %}
+          {% formfield form.enable_sharing label=_("Enable bookmark sharing") has_help=True %}
           {% formhelp form.enable_sharing %}
-            Allows to share bookmarks with other users, and to view shared bookmarks.
-            Disabling this feature will hide all previously shared bookmarks from other users.
+            {% blocktranslate trimmed %}
+              Allows to share bookmarks with other users, and to view shared bookmarks.
+              Disabling this feature will hide all previously shared bookmarks from other users.
+            {% endblocktranslate %}
           {% endformhelp %}
         </div>
         <div class="form-group">
-          {% formfield form.enable_public_sharing label="Enable public bookmark sharing" has_help=True %}
+          {% formfield form.enable_public_sharing label=_("Enable public bookmark sharing") has_help=True %}
+          {% url 'linkding:bookmarks.shared' as shared_bookmarks_url %}
           {% formhelp form.enable_public_sharing %}
-            Makes shared bookmarks publicly accessible, without requiring a login.
-            That means that anyone with a link to this instance can view shared bookmarks via the <a href="{% url 'linkding:bookmarks.shared' %}">shared bookmarks page</a>.
+            {% blocktranslate trimmed %}
+              Makes shared bookmarks publicly accessible, without requiring a login.
+              That means that anyone with a link to this instance can view shared bookmarks via the <a href="{{ shared_bookmarks_url }}">shared bookmarks page</a>.
+            {% endblocktranslate %}
           {% endformhelp %}
         </div>
         {% if has_snapshot_support %}
           <div class="form-group">
-            {% formfield form.enable_automatic_html_snapshots label="Automatically create HTML snapshots" has_help=True %}
+            {% formfield form.enable_automatic_html_snapshots label=_("Automatically create HTML snapshots") has_help=True %}
             {% formhelp form.enable_automatic_html_snapshots %}
-              Automatically creates HTML snapshots when adding bookmarks. Alternatively, when disabled, snapshots can be
-              created manually in the details view of a bookmark.
+              {% blocktranslate trimmed %}
+                Automatically creates HTML snapshots when adding bookmarks. Alternatively, when disabled, snapshots can be
+                created manually in the details view of a bookmark.
+              {% endblocktranslate %}
             {% endformhelp %}
-            <button class="btn mt-2" name="create_missing_html_snapshots">Create missing HTML snapshots</button>
+            <button class="btn mt-2" name="create_missing_html_snapshots">{% translate "Create missing HTML snapshots" %}</button>
           </div>
         {% endif %}
         <div class="form-group">
-          {% formfield form.default_mark_unread label="Create bookmarks as unread by default" has_help=True %}
+          {% formfield form.default_mark_unread label=_("Create bookmarks as unread by default") has_help=True %}
           {% formhelp form.default_mark_unread %}
-            Sets the default state for the "Mark as unread" option when creating a new bookmark.
-            Setting this option will make all new bookmarks default to unread.
-            This can be overridden when creating each new bookmark.
+            {% blocktranslate trimmed %}
+              Sets the default state for the "Mark as unread" option when creating a new bookmark.
+              Setting this option will make all new bookmarks default to unread.
+              This can be overridden when creating each new bookmark.
+            {% endblocktranslate %}
           {% endformhelp %}
         </div>
         <div class="form-group">
-          {% formfield form.default_mark_shared label="Create bookmarks as shared by default" has_help=True %}
+          {% formfield form.default_mark_shared label=_("Create bookmarks as shared by default") has_help=True %}
           {% formhelp form.default_mark_shared %}
-            Sets the default state for the "Share" option when creating a new bookmark.
-            Setting this option will make all new bookmarks default to shared.
-            This can be overridden when creating each new bookmark.
+            {% blocktranslate trimmed %}
+              Sets the default state for the "Share" option when creating a new bookmark.
+              Setting this option will make all new bookmarks default to shared.
+              This can be overridden when creating each new bookmark.
+            {% endblocktranslate %}
           {% endformhelp %}
         </div>
         <div class="form-group">
           <details {% if form.custom_css.value %}open{% endif %}>
             <summary>
-              <span class="form-label d-inline-block">Custom CSS</span>
+              <span class="form-label d-inline-block">{% translate "Custom CSS" %}</span>
             </summary>
-            <label for="{{ form.custom_css.id_for_label }}" class="text-assistive">Custom CSS</label>
+            <label for="{{ form.custom_css.id_for_label }}" class="text-assistive">{% translate "Custom CSS" %}</label>
             <div>{% formfield form.custom_css has_help=True class="monospace" rows="6" %}</div>
           </details>
           {% formhelp form.custom_css %}
-            Allows to add custom CSS to the page.
+            {% translate "Allows to add custom CSS to the page." %}
           {% endformhelp %}
         </div>
         <div class="form-group">
           <input type="submit"
                  name="update_profile"
-                 value="Save"
+                 value="{% translate 'Save' %}"
                  class="btn btn-primary btn-wide mt-2">
         </div>
       </form>
@@ -244,39 +278,43 @@ reddit.com/r/Music music reddit</pre>
     {# Global settings section #}
     {% if global_settings_form %}
       <section aria-labelledby="global-settings-heading">
-        <h2 id="global-settings-heading">Global settings</h2>
+        <h2 id="global-settings-heading">{% translate "Global settings" %}</h2>
         <form action="{% url 'linkding:settings.update' %}"
               method="post"
               novalidate
               data-turbo="false">
           {% csrf_token %}
           <div class="form-group">
-            {% formlabel global_settings_form.landing_page "Landing page" %}
+            {% formlabel global_settings_form.landing_page _("Landing page") %}
             {% formfield global_settings_form.landing_page has_help=True class="width-25 width-sm-100" %}
             {% formhelp global_settings_form.landing_page %}
-              The page that unauthenticated users are redirected to when accessing the root URL.
+              {% translate "The page that unauthenticated users are redirected to when accessing the root URL." %}
             {% endformhelp %}
           </div>
           <div class="form-group">
-            {% formlabel global_settings_form.guest_profile_user "Guest user profile" %}
+            {% formlabel global_settings_form.guest_profile_user _("Guest user profile") %}
             {% formfield global_settings_form.guest_profile_user has_help=True class="width-25 width-sm-100" %}
             {% formhelp global_settings_form.guest_profile_user %}
-              The user profile to use for users that are not logged in. This will affect how publicly shared bookmarks
-              are displayed regarding theme, bookmark list settings, etc. You can either use your own profile or create
-              a dedicated user for this purpose. By default, a standard profile with fixed settings is used.
+              {% blocktranslate trimmed %}
+                The user profile to use for users that are not logged in. This will affect how publicly shared bookmarks
+                are displayed regarding theme, bookmark list settings, etc. You can either use your own profile or create
+                a dedicated user for this purpose. By default, a standard profile with fixed settings is used.
+              {% endblocktranslate %}
             {% endformhelp %}
           </div>
           <div class="form-group">
-            {% formfield global_settings_form.enable_link_prefetch label="Enable prefetching links on hover" has_help=True %}
+            {% formfield global_settings_form.enable_link_prefetch label=_("Enable prefetching links on hover") has_help=True %}
             {% formhelp global_settings_form.enable_link_prefetch %}
-              Prefetches internal links when hovering over them. This can improve the perceived performance when
-              navigating application, but also increases the load on the server as well as bandwidth usage.
+              {% blocktranslate trimmed %}
+                Prefetches internal links when hovering over them. This can improve the perceived performance when
+                navigating application, but also increases the load on the server as well as bandwidth usage.
+              {% endblocktranslate %}
             {% endformhelp %}
           </div>
           <div class="form-group">
             <input type="submit"
                    name="update_global_settings"
-                   value="Save"
+                   value="{% translate 'Save' %}"
                    class="btn btn-primary btn-wide mt-2">
           </div>
         </form>
@@ -284,10 +322,12 @@ reddit.com/r/Music music reddit</pre>
     {% endif %}
     {# Import section #}
     <section aria-labelledby="import-heading">
-      <h2 id="import-heading">Import</h2>
+      <h2 id="import-heading">{% translate "Import" %}</h2>
       <p>
-        Import bookmarks and tags in the Netscape HTML format. This will execute a sync where new bookmarks are
-        added and existing ones are updated.
+        {% blocktranslate trimmed %}
+          Import bookmarks and tags in the Netscape HTML format. This will execute a sync where new bookmarks are
+          added and existing ones are updated.
+        {% endblocktranslate %}
       </p>
       <form method="post"
             enctype="multipart/form-data"
@@ -299,30 +339,34 @@ reddit.com/r/Music music reddit</pre>
                    id="import_map_private_flag"
                    name="map_private_flag"
                    aria-describedby="import_map_private_flag_help">
-            <i class="form-icon"></i> Import public bookmarks as shared
+            <i class="form-icon"></i> {% translate "Import public bookmarks as shared" %}
           </label>
           <div id="import_map_private_flag_help" class="form-input-hint">
-            When importing bookmarks from a service that supports marking bookmarks as public or private (using the
-            <code>PRIVATE</code> attribute), enabling this option will import all bookmarks that are marked as not
-            private as shared bookmarks.
-            Otherwise, all bookmarks will be imported as private bookmarks.
+            {% blocktranslate trimmed %}
+              When importing bookmarks from a service that supports marking bookmarks as public or private (using the
+              <code>PRIVATE</code> attribute), enabling this option will import all bookmarks that are marked as not
+              private as shared bookmarks.
+              Otherwise, all bookmarks will be imported as private bookmarks.
+            {% endblocktranslate %}
           </div>
         </div>
         <div class="form-group">
           <div class="input-group width-75 width-md-100">
             <input class="form-input" type="file" name="import_file">
-            <input type="submit" class="input-group-btn btn btn-primary" value="Upload">
+            <input type="submit"
+                   class="input-group-btn btn btn-primary"
+                   value="{% translate 'Upload' %}">
           </div>
         </div>
       </form>
     </section>
     {# Export section #}
     <section aria-labelledby="export-heading">
-      <h2 id="export-heading">Export</h2>
-      <p>Export all bookmarks in Netscape HTML format.</p>
+      <h2 id="export-heading">{% translate "Export" %}</h2>
+      <p>{% translate "Export all bookmarks in Netscape HTML format." %}</p>
       <a class="btn btn-primary"
          target="_blank"
-         href="{% url 'linkding:settings.export' %}">Download (.html)</a>
+         href="{% url 'linkding:settings.export' %}">{% translate "Download (.html)" %}</a>
       {% if export_error %}
         <div class="has-error">
           <p class="form-input-hint">{{ export_error }}</p>
@@ -331,21 +375,21 @@ reddit.com/r/Music music reddit</pre>
     </section>
     {# About section #}
     <section class="about" aria-labelledby="about-heading">
-      <h2 id="about-heading">About</h2>
+      <h2 id="about-heading">{% translate "About" %}</h2>
       <table class="table">
         <tbody>
           <tr>
-            <td>Version</td>
+            <td>{% translate "Version" %}</td>
             <td>{{ version_info }}</td>
           </tr>
           <tr>
-            <td style="vertical-align: top">Links</td>
+            <td style="vertical-align: top">{% translate "Links" %}</td>
             <td>
               <div class="d-flex flex-column gap-2">
                 <a href="https://github.com/sissbruecker/linkding/" target="_blank">GitHub</a>
-                <a href="https://linkding.link/" target="_blank">Documentation</a>
+                <a href="https://linkding.link/" target="_blank">{% translate "Documentation" %}</a>
                 <a href="https://github.com/sissbruecker/linkding/blob/master/CHANGELOG.md"
-                   target="_blank">Changelog</a>
+                   target="_blank">{% translate "Changelog" %}</a>
               </div>
             </td>
           </tr>

--- a/bookmarks/templates/settings/integrations.html
+++ b/bookmarks/templates/settings/integrations.html
@@ -1,15 +1,18 @@
 {% extends "shared/layout.html" %}
+{% load i18n %}
 {% block head %}
-  {% with page_title="Integrations - Linkding" %}{{ block.super }}{% endwith %}
+  {% with page_title=_("Integrations - Linkding") %}{{ block.super }}{% endwith %}
 {% endblock %}
 {% block content %}
   <main class="settings-page" aria-labelledby="main-heading">
-    <h1 id="main-heading">Integrations</h1>
+    <h1 id="main-heading">{% translate "Integrations" %}</h1>
     <section aria-labelledby="browser-extension-heading">
-      <h2 id="browser-extension-heading">Browser Extension</h2>
+      <h2 id="browser-extension-heading">{% translate "Browser Extension" %}</h2>
       <p>
-        The browser extension allows you to quickly add new bookmarks without leaving the page that you are on. The
-        extension is available in the official extension stores for:
+        {% blocktranslate trimmed %}
+          The browser extension allows you to quickly add new bookmarks without leaving the page that you are on. The
+          extension is available in the official extension stores for:
+        {% endblocktranslate %}
       </p>
       <ul>
         <li>
@@ -22,30 +25,36 @@
         </li>
       </ul>
       <p>
-        The extension is <a href="https://github.com/sissbruecker/linkding-extension"
+        {% blocktranslate trimmed %}
+          The extension is <a href="https://github.com/sissbruecker/linkding-extension"
     target="_blank">open source</a>
-        as well, which enables you to build and manually load it into any browser that supports Chrome extensions.
+          as well, which enables you to build and manually load it into any browser that supports Chrome extensions.
+        {% endblocktranslate %}
       </p>
-      <h2>Bookmarklet</h2>
+      <h2>{% translate "Bookmarklet" %}</h2>
       <p>
-        The bookmarklet is an alternative, cross-browser way to quickly add new bookmarks without opening the linkding
-        application first. Here's how it works:
+        {% blocktranslate trimmed %}
+          The bookmarklet is an alternative, cross-browser way to quickly add new bookmarks without opening the linkding
+          application first. Here's how it works:
+        {% endblocktranslate %}
       </p>
       <ul>
         <li>
-          Choose your preferred method for detecting website titles and descriptions below (<a href="https://linkding.link/troubleshooting/#automatically-detected-title-and-description-are-incorrect"
+          {% blocktranslate trimmed %}
+            Choose your preferred method for detecting website titles and descriptions below (<a href="https://linkding.link/troubleshooting/#automatically-detected-title-and-description-are-incorrect"
    target="_blank">Help</a>)
+          {% endblocktranslate %}
         </li>
-        <li>Drag the bookmarklet below into your browser's bookmark bar / toolbar</li>
-        <li>Open the website that you want to bookmark</li>
-        <li>Click the bookmarklet in your browser's toolbar</li>
-        <li>linkding opens in a new window or tab and allows you to add a bookmark for the site</li>
-        <li>After saving the bookmark, the linkding window closes, and you are back on your website</li>
+        <li>{% translate "Drag the bookmarklet below into your browser's bookmark bar / toolbar" %}</li>
+        <li>{% translate "Open the website that you want to bookmark" %}</li>
+        <li>{% translate "Click the bookmarklet in your browser's toolbar" %}</li>
+        <li>{% translate "linkding opens in a new window or tab and allows you to add a bookmark for the site" %}</li>
+        <li>{% translate "After saving the bookmark, the linkding window closes, and you are back on your website" %}</li>
       </ul>
       <div class="form-group radio-group"
            role="radiogroup"
            aria-labelledby="detection-method-label">
-        <p id="detection-method-label">Choose your preferred bookmarklet:</p>
+        <p id="detection-method-label">{% translate "Choose your preferred bookmarklet:" %}</p>
         <label for="detection-method-server" class="form-radio">
           <input id="detection-method-server"
                  type="radio"
@@ -53,7 +62,7 @@
                  value="server"
                  checked>
           <i class="form-icon"></i>
-          Detect title and description on the server
+          {% translate "Detect title and description on the server" %}
         </label>
         <label for="detection-method-client" class="form-radio">
           <input id="detection-method-client"
@@ -61,19 +70,19 @@
                  name="bookmarklet-type"
                  value="client">
           <i class="form-icon"></i>
-          Detect title and description in the browser
+          {% translate "Detect title and description in the browser" %}
         </label>
       </div>
       <div class="bookmarklet-container">
         <a id="bookmarklet-server"
            href="javascript: {% include 'settings/bookmarklet.js' %}"
            data-turbo="false"
-           class="btn btn-primary">📎 Add bookmark</a>
+           class="btn btn-primary">📎 {% translate "Add bookmark" %}</a>
         <a id="bookmarklet-client"
            href="javascript: {% include 'settings/bookmarklet_clientside.js' %}"
            data-turbo="false"
            class="btn btn-primary"
-           style="display: none">📎 Add bookmark</a>
+           style="display: none">📎 {% translate "Add bookmark" %}</a>
       </div>
       <script>
         (function init() {
@@ -102,27 +111,29 @@
     </section>
     <turbo-frame id="api-section">
     <section aria-labelledby="rest-api-heading">
-      <h2 id="rest-api-heading">REST API</h2>
+      <h2 id="rest-api-heading">{% translate "REST API" %}</h2>
       {% if api_success_message %}<div class="toast toast-success mb-2">{{ api_success_message }}</div>{% endif %}
       {% if api_token_name and api_token_key %}
         <div class="mt-4 mb-6">
           <p class="mb-2">
-            <strong>Copy this token now, it will only be shown once:</strong>
+            <strong>{% translate "Copy this token now, it will only be shown once:" %}</strong>
           </p>
-          <label class="text-assistive" for="new-token-key">New token key</label>
+          <label class="text-assistive" for="new-token-key">{% translate "New token key" %}</label>
           <div class="input-group">
             <input class="form-input"
                    value="{{ api_token_key }}"
                    readonly
                    id="new-token-key">
-            <button id="copy-new-token-key" class="btn input-group-btn" type="button">Copy</button>
+            <button id="copy-new-token-key" class="btn input-group-btn" type="button">{% translate "Copy" %}</button>
           </div>
         </div>
       {% endif %}
       <p>
-        API tokens can be used to authenticate 3rd-party applications against the REST API. <strong>Please treat
-        tokens as you would any other credential.</strong> Any party with access to a token can access and manage all
-        your bookmarks.
+        {% blocktranslate trimmed %}
+          API tokens can be used to authenticate 3rd-party applications against the REST API. <strong>Please treat
+          tokens as you would any other credential.</strong> Any party with access to a token can access and manage all
+          your bookmarks.
+        {% endblocktranslate %}
       </p>
       {% if api_tokens %}
         <form method="post"
@@ -131,10 +142,10 @@
           <table class="table crud-table mb-6">
             <thead>
               <tr>
-                <th>Name</th>
-                <th>Created</th>
+                <th>{% translate "Name" %}</th>
+                <th>{% translate "Created" %}</th>
                 <th class="actions">
-                  <span class="text-assistive">Actions</span>
+                  <span class="text-assistive">{% translate "Actions" %}</span>
                 </th>
               </tr>
             </thead>
@@ -149,7 +160,7 @@
                             name="token_id"
                             value="{{ token.id }}"
                             type="submit"
-                            class="btn btn-link">Delete</button>
+                            class="btn btn-link">{% translate "Delete" %}</button>
                   </td>
                 </tr>
               {% endfor %}
@@ -159,9 +170,11 @@
       {% endif %}
       <a class="btn"
          href="{% url 'linkding:settings.integrations.create_api_token' %}"
-         data-turbo-frame="api-modal">Create API token</a>
+         data-turbo-frame="api-modal">{% translate "Create API token" %}</a>
     </section>
     <turbo-frame id="api-modal"></turbo-frame>
+    {% translate "Copied!" as copied_label %}
+    {% translate "Copy" as copy_label %}
     <script>
       (function init() {
         // Copy new token key to clipboard
@@ -171,9 +184,9 @@
             const tokenInput = document.getElementById('new-token-key');
             const tokenValue = tokenInput.value;
             navigator.clipboard.writeText(tokenValue).then(() => {
-              copyButton.textContent = 'Copied!';
+              copyButton.textContent = '{{ copied_label|escapejs }}';
               setTimeout(() => {
-                copyButton.textContent = 'Copy';
+                copyButton.textContent = '{{ copy_label|escapejs }}';
               }, 2000);
             }, (err) => {
               console.error('Could not copy text: ', err);
@@ -184,53 +197,65 @@
     </script>
     </turbo-frame>
     <section aria-labelledby="rss-feeds-heading">
-      <h2 id="rss-feeds-heading">RSS Feeds</h2>
-      <p>The following URLs provide RSS feeds for your bookmarks:</p>
+      <h2 id="rss-feeds-heading">{% translate "RSS Feeds" %}</h2>
+      <p>{% translate "The following URLs provide RSS feeds for your bookmarks:" %}</p>
       <ul style="list-style-position: outside;">
         <li>
-          <a target="_blank" href="{{ all_feed_url }}">All bookmarks</a>
+          <a target="_blank" href="{{ all_feed_url }}">{% translate "All bookmarks" %}</a>
         </li>
         <li>
-          <a target="_blank" href="{{ unread_feed_url }}">Unread bookmarks</a>
+          <a target="_blank" href="{{ unread_feed_url }}">{% translate "Unread bookmarks" %}</a>
         </li>
         <li>
-          <a target="_blank" href="{{ shared_feed_url }}">Shared bookmarks</a>
+          <a target="_blank" href="{{ shared_feed_url }}">{% translate "Shared bookmarks" %}</a>
         </li>
         <li>
-          <a target="_blank" href="{{ public_shared_feed_url }}">Public shared bookmarks</a>
+          <a target="_blank" href="{{ public_shared_feed_url }}">{% translate "Public shared bookmarks" %}</a>
           <br>
-          <span class="text-small text-secondary">The public shared feed does not contain an authentication token and can be shared with other people. Only shows shared bookmarks from users who have explicitly enabled public sharing.</span>
+          <span class="text-small text-secondary">{% translate "The public shared feed does not contain an authentication token and can be shared with other people. Only shows shared bookmarks from users who have explicitly enabled public sharing." %}</span>
         </li>
       </ul>
-      <p>Feed URLs support the following URL parameters:</p>
+      <p>{% translate "Feed URLs support the following URL parameters:" %}</p>
       <ul style="list-style-position: outside;">
         <li>
-          A <code>limit</code> parameter for specifying the maximum number of bookmarks to include in the feed. By
-          default, only the latest 100 matching bookmarks are included.
+          {% blocktranslate trimmed %}
+            A <code>limit</code> parameter for specifying the maximum number of bookmarks to include in the feed. By
+            default, only the latest 100 matching bookmarks are included.
+          {% endblocktranslate %}
         </li>
         <li>
-          A <code>q</code> URL parameter for specifying a search query. You can get an example by doing a search in
-          the bookmarks view and then copying the parameter from the URL.
+          {% blocktranslate trimmed %}
+            A <code>q</code> URL parameter for specifying a search query. You can get an example by doing a search in
+            the bookmarks view and then copying the parameter from the URL.
+          {% endblocktranslate %}
         </li>
         <li>
-          An <code>unread</code> parameter for filtering for unread or read bookmarks. Use <code>yes</code> for unread
-          bookmarks and <code>no</code> for read bookmarks.
+          {% blocktranslate trimmed %}
+            An <code>unread</code> parameter for filtering for unread or read bookmarks. Use <code>yes</code> for unread
+            bookmarks and <code>no</code> for read bookmarks.
+          {% endblocktranslate %}
         </li>
         <li>
-          A <code>shared</code> parameter for filtering for shared or unshared bookmarks. Use <code>yes</code> for
-          shared bookmarks and <code>no</code> for unshared bookmarks.
+          {% blocktranslate trimmed %}
+            A <code>shared</code> parameter for filtering for shared or unshared bookmarks. Use <code>yes</code> for
+            shared bookmarks and <code>no</code> for unshared bookmarks.
+          {% endblocktranslate %}
         </li>
         <li>
-          A <code>user</code> parameter for filtering bookmarks by user name. Only applies to the shared bookmark feeds.
+          {% blocktranslate trimmed %}
+            A <code>user</code> parameter for filtering bookmarks by user name. Only applies to the shared bookmark feeds.
+          {% endblocktranslate %}
         </li>
       </ul>
+      {% url 'admin:bookmarks_feedtoken_changelist' as feed_token_admin_url %}
       <p>
-        <strong>Please note that these URLs include an authentication token that should be treated like any other
-        credential.</strong>
-        Any party with access to these URLs can read all your bookmarks.
-        If you think that a URL was compromised you can delete the feed token for your user in the <a target="_blank"
-    href="{% url 'admin:bookmarks_feedtoken_changelist' %}">admin panel</a>.
-        After deleting the feed token, new URLs will be generated when you reload this settings page.
+        {% blocktranslate trimmed %}
+          <strong>Please note that these URLs include an authentication token that should be treated like any other
+          credential.</strong>
+          Any party with access to these URLs can read all your bookmarks.
+          If you think that a URL was compromised you can delete the feed token for your user in the <a target="_blank" href="{{ feed_token_admin_url }}">admin panel</a>.
+          After deleting the feed token, new URLs will be generated when you reload this settings page.
+        {% endblocktranslate %}
       </p>
     </section>
   </main>

--- a/bookmarks/templates/shared/error_list.html
+++ b/bookmarks/templates/shared/error_list.html
@@ -1,10 +1,6 @@
-{% load i18n %}
-{# Force rendering validation errors in English language to align with the rest of the app #}
-{% language 'en-us' %}
-  {% if errors %}
-    <ul class="{{ error_class }} form-input-hint is-error"
-        {% if errors.field_id %}id="{{ errors.field_id }}_error"{% endif %}>
-      {% for error in errors %}<li>{{ error }}</li>{% endfor %}
-    </ul>
-  {% endif %}
-{% endlanguage %}
+{% if errors %}
+  <ul class="{{ error_class }} form-input-hint is-error"
+      {% if errors.field_id %}id="{{ errors.field_id }}_error"{% endif %}>
+    {% for error in errors %}<li>{{ error }}</li>{% endfor %}
+  </ul>
+{% endif %}

--- a/bookmarks/templates/shared/head.html
+++ b/bookmarks/templates/shared/head.html
@@ -1,4 +1,4 @@
-{% load static %}
+{% load static i18n %}
 <head>
   <meta charset="UTF-8">
   <link rel="icon" href="{% static 'favicon.ico' %}" sizes="48x48">
@@ -20,7 +20,8 @@
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="viewport"
         content="width=device-width, initial-scale=1.0, minimal-ui">
-  <meta name="description" content="Self-hosted bookmark service">
+  <meta name="description"
+        content="{% translate 'Self-hosted bookmark service' %}">
   <meta name="robots" content="index,follow">
   <meta name="author" content="Sascha Ißbrücker">
   <title>{{ page_title|default:'Linkding' }}</title>

--- a/bookmarks/templates/shared/layout.html
+++ b/bookmarks/templates/shared/layout.html
@@ -1,4 +1,4 @@
-{% load static %}
+{% load static i18n %}
 <!DOCTYPE html>
 {# Use data attributes as storage for access in static scripts #}
 <html lang="en" data-api-base-url="{% url 'linkding:api-root' %}">
@@ -26,7 +26,9 @@
       {% endif %}
       <div class="d-flex justify-between">
         <a href="{% url 'linkding:root' %}" class="app-link d-flex align-center">
-          <img class="app-logo" src="{% static 'logo.png' %}" alt="Application logo">
+          <img class="app-logo"
+               src="{% static 'logo.png' %}"
+               alt="{% translate 'Application logo' %}">
           <span class="app-name">LINKDING</span>
         </a>
         <nav>
@@ -35,7 +37,7 @@
             {% include 'shared/nav_menu.html' %}
           {% else %}
             {# Otherwise show login link #}
-            <a href="{% url 'login' %}" class="btn btn-link">Login</a>
+            <a href="{% url 'login' %}" class="btn btn-link">{% translate "Login" %}</a>
           {% endif %}
         </nav>
       </div>

--- a/bookmarks/templates/shared/layout.html
+++ b/bookmarks/templates/shared/layout.html
@@ -1,7 +1,13 @@
 {% load static i18n %}
 <!DOCTYPE html>
 {# Use data attributes as storage for access in static scripts #}
-<html lang="en" data-api-base-url="{% url 'linkding:api-root' %}">
+<html lang="en"
+      data-api-base-url="{% url 'linkding:api-root' %}"
+      data-i18n-are-you-sure="{% translate 'Are you sure?' %}"
+      data-i18n-cancel="{% translate 'Cancel' %}"
+      data-i18n-confirm="{% translate 'Confirm' %}"
+      data-i18n-filters="{% translate 'Filters' %}"
+      data-i18n-close-dialog="{% translate 'Close dialog' %}">
   {% block head %}
     {% include 'shared/head.html' %}
   {% endblock %}

--- a/bookmarks/templates/shared/modal_header.html
+++ b/bookmarks/templates/shared/modal_header.html
@@ -1,9 +1,9 @@
-{% load static %}
+{% load static i18n %}
 <div class="modal-header">
   <h2 class="title">{{ title }}</h2>
   <button type="button"
           class="btn btn-noborder close"
-          aria-label="Close dialog"
+          aria-label="{% translate 'Close dialog' %}"
           data-close-modal>
     <svg width="24" height="24">
       <use href="{% static 'icons.svg' %}?v={{ app_version }}#close"></use>

--- a/bookmarks/templates/shared/nav_menu.html
+++ b/bookmarks/templates/shared/nav_menu.html
@@ -1,45 +1,45 @@
-{% load shared static %}
+{% load shared static i18n %}
 {% htmlmin %}
 {# Basic menu list #}
 <div class="hide-md">
   <a href="{% url 'linkding:bookmarks.new' %}"
-     class="btn btn-primary mr-2">Add bookmark</a>
+     class="btn btn-primary mr-2">{% translate "Add bookmark" %}</a>
   <ld-dropdown class="dropdown">
-    <button class="btn btn-link dropdown-toggle" tabindex="0">Bookmarks</button>
+    <button class="btn btn-link dropdown-toggle" tabindex="0">{% translate "Bookmarks" %}</button>
     <ul class="menu" role="list" tabindex="-1">
       <li class="menu-item">
-        <a href="{% url 'linkding:bookmarks.index' %}" class="menu-link">Active</a>
+        <a href="{% url 'linkding:bookmarks.index' %}" class="menu-link">{% translate "Active" %}</a>
       </li>
       <li class="menu-item">
-        <a href="{% url 'linkding:bookmarks.archived' %}" class="menu-link">Archived</a>
+        <a href="{% url 'linkding:bookmarks.archived' %}" class="menu-link">{% translate "Archived" %}</a>
       </li>
       {% if request.user_profile.enable_sharing %}
         <li class="menu-item">
-          <a href="{% url 'linkding:bookmarks.shared' %}" class="menu-link">Shared</a>
+          <a href="{% url 'linkding:bookmarks.shared' %}" class="menu-link">{% translate "Shared" %}</a>
         </li>
       {% endif %}
       <li class="menu-item">
         <a href="{% url 'linkding:bookmarks.index' %}?unread=yes"
-           class="menu-link">Unread</a>
+           class="menu-link">{% translate "Unread" %}</a>
       </li>
       <li class="menu-item">
         <a href="{% url 'linkding:bookmarks.index' %}?q=!untagged"
-           class="menu-link">Untagged</a>
+           class="menu-link">{% translate "Untagged" %}</a>
       </li>
     </ul>
   </ld-dropdown>
   <ld-dropdown class="dropdown">
-    <button class="btn btn-link dropdown-toggle" tabindex="0">Settings</button>
+    <button class="btn btn-link dropdown-toggle" tabindex="0">{% translate "Settings" %}</button>
     <ul class="menu" role="list" tabindex="-1">
       <li class="menu-item">
-        <a href="{% url 'linkding:settings.general' %}" class="menu-link">General</a>
+        <a href="{% url 'linkding:settings.general' %}" class="menu-link">{% translate "General" %}</a>
       </li>
       <li class="menu-item">
-        <a href="{% url 'linkding:settings.integrations' %}" class="menu-link">Integrations</a>
+        <a href="{% url 'linkding:settings.integrations' %}" class="menu-link">{% translate "Integrations" %}</a>
       </li>
       {% if request.user.is_superuser %}
         <li class="menu-item">
-          <a href="{% url 'admin:index' %}" class="menu-link" data-turbo="false">Admin</a>
+          <a href="{% url 'admin:index' %}" class="menu-link" data-turbo="false">{% translate "Admin" %}</a>
         </li>
       {% endif %}
     </ul>
@@ -49,13 +49,13 @@
         method="post"
         data-turbo="false">
     {% csrf_token %}
-    <button type="submit" class="btn btn-link">Logout</button>
+    <button type="submit" class="btn btn-link">{% translate "Logout" %}</button>
   </form>
 </div>
 {# Menu drop-down for smaller devices #}
 <div class="show-md">
   <a href="{% url 'linkding:bookmarks.new' %}"
-     aria-label="Add bookmark"
+     aria-label="{% translate 'Add bookmark' %}"
      class="btn btn-primary">
     <svg width="24" height="24">
       <use href="{% static 'icons.svg' %}?v={{ app_version }}#plus"></use>
@@ -63,7 +63,7 @@
   </a>
   <ld-dropdown class="dropdown dropdown-right">
     <button class="btn btn-link dropdown-toggle"
-            aria-label="Navigation menu"
+            aria-label="{% translate 'Navigation menu' %}"
             tabindex="0">
       <svg width="24" height="24">
         <use href="{% static 'icons.svg' %}?v={{ app_version }}#menu"></use>
@@ -72,34 +72,34 @@
     <!-- menu component -->
     <ul class="menu" role="list" tabindex="-1">
       <li class="menu-item">
-        <a href="{% url 'linkding:bookmarks.index' %}" class="menu-link">Bookmarks</a>
+        <a href="{% url 'linkding:bookmarks.index' %}" class="menu-link">{% translate "Bookmarks" %}</a>
       </li>
       <li class="menu-item">
-        <a href="{% url 'linkding:bookmarks.archived' %}" class="menu-link">Archived bookmarks</a>
+        <a href="{% url 'linkding:bookmarks.archived' %}" class="menu-link">{% translate "Archived bookmarks" %}</a>
       </li>
       {% if request.user_profile.enable_sharing %}
         <li class="menu-item">
-          <a href="{% url 'linkding:bookmarks.shared' %}" class="menu-link">Shared bookmarks</a>
+          <a href="{% url 'linkding:bookmarks.shared' %}" class="menu-link">{% translate "Shared bookmarks" %}</a>
         </li>
       {% endif %}
       <li class="menu-item">
         <a href="{% url 'linkding:bookmarks.index' %}?unread=yes"
-           class="menu-link">Unread</a>
+           class="menu-link">{% translate "Unread" %}</a>
       </li>
       <li class="menu-item">
         <a href="{% url 'linkding:bookmarks.index' %}?q=!untagged"
-           class="menu-link">Untagged</a>
+           class="menu-link">{% translate "Untagged" %}</a>
       </li>
       <div class="divider"></div>
       <li class="menu-item">
-        <a href="{% url 'linkding:settings.general' %}" class="menu-link">Settings</a>
+        <a href="{% url 'linkding:settings.general' %}" class="menu-link">{% translate "Settings" %}</a>
       </li>
       <li class="menu-item">
-        <a href="{% url 'linkding:settings.integrations' %}" class="menu-link">Integrations</a>
+        <a href="{% url 'linkding:settings.integrations' %}" class="menu-link">{% translate "Integrations" %}</a>
       </li>
       {% if request.user.is_superuser %}
         <li class="menu-item">
-          <a href="{% url 'admin:index' %}" class="menu-link" data-turbo="false">Admin</a>
+          <a href="{% url 'admin:index' %}" class="menu-link" data-turbo="false">{% translate "Admin" %}</a>
         </li>
       {% endif %}
       <div class="divider"></div>
@@ -109,7 +109,7 @@
               method="post"
               data-turbo="false">
           {% csrf_token %}
-          <button type="submit" class="btn btn-link menu-link">Logout</button>
+          <button type="submit" class="btn btn-link menu-link">{% translate "Logout" %}</button>
         </form>
       </li>
     </ul>

--- a/bookmarks/templates/shared/pagination.html
+++ b/bookmarks/templates/shared/pagination.html
@@ -1,14 +1,14 @@
-{% load shared %}
+{% load shared i18n %}
 <ul class="pagination">
   {% if prev_link %}
     <li class="page-item">
       <a href="{{ prev_link }}"
          tabindex="-1"
-         data-turbo-frame="{{ pagination_frame }}">Previous</a>
+         data-turbo-frame="{{ pagination_frame }}">{% translate "Previous" %}</a>
     </li>
   {% else %}
     <li class="page-item disabled">
-      <a href="#" tabindex="-1">Previous</a>
+      <a href="#" tabindex="-1">{% translate "Previous" %}</a>
     </li>
   {% endif %}
   {% for page_link in page_links %}
@@ -26,11 +26,11 @@
     <li class="page-item">
       <a href="{{ next_link }}"
          tabindex="-1"
-         data-turbo-frame="{{ pagination_frame }}">Next</a>
+         data-turbo-frame="{{ pagination_frame }}">{% translate "Next" %}</a>
     </li>
   {% else %}
     <li class="page-item disabled">
-      <a href="#" tabindex="-1">Next</a>
+      <a href="#" tabindex="-1">{% translate "Next" %}</a>
     </li>
   {% endif %}
 </ul>

--- a/bookmarks/templates/tags/edit.html
+++ b/bookmarks/templates/tags/edit.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 <turbo-frame id="tag-modal">
 <form method="post"
       action="{% url 'linkding:tags.edit' tag.id %}?{{ request.GET.urlencode }}"
@@ -9,11 +10,11 @@
             data-turbo-frame="tag-modal">
     <div class="modal-overlay" data-close-modal></div>
     <div class="modal-container" role="dialog" aria-modal="true">
-      {% include 'shared/modal_header.html' with title="Edit Tag" %}
+      {% include 'shared/modal_header.html' with title=_("Edit Tag") %}
       <div class="modal-body">{% include 'tags/form.html' %}</div>
       <div class="modal-footer d-flex justify-between">
-        <button type="button" class="btn btn-wide" data-close-modal>Cancel</button>
-        <button type="submit" class="btn btn-primary btn-wide">Save</button>
+        <button type="button" class="btn btn-wide" data-close-modal>{% translate "Cancel" %}</button>
+        <button type="submit" class="btn btn-primary btn-wide">{% translate "Save" %}</button>
       </div>
     </div>
   </ld-modal>

--- a/bookmarks/templates/tags/form.html
+++ b/bookmarks/templates/tags/form.html
@@ -1,9 +1,9 @@
-{% load shared %}
+{% load shared i18n %}
 <div class="form-group">
-  {% formlabel form.name "Name" %}
+  {% formlabel form.name _("Name") %}
   {% formfield form.name has_help=True autofocus=True %}
   {% formhelp form.name %}
-    Tag names are case-insensitive and cannot contain spaces (spaces will be replaced with hyphens).
+    {% translate "Tag names are case-insensitive and cannot contain spaces (spaces will be replaced with hyphens)." %}
   {% endformhelp %}
   {{ form.name.errors }}
 </div>

--- a/bookmarks/templates/tags/index.html
+++ b/bookmarks/templates/tags/index.html
@@ -1,21 +1,21 @@
 {% extends "shared/layout.html" %}
-{% load shared static pagination %}
+{% load shared static pagination i18n %}
 {% block head %}
-  {% with page_title="Tags - Linkding" %}{{ block.super }}{% endwith %}
+  {% with page_title=_("Tags - Linkding") %}{{ block.super }}{% endwith %}
 {% endblock %}
 {% block content %}
   <div class="tags-page crud-page">
     <turbo-frame id="tag-main">
     <main aria-labelledby="main-heading">
       <div class="crud-header">
-        <h1 id="main-heading">Tags</h1>
+        <h1 id="main-heading">{% translate "Tags" %}</h1>
         <div class="d-flex gap-2 ml-auto">
           <a href="{% url 'linkding:tags.new' %}"
              data-turbo-frame="tag-modal"
-             class="btn">Create Tag</a>
+             class="btn">{% translate "Create Tag" %}</a>
           <a href="{% url 'linkding:tags.merge' %}"
              data-turbo-frame="tag-modal"
-             class="btn">Merge Tags</a>
+             class="btn">{% translate "Merge Tags" %}</a>
         </div>
       </div>
       {% include 'shared/messages.html' %}
@@ -24,19 +24,19 @@
         <ld-form data-form-reset>
           <form method="get" class="mb-2" data-turbo-frame="_top">
             <div class="form-group">
-              <label class="form-label text-assistive" for="search">Search tags</label>
+              <label class="form-label text-assistive" for="search">{% translate "Search tags" %}</label>
               <div class="input-group">
                 <input type="text"
                        id="search"
                        name="search"
                        value="{{ search }}"
-                       placeholder="Search tags..."
+                       placeholder="{% translate 'Search tags...' %}"
                        class="form-input">
-                <button type="submit" class="btn input-group-btn">Search</button>
+                <button type="submit" class="btn input-group-btn">{% translate "Search" %}</button>
               </div>
             </div>
             <div class="form-group">
-              <label class="form-label text-assistive" for="sort">Sort by</label>
+              <label class="form-label text-assistive" for="sort">{% translate "Sort by" %}</label>
               <div class="input-group">
                 <span class="input-group-addon text-secondary">
                   <svg width="20" height="20">
@@ -44,10 +44,10 @@
                   </svg>
                 </span>
                 <select id="sort" name="sort" class="form-select" data-submit-on-change>
-                  <option value="name-asc" {% if sort == "name-asc" %}selected{% endif %}>Name A-Z</option>
-                  <option value="name-desc" {% if sort == "name-desc" %}selected{% endif %}>Name Z-A</option>
-                  <option value="count-asc" {% if sort == "count-asc" %}selected{% endif %}>Fewest bookmarks</option>
-                  <option value="count-desc" {% if sort == "count-desc" %}selected{% endif %}>Most bookmarks</option>
+                  <option value="name-asc" {% if sort == "name-asc" %}selected{% endif %}>{% translate "Name A-Z" %}</option>
+                  <option value="name-desc" {% if sort == "name-desc" %}selected{% endif %}>{% translate "Name Z-A" %}</option>
+                  <option value="count-asc" {% if sort == "count-asc" %}selected{% endif %}>{% translate "Fewest bookmarks" %}</option>
+                  <option value="count-desc" {% if sort == "count-desc" %}selected{% endif %}>{% translate "Most bookmarks" %}</option>
                 </select>
               </div>
             </div>
@@ -58,7 +58,7 @@
                        value="true"
                        {% if unused_only %}checked{% endif %}
                        data-submit-on-change>
-                <i class="form-icon"></i> Show only unused tags
+                <i class="form-icon"></i> {% translate "Show only unused tags" %}
               </label>
             </div>
           </form>
@@ -66,9 +66,13 @@
         {# Tags count #}
         <p class="text-secondary text-small m-0">
           {% if search or unused_only %}
-            Showing {{ page.paginator.count }} of {{ total_tags }} tags
+            {% blocktranslate trimmed with count=page.paginator.count %}
+              Showing {{ count }} of {{ total_tags }} tags
+            {% endblocktranslate %}
           {% else %}
-            {{ total_tags }} tags total
+            {% blocktranslate trimmed %}
+              {{ total_tags }} tags total
+            {% endblocktranslate %}
           {% endif %}
         </p>
       </div>
@@ -79,10 +83,10 @@
           <table class="table crud-table">
             <thead>
               <tr>
-                <th>Name</th>
-                <th style="width: 25%">Bookmarks</th>
+                <th>{% translate "Name" %}</th>
+                <th style="width: 25%">{% translate "Bookmarks" %}</th>
                 <th class="actions">
-                  <span class="text-assistive">Actions</span>
+                  <span class="text-assistive">{% translate "Actions" %}</span>
                 </th>
               </tr>
             </thead>
@@ -100,12 +104,12 @@
                   <td class="actions">
                     <a class="btn btn-link"
                        href="{% url 'linkding:tags.edit' tag.id %}?{{ request.GET.urlencode }}"
-                       data-turbo-frame="tag-modal">Edit</a>
+                       data-turbo-frame="tag-modal">{% translate "Edit" %}</a>
                     <button type="submit"
                             name="delete_tag"
                             value="{{ tag.id }}"
                             class="btn btn-link text-error"
-                            data-confirm>Remove</button>
+                            data-confirm>{% translate "Remove" %}</button>
                   </td>
                 </tr>
               {% endfor %}
@@ -116,11 +120,11 @@
       {% else %}
         <div class="empty">
           {% if search or unused_only %}
-            <p class="empty-title h5">No tags found</p>
-            <p class="empty-subtitle">Try adjusting your search or filters</p>
+            <p class="empty-title h5">{% translate "No tags found" %}</p>
+            <p class="empty-subtitle">{% translate "Try adjusting your search or filters" %}</p>
           {% else %}
-            <p class="empty-title h5">You have no tags yet</p>
-            <p class="empty-subtitle">Tags will appear here when you add bookmarks with tags</p>
+            <p class="empty-title h5">{% translate "You have no tags yet" %}</p>
+            <p class="empty-subtitle">{% translate "Tags will appear here when you add bookmarks with tags" %}</p>
           {% endif %}
         </div>
       {% endif %}

--- a/bookmarks/templates/tags/merge.html
+++ b/bookmarks/templates/tags/merge.html
@@ -1,4 +1,4 @@
-{% load shared %}
+{% load shared i18n %}
 <turbo-frame id="tag-modal">
 <form method="post"
       action="{% url 'linkding:tags.merge' %}"
@@ -10,40 +10,42 @@
             data-turbo-frame="tag-modal">
     <div class="modal-overlay" data-close-modal></div>
     <div class="modal-container" role="dialog" aria-modal="true">
-      {% include 'shared/modal_header.html' with title="Merge Tags" %}
+      {% include 'shared/modal_header.html' with title=_("Merge Tags") %}
       <div class="modal-body">
         <details class="mb-4">
           <summary>
-            <span class="text-bold mb-1">How to merge tags</span>
+            <span class="text-bold mb-1">{% translate "How to merge tags" %}</span>
           </summary>
           <ol>
-            <li>Enter the name of the tag you want to keep</li>
-            <li>Enter the names of tags to merge into the target tag</li>
-            <li>The target tag is added to all bookmarks that have any of the merge tags</li>
-            <li>The merged tags are deleted</li>
+            <li>{% translate "Enter the name of the tag you want to keep" %}</li>
+            <li>{% translate "Enter the names of tags to merge into the target tag" %}</li>
+            <li>{% translate "The target tag is added to all bookmarks that have any of the merge tags" %}</li>
+            <li>{% translate "The merged tags are deleted" %}</li>
           </ol>
         </details>
         <div class="form-group">
-          {% formlabel form.target_tag "Target tag" %}
+          {% formlabel form.target_tag _("Target tag") %}
           {% formfield form.target_tag has_help=True %}
           {% formhelp form.target_tag %}
-            Enter the name of the tag you want to keep. The tags entered below will be merged into this one.
+            {% translate "Enter the name of the tag you want to keep. The tags entered below will be merged into this one." %}
           {% endformhelp %}
           {{ form.target_tag.errors }}
         </div>
         <div class="form-group">
-          {% formlabel form.merge_tags "Tags to merge" %}
+          {% formlabel form.merge_tags _("Tags to merge") %}
           {% formfield form.merge_tags has_help=True %}
           {% formhelp form.merge_tags %}
-            Enter the names of tags to merge into the target tag, separated by spaces.
-            These tags will be deleted after merging.
+            {% blocktranslate trimmed %}
+              Enter the names of tags to merge into the target tag, separated by spaces.
+              These tags will be deleted after merging.
+            {% endblocktranslate %}
           {% endformhelp %}
           {{ form.merge_tags.errors }}
         </div>
       </div>
       <div class="modal-footer d-flex justify-between">
-        <button type="button" class="btn btn-wide" data-close-modal>Cancel</button>
-        <button type="submit" class="btn btn-primary btn-wide">Merge Tags</button>
+        <button type="button" class="btn btn-wide" data-close-modal>{% translate "Cancel" %}</button>
+        <button type="submit" class="btn btn-primary btn-wide">{% translate "Merge Tags" %}</button>
       </div>
     </div>
   </ld-modal>

--- a/bookmarks/templates/tags/new.html
+++ b/bookmarks/templates/tags/new.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 <turbo-frame id="tag-modal">
 <form method="post"
       action="{% url 'linkding:tags.new' %}"
@@ -9,11 +10,11 @@
             data-turbo-frame="tag-modal">
     <div class="modal-overlay" data-close-modal></div>
     <div class="modal-container" role="dialog" aria-modal="true">
-      {% include 'shared/modal_header.html' with title="Create Tag" %}
+      {% include 'shared/modal_header.html' with title=_("Create Tag") %}
       <div class="modal-body">{% include 'tags/form.html' %}</div>
       <div class="modal-footer d-flex justify-between">
-        <button type="button" class="btn btn-wide" data-close-modal>Cancel</button>
-        <button type="submit" class="btn btn-primary btn-wide">Save</button>
+        <button type="button" class="btn btn-wide" data-close-modal>{% translate "Cancel" %}</button>
+        <button type="submit" class="btn btn-primary btn-wide">{% translate "Save" %}</button>
       </div>
     </div>
   </ld-modal>

--- a/bookmarks/templatetags/shared.py
+++ b/bookmarks/templatetags/shared.py
@@ -6,6 +6,7 @@ from bleach.linkifier import DEFAULT_CALLBACKS, Linker
 from bleach_allowlist import markdown_attrs, markdown_tags
 from django import template
 from django.forms.models import model_to_dict
+from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 
 from bookmarks import utils
@@ -129,8 +130,8 @@ def append_attr(widget, attr, value):
 
 @register.simple_tag
 def formlabel(field, label_text):
-    return mark_safe(
-        f'<label for="{field.id_for_label}" class="form-label">{label_text}</label>'
+    return format_html(
+        '<label for="{}" class="form-label">{}</label>', field.id_for_label, label_text
     )
 
 

--- a/bookmarks/tests/test_formlabel_tag.py
+++ b/bookmarks/tests/test_formlabel_tag.py
@@ -1,0 +1,28 @@
+from django import forms
+from django.template import Context, Template
+from django.test import SimpleTestCase
+
+
+class ExampleForm(forms.Form):
+    theme = forms.CharField()
+
+
+class FormLabelTagTestCase(SimpleTestCase):
+    def render(self, label_text):
+        template = Template("{% load shared %}{% formlabel form.theme label %}")
+        context = Context({"form": ExampleForm(), "label": label_text})
+        return template.render(context)
+
+    def test_renders_label_for_field(self):
+        html = self.render("Theme")
+
+        self.assertEqual('<label for="id_theme" class="form-label">Theme</label>', html)
+
+    def test_escapes_label_text(self):
+        html = self.render("Theme <script>alert(1)</script>")
+
+        self.assertEqual(
+            '<label for="id_theme" class="form-label">'
+            "Theme &lt;script&gt;alert(1)&lt;/script&gt;</label>",
+            html,
+        )

--- a/bookmarks/tests/test_i18n.py
+++ b/bookmarks/tests/test_i18n.py
@@ -1,0 +1,69 @@
+import os
+import tempfile
+
+from django.test import SimpleTestCase
+
+from bookmarks.i18n import discover_extra_languages
+
+
+class DiscoverExtraLanguagesTestCase(SimpleTestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.locale_dir = self.temp_dir.name
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def add_language(self, code, filename="django.po"):
+        messages_dir = os.path.join(self.locale_dir, code, "LC_MESSAGES")
+        os.makedirs(messages_dir)
+        with open(os.path.join(messages_dir, filename), "w") as f:
+            f.write("")
+
+    def test_returns_empty_list_for_missing_directory(self):
+        result = discover_extra_languages(
+            os.path.join(self.locale_dir, "does-not-exist"), ["en"]
+        )
+        self.assertEqual([], result)
+
+    def test_returns_empty_list_for_empty_directory(self):
+        result = discover_extra_languages(self.locale_dir, ["en"])
+        self.assertEqual([], result)
+
+    def test_returns_languages_with_po_or_mo_file(self):
+        self.add_language("ja", "django.po")
+        self.add_language("fr", "django.mo")
+
+        result = discover_extra_languages(self.locale_dir, ["en"])
+
+        self.assertEqual([("fr", "français"), ("ja", "日本語")], result)
+
+    def test_skips_known_languages(self):
+        self.add_language("de")
+        self.add_language("ja")
+
+        result = discover_extra_languages(self.locale_dir, ["en", "de"])
+
+        self.assertEqual([("ja", "日本語")], result)
+
+    def test_skips_directories_without_message_file(self):
+        os.makedirs(os.path.join(self.locale_dir, "ja", "LC_MESSAGES"))
+        os.makedirs(os.path.join(self.locale_dir, "fr"))
+
+        result = discover_extra_languages(self.locale_dir, ["en"])
+
+        self.assertEqual([], result)
+
+    def test_uses_code_as_name_for_unknown_language(self):
+        self.add_language("xx")
+
+        result = discover_extra_languages(self.locale_dir, ["en"])
+
+        self.assertEqual([("xx", "xx")], result)
+
+    def test_normalizes_code_to_django_language_code(self):
+        self.add_language("pt_BR")
+
+        result = discover_extra_languages(self.locale_dir, ["en"])
+
+        self.assertEqual([("pt-br", "Português Brasileiro")], result)

--- a/bookmarks/utils.py
+++ b/bookmarks/utils.py
@@ -7,8 +7,8 @@ from dataclasses import dataclass
 
 from django.conf import settings
 from django.http import HttpResponseRedirect
-from django.template.defaultfilters import pluralize
 from django.utils import formats, timezone
+from django.utils.translation import gettext, gettext_lazy, ngettext
 
 try:
     with open("version.txt") as f:
@@ -23,13 +23,13 @@ def unique(elements, key):
 
 
 weekday_names = {
-    1: "Monday",
-    2: "Tuesday",
-    3: "Wednesday",
-    4: "Thursday",
-    5: "Friday",
-    6: "Saturday",
-    7: "Sunday",
+    1: gettext_lazy("Monday"),
+    2: gettext_lazy("Tuesday"),
+    3: gettext_lazy("Wednesday"),
+    4: gettext_lazy("Thursday"),
+    5: gettext_lazy("Friday"),
+    6: gettext_lazy("Saturday"),
+    7: gettext_lazy("Sunday"),
 }
 
 
@@ -73,9 +73,9 @@ def humanize_absolute_date(
     if is_older_than_a_week:
         return formats.date_format(value, "SHORT_DATE_FORMAT")
     elif value.day == now.day:
-        return "Today"
+        return gettext("Today")
     elif value.day == yesterday.day:
-        return "Yesterday"
+        return gettext("Yesterday")
     else:
         return weekday_names[value.isoweekday()]
 
@@ -88,17 +88,23 @@ def humanize_relative_date(
     delta = _calculate_date_delta(now, value)
 
     if delta.years > 0:
-        return f"{delta.years} year{pluralize(delta.years)} ago"
+        return ngettext("%(count)d year ago", "%(count)d years ago", delta.years) % {
+            "count": delta.years
+        }
     elif delta.months > 0:
-        return f"{delta.months} month{pluralize(delta.months)} ago"
+        return ngettext("%(count)d month ago", "%(count)d months ago", delta.months) % {
+            "count": delta.months
+        }
     elif delta.weeks > 0:
-        return f"{delta.weeks} week{pluralize(delta.weeks)} ago"
+        return ngettext("%(count)d week ago", "%(count)d weeks ago", delta.weeks) % {
+            "count": delta.weeks
+        }
     else:
         yesterday = now - datetime.timedelta(days=1)
         if value.day == now.day:
-            return "Today"
+            return gettext("Today")
         elif value.day == yesterday.day:
-            return "Yesterday"
+            return gettext("Yesterday")
         else:
             return weekday_names[value.isoweekday()]
 

--- a/bookmarks/views/bookmarks.py
+++ b/bookmarks/views/bookmarks.py
@@ -10,6 +10,7 @@ from django.http import (
 )
 from django.shortcuts import render
 from django.urls import reverse
+from django.utils.translation import gettext as _
 
 from bookmarks import queries, utils
 from bookmarks.forms import BookmarkForm
@@ -57,7 +58,7 @@ def index(request: HttpRequest):
     return render_bookmarks_view(
         request,
         {
-            "page_title": "Bookmarks - Linkding",
+            "page_title": _("Bookmarks - Linkding"),
             "bookmark_list": bookmark_list,
             "bundles": bundles,
             "tag_cloud": tag_cloud,
@@ -96,7 +97,7 @@ def archived(request: HttpRequest):
     return render_bookmarks_view(
         request,
         {
-            "page_title": "Archived bookmarks - Linkding",
+            "page_title": _("Archived bookmarks - Linkding"),
             "bookmark_list": bookmark_list,
             "bundles": bundles,
             "tag_cloud": tag_cloud,
@@ -133,7 +134,7 @@ def shared(request: HttpRequest):
     return render_bookmarks_view(
         request,
         {
-            "page_title": "Shared bookmarks - Linkding",
+            "page_title": _("Shared bookmarks - Linkding"),
             "bookmark_list": bookmark_list,
             "tag_cloud": tag_cloud,
             "details": bookmark_details,
@@ -157,7 +158,7 @@ def shared_update(request: HttpRequest):
 
 def render_bookmarks_view(request: HttpRequest, context):
     if context["details"]:
-        context["page_title"] = "Bookmark details - Linkding"
+        context["page_title"] = _("Bookmark details - Linkding")
 
     if turbo.is_frame(request, "details-modal"):
         return turbo.frame(request, "bookmarks/details/modal.html", context)

--- a/bookmarks/views/bundles.py
+++ b/bookmarks/views/bundles.py
@@ -3,6 +3,7 @@ from django.contrib.auth.decorators import login_required
 from django.http import HttpRequest, HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import reverse
+from django.utils.translation import gettext as _
 
 from bookmarks.forms import BookmarkBundleForm
 from bookmarks.models import BookmarkBundle, BookmarkSearch
@@ -26,7 +27,10 @@ def action(request: HttpRequest):
         bundle = access.bundle_write(request, remove_bundle_id)
         bundle_name = bundle.name
         bundles.delete_bundle(bundle)
-        messages.success(request, f"Bundle '{bundle_name}' removed successfully.")
+        messages.success(
+            request,
+            _("Bundle '%(name)s' removed successfully.") % {"name": bundle_name},
+        )
 
     elif "move_bundle" in request.POST:
         bundle_id = request.POST.get("move_bundle")
@@ -61,7 +65,7 @@ def _handle_edit(request: HttpRequest, template: str, bundle: BookmarkBundle = N
         else:
             instance.save()
 
-        messages.success(request, "Bundle saved successfully.")
+        messages.success(request, _("Bundle saved successfully."))
         return HttpResponseRedirect(reverse("linkding:bundles.index"))
 
     status = 422 if request.method == "POST" and not form.is_valid() else 200

--- a/bookmarks/views/contexts.py
+++ b/bookmarks/views/contexts.py
@@ -6,6 +6,7 @@ from django.core.paginator import Paginator
 from django.db import models
 from django.http import Http404
 from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
 
 from bookmarks import queries, utils
 from bookmarks.forms import BookmarkSearchForm
@@ -152,10 +153,10 @@ class BookmarkItem:
             self.snapshot_url = reverse(
                 "linkding:assets.view", args=[bookmark.latest_snapshot_id]
             )
-            self.snapshot_title = "View latest snapshot"
+            self.snapshot_title = _("View latest snapshot")
         else:
             self.snapshot_url = bookmark.web_archive_snapshot_url
-            self.snapshot_title = (
+            self.snapshot_title = _(
                 "View snapshot on the Internet Archive Wayback Machine"
             )
             if not self.snapshot_url:
@@ -265,7 +266,7 @@ class BookmarkListContext:
 
 
 class ActiveBookmarkListContext(BookmarkListContext):
-    list_title = "Bookmarks"
+    list_title = _("Bookmarks")
     search_mode = ""
     bulk_edit_enabled = True
     bulk_edit_disabled_actions = "bulk_unarchive"
@@ -273,7 +274,7 @@ class ActiveBookmarkListContext(BookmarkListContext):
 
 
 class ArchivedBookmarkListContext(BookmarkListContext):
-    list_title = "Archived bookmarks"
+    list_title = _("Archived bookmarks")
     search_mode = "archived"
     bulk_edit_enabled = True
     bulk_edit_disabled_actions = "bulk_archive"
@@ -281,7 +282,7 @@ class ArchivedBookmarkListContext(BookmarkListContext):
 
 
 class SharedBookmarkListContext(BookmarkListContext):
-    list_title = "Shared bookmarks"
+    list_title = _("Shared bookmarks")
     search_mode = "shared"
     bulk_edit_enabled = False
     bulk_edit_disabled_actions = ""

--- a/bookmarks/views/manifest.py
+++ b/bookmarks/views/manifest.py
@@ -1,12 +1,13 @@
 from django.conf import settings
 from django.http import JsonResponse
+from django.utils.translation import gettext as _
 
 
 def manifest(request):
     response = {
         "short_name": "linkding",
         "name": "linkding",
-        "description": "Self-hosted bookmark service",
+        "description": _("Self-hosted bookmark service"),
         "start_url": "bookmarks",
         "display": "standalone",
         "scope": "/" + settings.LD_CONTEXT_PATH,
@@ -54,23 +55,23 @@ def manifest(request):
         ],
         "shortcuts": [
             {
-                "name": "Add bookmark",
+                "name": _("Add bookmark"),
                 "url": "/" + settings.LD_CONTEXT_PATH + "bookmarks/new",
             },
             {
-                "name": "Archived",
+                "name": _("Archived"),
                 "url": "/" + settings.LD_CONTEXT_PATH + "bookmarks/archived",
             },
             {
-                "name": "Unread",
+                "name": _("Unread"),
                 "url": "/" + settings.LD_CONTEXT_PATH + "bookmarks?unread=yes",
             },
             {
-                "name": "Untagged",
+                "name": _("Untagged"),
                 "url": "/" + settings.LD_CONTEXT_PATH + "bookmarks?q=!untagged",
             },
             {
-                "name": "Shared",
+                "name": _("Shared"),
                 "url": "/" + settings.LD_CONTEXT_PATH + "bookmarks/shared",
             },
         ],

--- a/bookmarks/views/settings.py
+++ b/bookmarks/views/settings.py
@@ -74,13 +74,13 @@ def update(request: HttpRequest):
         if "update_global_settings" in request.POST:
             update_global_settings(request)
             messages.success(
-                request, "Global settings updated", "settings_success_message"
+                request, _("Global settings updated"), "settings_success_message"
             )
         if "refresh_favicons" in request.POST:
             tasks.schedule_refresh_favicons(request.user)
             messages.success(
                 request,
-                "Scheduled favicon update. This may take a while...",
+                _("Scheduled favicon update. This may take a while..."),
                 "settings_success_message",
             )
         if "create_missing_html_snapshots" in request.POST:
@@ -88,12 +88,15 @@ def update(request: HttpRequest):
             if count > 0:
                 messages.success(
                     request,
-                    f"Queued {count} missing snapshots. This may take a while...",
+                    _("Queued %(count)d missing snapshots. This may take a while...")
+                    % {"count": count},
                     "settings_success_message",
                 )
             else:
                 messages.success(
-                    request, "No missing snapshots found.", "settings_success_message"
+                    request,
+                    _("No missing snapshots found."),
+                    "settings_success_message",
                 )
 
     return HttpResponseRedirect(reverse("linkding:settings.general"))
@@ -119,7 +122,7 @@ def update_profile(request: HttpRequest):
 
     messages.error(
         request,
-        "Profile update failed, check the form below for errors",
+        _("Profile update failed, check the form below for errors"),
         "settings_error_message",
     )
     return general(request, 422, {"form": form})
@@ -215,7 +218,7 @@ def create_api_token(request):
 
         messages.success(
             request,
-            f'API token "{token.name}" created successfully',
+            _('API token "%(name)s" created successfully') % {"name": token.name},
             "api_success_message",
         )
 
@@ -233,7 +236,7 @@ def delete_api_token(request):
         token.delete()
         messages.success(
             request,
-            f'API token "{token_name}" has been deleted.',
+            _('API token "%(name)s" has been deleted.') % {"name": token_name},
             "api_success_message",
         )
 
@@ -249,26 +252,27 @@ def bookmark_import(request: HttpRequest):
 
     if import_file is None:
         messages.error(
-            request, "Please select a file to import.", "settings_error_message"
+            request, _("Please select a file to import."), "settings_error_message"
         )
         return HttpResponseRedirect(reverse("linkding:settings.general"))
 
     try:
         content = import_file.read().decode()
         result = importer.import_netscape_html(content, request.user, import_options)
-        success_msg = str(result.success) + " bookmarks were successfully imported."
+        success_msg = _("%(count)s bookmarks were successfully imported.") % {
+            "count": result.success
+        }
         messages.success(request, success_msg, "settings_success_message")
         if result.failed > 0:
-            err_msg = (
-                str(result.failed)
-                + " bookmarks could not be imported. Please check the logs for more details."
-            )
+            err_msg = _(
+                "%(count)s bookmarks could not be imported. Please check the logs for more details."
+            ) % {"count": result.failed}
             messages.error(request, err_msg, "settings_error_message")
     except Exception:
         logging.exception("Unexpected error during bookmark import")
         messages.error(
             request,
-            "An error occurred during bookmark import.",
+            _("An error occurred during bookmark import."),
             "settings_error_message",
         )
 
@@ -297,7 +301,7 @@ def bookmark_export(request: HttpRequest):
         return general(
             request,
             context_overrides={
-                "export_error": "An error occurred during bookmark export."
+                "export_error": _("An error occurred during bookmark export.")
             },
         )
 

--- a/bookmarks/views/settings.py
+++ b/bookmarks/views/settings.py
@@ -12,6 +12,7 @@ from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import reverse
 from django.utils import timezone
+from django.utils.translation import gettext as _
 
 from bookmarks.forms import GlobalSettingsForm, UserProfileForm
 from bookmarks.models import (
@@ -106,7 +107,7 @@ def update_profile(request: HttpRequest):
     form = UserProfileForm(request.POST, instance=profile)
     if form.is_valid():
         form.save()
-        messages.success(request, "Profile updated", "settings_success_message")
+        messages.success(request, _("Profile updated"), "settings_success_message")
         # Load missing favicons if the feature was just enabled
         if profile.enable_favicons and not favicons_were_enabled:
             tasks.schedule_bookmarks_without_favicons(request.user)

--- a/bookmarks/views/tags.py
+++ b/bookmarks/views/tags.py
@@ -6,6 +6,7 @@ from django.db.models import Count
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
+from django.utils.translation import gettext as _
 
 from bookmarks.forms import TagForm, TagMergeForm
 from bookmarks.models import Bookmark, Tag
@@ -69,7 +70,10 @@ def tag_new(request: HttpRequest):
     if request.method == "POST":
         if form.is_valid():
             tag = form.save()
-            messages.success(request, f'Tag "{tag.name}" created successfully.')
+            messages.success(
+                request,
+                _('Tag "%(name)s" created successfully.') % {"name": tag.name},
+            )
             return HttpResponseRedirect(reverse("linkding:tags.index"))
         else:
             return turbo.stream(
@@ -150,7 +154,14 @@ def tag_merge(request: HttpRequest):
 
                 messages.success(
                     request,
-                    f'Successfully merged {len(merge_tags)} tags ({", ".join(tag_names)}) into "{target_tag.name}".',
+                    _(
+                        'Successfully merged %(count)d tags (%(tags)s) into "%(target)s".'
+                    )
+                    % {
+                        "count": len(merge_tags),
+                        "tags": ", ".join(tag_names),
+                        "target": target_tag.name,
+                    },
                 )
 
             return HttpResponseRedirect(reverse("linkding:tags.index"))

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -13,6 +13,14 @@ mkdir -p data/previews
 # Create assets folder if it does not exist
 mkdir -p data/assets
 
+# Compile translations that were added to the data folder, see docs/translations
+for po_file in data/locale/*/LC_MESSAGES/django.po; do
+  [ -f "$po_file" ] || continue
+  if ! msgfmt --check -o "${po_file%.po}.mo" "$po_file"; then
+    echo "Could not compile translation $po_file, skipping"
+  fi
+done
+
 # Generate secret key file if it does not exist
 python manage.py generate_secret_key
 # Run database migration

--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -52,7 +52,7 @@ RUN wget https://www.sqlite.org/${SQLITE_RELEASE_YEAR}/sqlite-amalgamation-${SQL
 FROM python:3.13.7-alpine3.22 AS linkding
 LABEL org.opencontainers.image.source="https://github.com/sissbruecker/linkding"
 # install runtime dependencies
-RUN apk update && apk add bash curl icu libpq mailcap libssl3 pcre2
+RUN apk update && apk add bash curl icu libpq mailcap libssl3 pcre2 gettext
 # create www-data user and group
 RUN set -x ; \
   addgroup -g 82 -S www-data ; \
@@ -69,9 +69,10 @@ COPY . .
 # Activate virtual env
 ENV VIRTUAL_ENV=/etc/linkding/.venv
 ENV PATH="/etc/linkding/.venv/bin:$PATH"
-# Generate static files, remove source styles that are not needed
+# Generate static files and compile translations
 RUN mkdir data && \
-    python manage.py collectstatic
+    python manage.py collectstatic && \
+    python manage.py compilemessages --ignore .venv
 
 # Limit file descriptors used by uwsgi, see https://github.com/sissbruecker/linkding/issues/453
 ENV UWSGI_MAX_FD=4096

--- a/docker/default.Dockerfile
+++ b/docker/default.Dockerfile
@@ -51,7 +51,7 @@ RUN wget https://www.sqlite.org/${SQLITE_RELEASE_YEAR}/sqlite-amalgamation-${SQL
 FROM python:3.13.7-slim-trixie AS linkding
 LABEL org.opencontainers.image.source="https://github.com/sissbruecker/linkding"
 # install runtime dependencies
-RUN apt-get update && apt-get -y install media-types libpq-dev libicu-dev libssl3t64 libpcre2-8-0 curl
+RUN apt-get update && apt-get -y install media-types libpq-dev libicu-dev libssl3t64 libpcre2-8-0 curl gettext
 WORKDIR /etc/linkding
 # copy python dependencies
 COPY --from=build-deps /etc/linkding/.venv /etc/linkding/.venv
@@ -64,9 +64,10 @@ COPY . .
 # Activate virtual env
 ENV VIRTUAL_ENV=/etc/linkding/.venv
 ENV PATH="/etc/linkding/.venv/bin:$PATH"
-# Generate static files
+# Generate static files and compile translations
 RUN mkdir data && \
-    python manage.py collectstatic
+    python manage.py collectstatic && \
+    python manage.py compilemessages --ignore .venv
 
 # Limit file descriptors used by uwsgi, see https://github.com/sissbruecker/linkding/issues/453
 ENV UWSGI_MAX_FD=4096

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -39,6 +39,7 @@ export default defineConfig({
             { label: "Troubleshooting", slug: "troubleshooting" },
             { label: "Admin", slug: "admin" },
             { label: "REST API", slug: "api" },
+            { label: "Translations", slug: "translations" },
           ],
         },
         {

--- a/docs/src/content/docs/translations.md
+++ b/docs/src/content/docs/translations.md
@@ -24,6 +24,8 @@ To create the file, follow the steps in [Contributing a translation](#contributi
 
 If a file can not be compiled, linkding logs a message at startup and ignores that language.
 
+Treat translation files like code: texts from a catalog are rendered as part of the page, and some of them contain HTML on purpose. Only install catalogs from sources you trust.
+
 ## Contributing a translation
 
 Translations live in `bookmarks/locale/<language code>/LC_MESSAGES/django.po`. To add a new language, or to update an existing one, set up the [development environment](https://github.com/sissbruecker/linkding#development) first, then:

--- a/docs/src/content/docs/translations.md
+++ b/docs/src/content/docs/translations.md
@@ -9,12 +9,20 @@ The linkding user interface is written in English and can be translated into oth
 
 linkding picks the language from the `Accept-Language` header that the browser sends, so the user interface follows the language settings of your browser. There is no language switcher in the application.
 
-Only languages listed in the `LANGUAGES` setting are used. If the browser requests a language that is not available, or if a text has not been translated yet, linkding falls back to English.
+linkding uses the languages bundled with the application plus any translation found in the data folder (see below). If the browser requests a language that is not available, or if a text has not been translated yet, linkding falls back to English.
 
-Currently available languages:
+Currently bundled languages:
 
 - English
 - German
+
+## Adding your own translation
+
+You can add a language, or override texts of a bundled language, without rebuilding linkding. Put a message file at `data/locale/<language code>/LC_MESSAGES/django.po` in the data folder (the folder that is mounted as a volume when running with Docker) and restart linkding. The file is compiled at startup and the language becomes available, named after Django's built-in language names. For example, `data/locale/ja/LC_MESSAGES/django.po` adds Japanese.
+
+To create the file, follow the steps in [Contributing a translation](#contributing-a-translation) up to translating the `.po` file, or start from the `.po` file of a bundled language in `bookmarks/locale`. Files in the data folder take precedence over the bundled ones, so a `data/locale/de/LC_MESSAGES/django.po` replaces the bundled German texts.
+
+If a file can not be compiled, linkding logs a message at startup and ignores that language.
 
 ## Contributing a translation
 

--- a/docs/src/content/docs/translations.md
+++ b/docs/src/content/docs/translations.md
@@ -1,0 +1,51 @@
+---
+title: "Translations"
+description: "How linkding chooses the UI language and how to contribute a translation"
+---
+
+The linkding user interface is written in English and can be translated into other languages using Django's [translation framework](https://docs.djangoproject.com/en/stable/topics/i18n/translation/).
+
+## Choosing the language
+
+linkding picks the language from the `Accept-Language` header that the browser sends, so the user interface follows the language settings of your browser. There is no language switcher in the application.
+
+Only languages listed in the `LANGUAGES` setting are used. If the browser requests a language that is not available, or if a text has not been translated yet, linkding falls back to English.
+
+Currently available languages:
+
+- English
+- German
+
+## Contributing a translation
+
+Translations live in `bookmarks/locale/<language code>/LC_MESSAGES/django.po`. To add a new language, or to update an existing one, set up the [development environment](https://github.com/sissbruecker/linkding#development) first, then:
+
+1. Generate or update the message file for your language. Run this from the project root:
+
+   ```shell
+   uv run manage.py makemessages -l <language code> --ignore=node_modules --ignore=.venv --ignore=static --ignore=data --ignore=docs
+   ```
+
+   For example, `uv run manage.py makemessages -l fr ...` creates `bookmarks/locale/fr/LC_MESSAGES/django.po`. When updating an existing language, the command keeps existing translations and adds new or changed texts.
+
+2. Translate the `msgstr` entries in the `.po` file. Any text editor works, tools like [Poedit](https://poedit.net/) make this easier. Keep placeholders such as `%(count)s` and HTML tags exactly as they are in the original text.
+
+3. If the language is new, add it to the `LANGUAGES` setting in `bookmarks/settings/base.py`.
+
+4. Compile the translations so that they can be used by the application:
+
+   ```shell
+   uv run manage.py compilemessages --ignore .venv --ignore node_modules
+   ```
+
+   The compiled `.mo` files are not committed. When building the Docker image, they are generated automatically.
+
+5. Start the development server with `make serve` and set your browser language to the new language to check the result.
+
+When submitting a pull request, only include the `.po` file for your language and, for a new language, the change to the `LANGUAGES` setting.
+
+## Notes for developers
+
+New texts in templates need to be marked for translation using the `{% translate %}` and `{% blocktranslate %}` template tags, texts in Python code using `gettext` or `gettext_lazy`. After adding or changing texts, run `makemessages` with `-a` instead of `-l <language code>` to update all message files at once.
+
+The few texts that are rendered by JavaScript are passed from the shared layout template to the scripts as data attributes on the `<html>` element, see `bookmarks/frontend/utils/i18n.js`.


### PR DESCRIPTION
Relates to #309.

This is the "maintainer-side scaffolding" half of the split proposed in [this comment](https://github.com/sissbruecker/linkding/issues/309#issuecomment-5158867332) on #309: make the UI texts translatable with Django's i18n API, and let translations be loaded from the data folder so that individual languages do not have to be bundled or maintained here. German is included as a working example.

### What is in this PR

- All user-facing texts in templates, Python code and the few JavaScript strings are wrapped with Django's translation calls (`{% translate %}`, `{% blocktranslate %}`, `gettext`, `gettext_lazy`). No English text was reworded, only wrapped.
- `LANGUAGES = [en, de]`, English stays the source language and the fallback for anything that is not translated.
- A German catalog (`bookmarks/locale/de/LC_MESSAGES/django.po`, 362 strings, complete).
- Translations can be dropped into `data/locale/<code>/LC_MESSAGES/django.po`. They are compiled at container start (`msgfmt --check` in `bootstrap.sh`), take precedence over bundled catalogs, and additional languages found there are added to `LANGUAGES` automatically. So further languages can live outside this repository.
- `gettext` in the runtime image and `compilemessages` in the Docker build. On arm64 the image grows from 623 MB to 632 MB.
- A docs page "Translations" describing how the language is chosen, how to drop in a translation, and the `makemessages` workflow for contributors.

### What stays the same for English users

- No language switcher and no new settings. The language comes from the browser's `Accept-Language` header, as Django's `LocaleMiddleware` does it; anything else gets English.
- The test client sends no `Accept-Language`, so all existing tests pass unchanged. 1307 tests, lint and format are green.
- `<html lang="en">` is left untouched.

### Deliberately not included

- A language switcher in the UI. I have one on a separate branch in my fork (`feature/i18n-extras`, together with a Spanish catalog), happy to send it as a follow-up if that is wanted.
- Other bundled languages.
- Texts in the Django admin, API error responses and log messages.
- Locale-aware tag sorting (the point raised by @BunnySakura above), which is a separate problem from translation.
- A handful of texts that are stored in the database rather than rendered (the toast from migration 0050, asset display names).

### How it was tested

- `make format`, `make lint`, `make test`.
- Every page and dialog clicked through in English and German with Playwright, including form errors, bulk edit, the confirm dropdown and the mobile filter drawer; the visible texts of both runs were diffed to find leftovers. Screenshots are available on request.
- The image was built and run on an arm64 host, with a dropped-in extra language to check the `data/locale` path.

### Maintenance

If new texts are added upstream, `manage.py makemessages -a` lists them; an untranslated text simply falls back to English, so a stale catalog never breaks the UI. I am happy to keep the German file current, and to cut this PR down further if a smaller first step is preferred, for example without the bundled German catalog.

The mechanical wrapping and the translation catalogs were prepared with an LLM (Claude Code), then reviewed, corrected and tested by hand.
